### PR TITLE
Improve primary interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 add_library(urcl SHARED
     src/comm/tcp_socket.cpp
     src/comm/server.cpp
+    src/primary/primary_client.cpp
     src/primary/primary_package.cpp
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(urcl SHARED
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp
     src/primary/robot_message/version_message.cpp
+    src/primary/robot_message/text_message.cpp
+    src/primary/robot_message/key_message.cpp
     src/primary/robot_state/kinematics_info.cpp
     src/rtde/control_package_pause.cpp
     src/rtde/control_package_setup_inputs.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,10 @@ add_library(urcl SHARED
     src/comm/server.cpp
     src/primary/primary_client.cpp
     src/primary/primary_package.cpp
+    src/primary/program_state_message.cpp
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp
+    src/primary/program_state_message/global_variables_update_message.cpp
     src/primary/robot_message/error_code_message.cpp
     src/primary/robot_message/runtime_exception_message.cpp
     src/primary/robot_message/version_message.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(urcl SHARED
     src/primary/primary_package.cpp
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp
+    src/primary/robot_message/error_code_message.cpp
+    src/primary/robot_message/runtime_exception_message.cpp
     src/primary/robot_message/version_message.cpp
     src/primary/robot_message/text_message.cpp
     src/primary/robot_message/key_message.cpp

--- a/include/ur_client_library/comm/producer.h
+++ b/include/ur_client_library/comm/producer.h
@@ -57,6 +57,8 @@ public:
   {
   }
 
+  virtual ~URProducer() = default;
+
   /*!
    * \brief Triggers the stream to connect to the robot.
    */

--- a/include/ur_client_library/primary/abstract_primary_consumer.h
+++ b/include/ur_client_library/primary/abstract_primary_consumer.h
@@ -36,6 +36,7 @@
 #include "ur_client_library/primary/robot_message/text_message.h"
 #include "ur_client_library/primary/robot_message/version_message.h"
 #include "ur_client_library/primary/robot_state/kinematics_info.h"
+#include "ur_client_library/primary/program_state_message/global_variables_update_message.h"
 
 namespace urcl
 {
@@ -80,6 +81,8 @@ public:
   virtual bool consume(TextMessage& pkg) = 0;
   virtual bool consume(VersionMessage& pkg) = 0;
   virtual bool consume(KinematicsInfo& pkg) = 0;
+  virtual bool consume(ProgramStateMessage& pkg) = 0;
+  virtual bool consume(GlobalVariablesUpdateMessage& pkg) = 0;
 
 private:
   /* data */

--- a/include/ur_client_library/primary/abstract_primary_consumer.h
+++ b/include/ur_client_library/primary/abstract_primary_consumer.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_ROBOT_DRIVER_ABSTRACT_PRIMARY_CONSUMER_H_INCLUDED
-#define UR_ROBOT_DRIVER_ABSTRACT_PRIMARY_CONSUMER_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_ABSTRACT_PRIMARY_CONSUMER_H_INCLUDED
+#define UR_CLIENT_LIBRARY_ABSTRACT_PRIMARY_CONSUMER_H_INCLUDED
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/comm/pipeline.h"
@@ -87,4 +87,4 @@ private:
 }  // namespace primary_interface
 }  // namespace urcl
 
-#endif  // ifndef UR_ROBOT_DRIVER_ABSTRACT_PRIMARY_CONSUMER_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_ABSTRACT_PRIMARY_CONSUMER_H_INCLUDED

--- a/include/ur_client_library/primary/abstract_primary_consumer.h
+++ b/include/ur_client_library/primary/abstract_primary_consumer.h
@@ -30,6 +30,10 @@
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/comm/pipeline.h"
+#include "ur_client_library/primary/robot_message/error_code_message.h"
+#include "ur_client_library/primary/robot_message/key_message.h"
+#include "ur_client_library/primary/robot_message/runtime_exception_message.h"
+#include "ur_client_library/primary/robot_message/text_message.h"
 #include "ur_client_library/primary/robot_message/version_message.h"
 #include "ur_client_library/primary/robot_state/kinematics_info.h"
 
@@ -70,6 +74,10 @@ public:
   // To be implemented in specific consumers
   virtual bool consume(RobotMessage& pkg) = 0;
   virtual bool consume(RobotState& pkg) = 0;
+  virtual bool consume(ErrorCodeMessage& pkg) = 0;
+  virtual bool consume(KeyMessage& pkg) = 0;
+  virtual bool consume(RuntimeExceptionMessage& pkg) = 0;
+  virtual bool consume(TextMessage& pkg) = 0;
   virtual bool consume(VersionMessage& pkg) = 0;
   virtual bool consume(KinematicsInfo& pkg) = 0;
 

--- a/include/ur_client_library/primary/error_code_message_handler.h
+++ b/include/ur_client_library/primary/error_code_message_handler.h
@@ -1,0 +1,95 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+//
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_ERROR_CODE_MESSAGE_HANDLER_H_INCLUDED
+#define UR_CLIENT_LIBRARY_ERROR_CODE_MESSAGE_HANDLER_H_INCLUDED
+
+#include <ur_client_library/log.h>
+#include <ur_client_library/primary/primary_package_handler.h>
+#include <ur_client_library/primary/robot_message/error_code_message.h>
+
+namespace urcl
+{
+namespace primary_interface
+{
+class ErrorCodeMessageHandler : public IPrimaryPackageHandler<ErrorCodeMessage>
+{
+public:
+  ErrorCodeMessageHandler() = default;
+  virtual ~ErrorCodeMessageHandler() = default;
+
+  /*!
+   * \brief Actual worker function
+   *
+   * \param pkg package that should be handled
+   */
+  virtual void handle(ErrorCodeMessage& pkg) override
+  {
+    std::stringstream out_ss;
+    out_ss << "---ErrorCodeMessage---\n" << pkg.toString().c_str() << std::endl;
+    switch (pkg.report_level_)
+    {
+      case ReportLevel::DEBUG:
+      case ReportLevel::DEVL_DEBUG:
+      {
+        LOG_DEBUG("%s", out_ss.str().c_str());
+        break;
+      }
+      case ReportLevel::INFO:
+      case ReportLevel::DEVL_INFO:
+      {
+        LOG_INFO("%s", out_ss.str().c_str());
+        break;
+      }
+      case ReportLevel::WARNING:
+      {
+        LOG_WARN("%s", out_ss.str().c_str());
+        break;
+      }
+      case ReportLevel::VIOLATION:
+      case ReportLevel::FAULT:
+      case ReportLevel::DEVL_VIOLATION:
+      case ReportLevel::DEVL_FAULT:
+      {
+        LOG_ERROR("%s", out_ss.str().c_str());
+        break;
+      }
+      default:
+      {
+        std::stringstream ss;
+        ss << "Unknown report level: " << static_cast<int>(pkg.report_level_) << std::endl << out_ss.str();
+        LOG_ERROR("%s", ss.str().c_str());
+      }
+    }
+  }
+
+private:
+  /* data */
+};
+}  // namespace primary_interface
+}  // namespace urcl
+#endif  // ifndef UR_CLIENT_LIBRARY_ERROR_CODE_MESSAGE_HANDLER_H_INCLUDED

--- a/include/ur_client_library/primary/key_message_handler.h
+++ b/include/ur_client_library/primary/key_message_handler.h
@@ -49,7 +49,7 @@ public:
    */
   virtual void handle(KeyMessage& pkg) override
   {
-    LOG_INFO("%s", pkg.toString().c_str());
+    LOG_INFO("---KeyMessage---\n%s", pkg.toString().c_str());
   }
 
 private:

--- a/include/ur_client_library/primary/key_message_handler.h
+++ b/include/ur_client_library/primary/key_message_handler.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
-#define UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_KEY_MESSAGE_HANDLER_H_INCLUDED
+#define UR_CLIENT_LIBRARY_KEY_MESSAGE_HANDLER_H_INCLUDED
 
 #include <ur_client_library/log.h>
 #include <ur_client_library/primary/primary_package_handler.h>
@@ -57,4 +57,4 @@ private:
 };
 }  // namespace primary_interface
 }  // namespace urcl
-#endif  // ifndef UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_KEY_MESSAGE_HANDLER_H_INCLUDED

--- a/include/ur_client_library/primary/key_message_handler.h
+++ b/include/ur_client_library/primary/key_message_handler.h
@@ -1,7 +1,7 @@
 // this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
-
+//
 // -- BEGIN LICENSE BLOCK ----------------------------------------------
-// Copyright 2019 FZI Forschungszentrum Informatik
+// Copyright 2020 FZI Forschungszentrum Informatik
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,35 +20,41 @@
 /*!\file
  *
  * \author  Felix Exner exner@fzi.de
- * \date    2019-06-14
+ * \date    2020-04-30
  *
  */
 //----------------------------------------------------------------------
 
-#include <ur_client_library/ur/calibration_checker.h>
+#ifndef UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
+#define UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED
+
+#include <ur_client_library/log.h>
+#include <ur_client_library/primary/primary_package_handler.h>
+#include <ur_client_library/primary/robot_message/key_message.h>
 
 namespace urcl
 {
-CalibrationChecker::CalibrationChecker(const std::string& expected_hash)
-  : expected_hash_(expected_hash), checked_(false)
+namespace primary_interface
 {
-}
-void CalibrationChecker::handle(primary_interface::KinematicsInfo& kin_info)
+class KeyMessageHandler : public IPrimaryPackageHandler<KeyMessage>
 {
-  if (kin_info.toHash() != expected_hash_)
+public:
+  KeyMessageHandler() = default;
+  virtual ~KeyMessageHandler() = default;
+
+  /*!
+   * \brief Actual worker function
+   *
+   * \param pkg package that should be handled
+   */
+  virtual void handle(KeyMessage& pkg) override
   {
-    LOG_ERROR("The calibration parameters of the connected robot don't match the ones from the given kinematics "
-              "config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use the "
-              "ur_calibration tool to extract the correct calibration from the robot and pass that into the "
-              "description. See "
-              "[https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] for "
-              "details.");
-  }
-  else
-  {
-    LOG_INFO("Calibration checked successfully.");
+    LOG_INFO("%s", pkg.toString().c_str());
   }
 
-  checked_ = true;
-}
+private:
+  /* data */
+};
+}  // namespace primary_interface
 }  // namespace urcl
+#endif  // ifndef UR_ROBOT_DRIVER_KEY_MESSAGE_HANDLER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_client.h
+++ b/include/ur_client_library/primary/primary_client.h
@@ -31,6 +31,8 @@
 #include <ur_client_library/comm/producer.h>
 #include <ur_client_library/comm/stream.h>
 #include <ur_client_library/comm/pipeline.h>
+#include <ur_client_library/ur/calibration_checker.h>
+#include <ur_client_library/primary/primary_consumer.h>
 
 namespace urcl
 {
@@ -40,13 +42,31 @@ class PrimaryClient
 {
 public:
   PrimaryClient() = delete;
-  PrimaryClient(const std::string& robot_ip);
+  PrimaryClient(const std::string& robot_ip, const std::string& calibration_checksum);
   virtual ~PrimaryClient() = default;
+
+  /*!
+   * \brief Sends a custom script program to the robot.
+   *
+   * The given code must be valid according the UR Scripting Manual.
+   *
+   * \param script_code URScript code that shall be executed by the robot.
+   *
+   * \returns true on successful upload, false otherwise.
+   */
+  bool sendScript(const std::string& script_code);
+
+  /*!
+   * \brief Checks if the kinematics information in the used model fits the actual robot.
+   *
+   * \param checksum Hash of the used kinematics information
+   */
+  void checkCalibration(const std::string& checksum);
 
 private:
   std::string robot_ip_;
   PrimaryParser parser_;
-  std::unique_ptr<comm::IConsumer<PrimaryPackage>> consumer_;
+  std::unique_ptr<PrimaryConsumer> consumer_;
   comm::INotifier notifier_;
   std::unique_ptr<comm::URProducer<PrimaryPackage>> producer_;
   std::unique_ptr<comm::URStream<PrimaryPackage>> stream_;
@@ -54,6 +74,6 @@ private:
 };
 
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl
 
 #endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED

--- a/include/ur_client_library/primary/primary_client.h
+++ b/include/ur_client_library/primary/primary_client.h
@@ -1,0 +1,59 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+#ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
+
+#include <ur_client_library/primary/primary_parser.h>
+#include <ur_client_library/comm/producer.h>
+#include <ur_client_library/comm/stream.h>
+#include <ur_client_library/comm/pipeline.h>
+
+namespace urcl
+{
+namespace primary_interface
+{
+class PrimaryClient
+{
+public:
+  PrimaryClient() = delete;
+  PrimaryClient(const std::string& robot_ip);
+  virtual ~PrimaryClient() = default;
+
+private:
+  std::string robot_ip_;
+  PrimaryParser parser_;
+  std::unique_ptr<comm::IConsumer<PrimaryPackage>> consumer_;
+  comm::INotifier notifier_;
+  std::unique_ptr<comm::URProducer<PrimaryPackage>> producer_;
+  std::unique_ptr<comm::URStream<PrimaryPackage>> stream_;
+  std::unique_ptr<comm::Pipeline<PrimaryPackage>> pipeline_;
+};
+
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED

--- a/include/ur_client_library/primary/primary_client.h
+++ b/include/ur_client_library/primary/primary_client.h
@@ -24,8 +24,8 @@
  *
  */
 //----------------------------------------------------------------------
-#ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
-#define UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_CLIENT_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_CLIENT_H_INCLUDED
 
 #include <ur_client_library/primary/primary_parser.h>
 #include <ur_client_library/comm/producer.h>
@@ -76,4 +76,4 @@ private:
 }  // namespace primary_interface
 }  // namespace urcl
 
-#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CLIENT_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_CLIENT_H_INCLUDED

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -1,0 +1,137 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+//
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
+
+#include "ur_client_library/log.h"
+#include "ur_client_library/comm/pipeline.h"
+#include "ur_client_library/primary/primary_package_handler.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
+#include "ur_client_library/primary/key_message_handler.h"
+#include "ur_client_library/primary/robot_message/error_code_message.h"
+#include "ur_client_library/primary/robot_message/key_message.h"
+#include "ur_client_library/primary/robot_message/runtime_exception_message.h"
+#include "ur_client_library/primary/robot_message/text_message.h"
+#include "ur_client_library/primary/robot_message/version_message.h"
+#include "ur_client_library/primary/robot_state/kinematics_info.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+/*!
+ * \brief Primary consumer implementation
+ *
+ * This class implements am AbstractPrimaryConsumer such that it can consume all incoming primary
+ * messages. However, actual work will be done by workers for each specific type.
+ */
+class PrimaryConsumer : public AbstractPrimaryConsumer
+{
+public:
+  PrimaryConsumer()
+  {
+    LOG_INFO("Constructing primary consumer");
+    key_message_worker_.reset(new KeyMessageHandler());
+    LOG_INFO("Constructed primary consumer");
+  }
+  virtual ~PrimaryConsumer() = default;
+
+  virtual bool consume(RobotMessage& msg) override
+  {
+    LOG_INFO("---RobotMessage:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RobotState& msg) override
+  {
+    // LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(ErrorCodeMessage& msg) override
+  {
+    LOG_INFO("---ErrorCodeMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RuntimeExceptionMessage& msg) override
+  {
+    LOG_INFO("---RuntimeExceptionMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(TextMessage& msg) override
+  {
+    LOG_INFO("---TextMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(VersionMessage& msg) override
+  {
+    LOG_INFO("---VersionMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
+
+  /*!
+   * \brief Handle a KinematicsInfo
+   *
+   * \returns True if there's a handler for this message type registered. False otherwise.
+   */
+  virtual bool consume(KinematicsInfo& pkg) override
+  {
+    if (kinematics_info_message_worker_ != nullptr)
+    {
+      kinematics_info_message_worker_->handle(pkg);
+      return true;
+    }
+    return false;
+  }
+
+  /*!
+   * \brief Handle a KeyMessage
+   *
+   * \returns True if there's a handler for this message type registered. False otherwise.
+   */
+  virtual bool consume(KeyMessage& pkg) override
+  {
+    if (key_message_worker_ != nullptr)
+    {
+      key_message_worker_->handle(pkg);
+      return true;
+    }
+    return false;
+  }
+
+  void setKinematicsInfoHandler(const std::shared_ptr<IPrimaryPackageHandler<KinematicsInfo>>& handler)
+  {
+    kinematics_info_message_worker_ = handler;
+  }
+
+private:
+  std::shared_ptr<IPrimaryPackageHandler<KeyMessage>> key_message_worker_;
+  std::shared_ptr<IPrimaryPackageHandler<KinematicsInfo>> kinematics_info_message_worker_;
+};
+}  // namespace primary_interface
+}  // namespace urcl
+
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -33,6 +33,7 @@
 #include "ur_client_library/primary/primary_package_handler.h"
 #include "ur_client_library/primary/abstract_primary_consumer.h"
 #include "ur_client_library/primary/key_message_handler.h"
+#include "ur_client_library/primary/error_code_message_handler.h"
 #include "ur_client_library/primary/robot_message/error_code_message.h"
 #include "ur_client_library/primary/robot_message/key_message.h"
 #include "ur_client_library/primary/robot_message/runtime_exception_message.h"
@@ -57,6 +58,7 @@ public:
   {
     LOG_INFO("Constructing primary consumer");
     key_message_worker_.reset(new KeyMessageHandler());
+    error_code_message_worker_.reset(new ErrorCodeMessageHandler());
     LOG_INFO("Constructed primary consumer");
   }
   virtual ~PrimaryConsumer() = default;
@@ -69,11 +71,6 @@ public:
   virtual bool consume(RobotState& msg) override
   {
     // LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
-    return true;
-  }
-  virtual bool consume(ErrorCodeMessage& msg) override
-  {
-    LOG_INFO("---ErrorCodeMessage---\n%s", msg.toString().c_str());
     return true;
   }
   virtual bool consume(RuntimeExceptionMessage& msg) override
@@ -122,6 +119,20 @@ public:
     return false;
   }
 
+  /*!
+   * \brief Handle a ErrorCodeMessage
+   *
+   * \returns True if there's a handler for this message type registered. False otherwise.
+   */
+  virtual bool consume(ErrorCodeMessage& pkg) override
+  {
+    if (error_code_message_worker_ != nullptr)
+    {
+      error_code_message_worker_->handle(pkg);
+      return true;
+    }
+    return false;
+  }
   void setKinematicsInfoHandler(const std::shared_ptr<IPrimaryPackageHandler<KinematicsInfo>>& handler)
   {
     kinematics_info_message_worker_ = handler;
@@ -129,6 +140,7 @@ public:
 
 private:
   std::shared_ptr<IPrimaryPackageHandler<KeyMessage>> key_message_worker_;
+  std::shared_ptr<IPrimaryPackageHandler<ErrorCodeMessage>> error_code_message_worker_;
   std::shared_ptr<IPrimaryPackageHandler<KinematicsInfo>> kinematics_info_message_worker_;
 };
 }  // namespace primary_interface

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
-#define UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_CONSUMER_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_CONSUMER_H_INCLUDED
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/comm/pipeline.h"
@@ -146,4 +146,4 @@ private:
 }  // namespace primary_interface
 }  // namespace urcl
 
-#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_CONSUMER_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_CONSUMER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_package_handler.h
+++ b/include/ur_client_library/primary/primary_package_handler.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
-#define UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
 
 namespace urcl
 {
@@ -55,4 +55,4 @@ private:
 };
 }  // namespace primary_interface
 }  // namespace urcl
-#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_PACKAGE_HANDLER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_package_handler.h
+++ b/include/ur_client_library/primary/primary_package_handler.h
@@ -1,7 +1,7 @@
 // this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
-
+//
 // -- BEGIN LICENSE BLOCK ----------------------------------------------
-// Copyright 2019 FZI Forschungszentrum Informatik
+// Copyright 2020 FZI Forschungszentrum Informatik
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,35 +20,39 @@
 /*!\file
  *
  * \author  Felix Exner exner@fzi.de
- * \date    2019-06-14
+ * \date    2020-04-30
  *
  */
 //----------------------------------------------------------------------
 
-#include <ur_client_library/ur/calibration_checker.h>
+#ifndef UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED
 
 namespace urcl
 {
-CalibrationChecker::CalibrationChecker(const std::string& expected_hash)
-  : expected_hash_(expected_hash), checked_(false)
+namespace primary_interface
 {
-}
-void CalibrationChecker::handle(primary_interface::KinematicsInfo& kin_info)
+/*!
+ * \brief Interface for a class handling a primary interface package. Classes that implement this
+ * interface with a specific package type will be able to handle packages of this type.
+ */
+template <typename PackageT>
+class IPrimaryPackageHandler
 {
-  if (kin_info.toHash() != expected_hash_)
-  {
-    LOG_ERROR("The calibration parameters of the connected robot don't match the ones from the given kinematics "
-              "config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use the "
-              "ur_calibration tool to extract the correct calibration from the robot and pass that into the "
-              "description. See "
-              "[https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] for "
-              "details.");
-  }
-  else
-  {
-    LOG_INFO("Calibration checked successfully.");
-  }
+public:
+  IPrimaryPackageHandler() = default;
+  virtual ~IPrimaryPackageHandler() = default;
 
-  checked_ = true;
-}
+  /*!
+   * \brief Actual worker function
+   *
+   * \param pkg package that should be handled
+   */
+  virtual void handle(PackageT& pkg) = 0;
+
+private:
+  /* data */
+};
+}  // namespace primary_interface
 }  // namespace urcl
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_PACKAGE_HANDLER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_parser.h
+++ b/include/ur_client_library/primary/primary_parser.h
@@ -28,6 +28,8 @@
 #include "ur_client_library/primary/robot_message.h"
 #include "ur_client_library/primary/robot_state/kinematics_info.h"
 #include "ur_client_library/primary/robot_message/key_message.h"
+#include "ur_client_library/primary/robot_message/error_code_message.h"
+#include "ur_client_library/primary/robot_message/runtime_exception_message.h"
 #include "ur_client_library/primary/robot_message/text_message.h"
 #include "ur_client_library/primary/robot_message/version_message.h"
 
@@ -180,6 +182,10 @@ private:
         return new TextMessage(timestamp, source);
       case RobotMessagePackageType::ROBOT_MESSAGE_KEY:
         return new KeyMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_ERROR_CODE:
+        return new ErrorCodeMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_RUNTIME_EXCEPTION:
+        return new RuntimeExceptionMessage(timestamp, source);
       default:
         return new RobotMessage(timestamp, source, type);
     }

--- a/include/ur_client_library/primary/primary_parser.h
+++ b/include/ur_client_library/primary/primary_parser.h
@@ -115,7 +115,7 @@ public:
       case RobotPackageType::ROBOT_MESSAGE:
       {
         uint64_t timestamp;
-        uint8_t source;
+        int8_t source;
         RobotMessagePackageType message_type;
 
         bp.parse(timestamp);

--- a/include/ur_client_library/primary/primary_parser.h
+++ b/include/ur_client_library/primary/primary_parser.h
@@ -175,7 +175,7 @@ private:
       case RobotMessagePackageType::ROBOT_MESSAGE_VERSION:
         return new VersionMessage(timestamp, source);
       default:
-        return new RobotMessage(timestamp, source);
+        return new RobotMessage(timestamp, source, type);
     }
   }
 };

--- a/include/ur_client_library/primary/primary_parser.h
+++ b/include/ur_client_library/primary/primary_parser.h
@@ -27,6 +27,8 @@
 #include "ur_client_library/primary/robot_state.h"
 #include "ur_client_library/primary/robot_message.h"
 #include "ur_client_library/primary/robot_state/kinematics_info.h"
+#include "ur_client_library/primary/robot_message/key_message.h"
+#include "ur_client_library/primary/robot_message/text_message.h"
 #include "ur_client_library/primary/robot_message/version_message.h"
 
 namespace urcl
@@ -174,6 +176,10 @@ private:
         return new MBD;*/
       case RobotMessagePackageType::ROBOT_MESSAGE_VERSION:
         return new VersionMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_TEXT:
+        return new TextMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_KEY:
+        return new KeyMessage(timestamp, source);
       default:
         return new RobotMessage(timestamp, source, type);
     }

--- a/include/ur_client_library/primary/primary_shell_consumer.h
+++ b/include/ur_client_library/primary/primary_shell_consumer.h
@@ -26,8 +26,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
-#define UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_SHELL_CONSUMER_H_INCLUDED
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/primary/abstract_primary_consumer.h"
@@ -89,4 +89,4 @@ private:
 }  // namespace primary_interface
 }  // namespace urcl
 
-#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_SHELL_CONSUMER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_shell_consumer.h
+++ b/include/ur_client_library/primary/primary_shell_consumer.h
@@ -1,0 +1,92 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+#define UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED
+
+#include "ur_client_library/log.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+class PrimaryShellConsumer : public AbstractPrimaryConsumer
+{
+public:
+  PrimaryShellConsumer() = default;
+  virtual ~PrimaryShellConsumer() = default;
+
+  virtual bool consume(RobotMessage& msg) override
+  {
+    LOG_INFO("---RobotMessage:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RobotState& msg) override
+  {
+    LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(ErrorCodeMessage& msg) override
+  {
+    LOG_INFO("---ErrorCodeMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(KeyMessage& msg) override
+  {
+    LOG_INFO("---KeyMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(RuntimeExceptionMessage& msg) override
+  {
+    LOG_INFO("---RuntimeExceptionMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(TextMessage& msg) override
+  {
+    LOG_INFO("---TextMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(VersionMessage& msg) override
+  {
+    LOG_INFO("---VersionMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(KinematicsInfo& msg) override
+  {
+    LOG_INFO("%s", msg.toString().c_str());
+    return true;
+  }
+
+private:
+  /* data */
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_shell_consumer.h
+++ b/include/ur_client_library/primary/primary_shell_consumer.h
@@ -49,7 +49,7 @@ public:
   }
   virtual bool consume(RobotState& msg) override
   {
-    LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
+    // LOG_INFO("---RobotState:---\n%s", msg.toString().c_str());
     return true;
   }
   virtual bool consume(ErrorCodeMessage& msg) override
@@ -87,6 +87,6 @@ private:
   /* data */
 };
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl
 
 #endif  // ifndef UR_ROBOT_DRIVER_PRIMARY_SHELL_CONSUMER_H_INCLUDED

--- a/include/ur_client_library/primary/primary_shell_consumer.h
+++ b/include/ur_client_library/primary/primary_shell_consumer.h
@@ -82,6 +82,16 @@ public:
     LOG_INFO("%s", msg.toString().c_str());
     return true;
   }
+  virtual bool consume(ProgramStateMessage& msg) override
+  {
+    LOG_INFO("---ProgramStateMessage---%s", msg.toString().c_str());
+    return true;
+  }
+  virtual bool consume(GlobalVariablesUpdateMessage& msg) override
+  {
+    LOG_INFO("---GlobalVariablesUpdateMessage---\n%s", msg.toString().c_str());
+    return true;
+  }
 
 private:
   /* data */

--- a/include/ur_client_library/primary/program_state_message.h
+++ b/include/ur_client_library/primary/program_state_message.h
@@ -1,0 +1,108 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner <exner@fzi.de>
+ * \date    2022-02-21
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_PROGRAM_STATE_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PROGRAM_STATE_MESSAGE_H_INCLUDED
+
+#include "ur_client_library/primary/primary_package.h"
+#include "ur_client_library/primary/package_header.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+/*!
+ * \brief Possible ProgramStateMessage types
+ */
+enum class ProgramStateMessageType : uint8_t
+{
+  GLOBAL_VARIABLES_SETUP = 0,
+  GLOBAL_VARIABLES_UPDATE = 1,
+  TYPE_VARIABLES_UPDATE = 2,
+};
+
+/*!
+ * \brief The ProgramStateMessage class is a parent class for the different received robot messages.
+ */
+class ProgramStateMessage : public PrimaryPackage
+{
+public:
+  /*!
+   * \brief Creates a new ProgramStateMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   */
+  ProgramStateMessage(const uint64_t timestamp) : timestamp_(timestamp)
+  {
+  }
+
+  /*!
+   * \brief Creates a new ProgramStateMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param message_type The package's message type
+   */
+  ProgramStateMessage(const uint64_t timestamp, const ProgramStateMessageType state_type)
+    : timestamp_(timestamp), state_type_(state_type)
+  {
+  }
+  virtual ~ProgramStateMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized version of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  uint64_t timestamp_;
+  ProgramStateMessageType state_type_;
+};
+
+}  // namespace primary_interface
+}  // namespace urcl
+
+#endif /* UR_CLIENT_LIBRARY_ROBOT_STATE_H_INCLUDED */

--- a/include/ur_client_library/primary/program_state_message/global_variables_update_message.h
+++ b/include/ur_client_library/primary/program_state_message/global_variables_update_message.h
@@ -1,0 +1,90 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    20222-02-21
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_GLOBAL_VARIABLES_UPDATE_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_GLOBAL_VARIABLES_UPDATE_MESSAGE_H_INCLUDED
+
+#include "ur_client_library/primary/program_state_message.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+/*!
+ * \brief The GlobalVariablesUpdateMessage class handles the key messages sent via the primary UR interface.
+ */
+class GlobalVariablesUpdateMessage : public ProgramStateMessage
+{
+public:
+  GlobalVariablesUpdateMessage() = delete;
+  /*!
+   * \brief Creates a new GlobalVariablesUpdateMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  GlobalVariablesUpdateMessage(const uint64_t timestamp)
+    : ProgramStateMessage(timestamp, ProgramStateMessageType::GLOBAL_VARIABLES_UPDATE)
+  {
+  }
+  virtual ~GlobalVariablesUpdateMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  uint16_t start_index_;
+  std::string variables_;
+
+};
+}  // namespace primary_interface
+}  // namespace urcl
+
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+

--- a/include/ur_client_library/primary/robot_message.h
+++ b/include/ur_client_library/primary/robot_message.h
@@ -65,6 +65,18 @@ public:
   RobotMessage(const uint64_t timestamp, const int8_t source) : timestamp_(timestamp), source_(source)
   {
   }
+
+  /*!
+   * \brief Creates a new RobotMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   * \param message_type The package's message type
+   */
+  RobotMessage(const uint64_t timestamp, const int8_t source, const RobotMessagePackageType message_type)
+    : timestamp_(timestamp), source_(source), message_type_(message_type)
+  {
+  }
   virtual ~RobotMessage() = default;
 
   /*!

--- a/include/ur_client_library/primary/robot_message.h
+++ b/include/ur_client_library/primary/robot_message.h
@@ -37,7 +37,7 @@ namespace primary_interface
 /*!
  * \brief Possible RobotMessage types
  */
-enum class RobotMessagePackageType : uint8_t
+enum class RobotMessagePackageType : int8_t
 {
   ROBOT_MESSAGE_TEXT = 0,
   ROBOT_MESSAGE_PROGRAM_LABEL = 1,
@@ -62,7 +62,7 @@ public:
    * \param timestamp Timestamp of the package
    * \param source The package's source
    */
-  RobotMessage(const uint64_t timestamp, const uint8_t source) : timestamp_(timestamp), source_(source)
+  RobotMessage(const uint64_t timestamp, const int8_t source) : timestamp_(timestamp), source_(source)
   {
   }
   virtual ~RobotMessage() = default;
@@ -94,7 +94,7 @@ public:
   virtual std::string toString() const;
 
   uint64_t timestamp_;
-  uint8_t source_;
+  int8_t source_;
   RobotMessagePackageType message_type_;
 };
 

--- a/include/ur_client_library/primary/robot_message/error_code_message.h
+++ b/include/ur_client_library/primary/robot_message/error_code_message.h
@@ -34,6 +34,20 @@ namespace urcl
 {
 namespace primary_interface
 {
+enum class ReportLevel : int32_t
+{
+  DEBUG = 0,
+  INFO = 1,
+  WARNING = 2,
+  VIOLATION = 3,
+  FAULT = 4,
+  DEVL_DEBUG = 128,
+  DEVL_INFO = 129,
+  DEVL_WARNING = 130,
+  DEVL_VIOLATION = 131,
+  DEVL_FAULT = 132
+};
+
 /*!
  * \brief The ErrorCodeMessage class handles the error code messages sent via the primary UR interface.
  */
@@ -81,7 +95,7 @@ public:
 
   int32_t message_code_;
   int32_t message_argument_;
-  int32_t report_level_;
+  ReportLevel report_level_;
   uint8_t data_type_;
   uint32_t data_;
   std::string text_;

--- a/include/ur_client_library/primary/robot_message/error_code_message.h
+++ b/include/ur_client_library/primary/robot_message/error_code_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/include/ur_client_library/primary/robot_message/error_code_message.h
+++ b/include/ur_client_library/primary/robot_message/error_code_message.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_RTDE_DRIVER_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
-#define UR_RTDE_DRIVER_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
 
 #include "ur_client_library/primary/robot_message.h"
 
@@ -101,6 +101,6 @@ public:
   std::string text_;
 };
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl
 
-#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/error_code_message.h
+++ b/include/ur_client_library/primary/robot_message/error_code_message.h
@@ -1,0 +1,83 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_ERROR_CODE_MESSAGE_H_INCLUDED
+
+#include "ur_client_library/primary/robot_message.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+/*!
+ * \brief The ErrorCodeMessage class handles the error code messages sent via the primary UR interface.
+ */
+class ErrorCodeMessage : public RobotMessage
+{
+public:
+  ErrorCodeMessage() = delete;
+  /*!
+   * \brief Creates a new ErrorCodeMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  ErrorCodeMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_ERROR_CODE)
+  {
+  }
+  virtual ~ErrorCodeMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t message_code_;
+  int32_t message_argument_;
+  int32_t report_level_;
+  uint8_t data_type_;
+  uint32_t data_;
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/key_message.h
+++ b/include/ur_client_library/primary/robot_message/key_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/include/ur_client_library/primary/robot_message/key_message.h
+++ b/include/ur_client_library/primary/robot_message/key_message.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
-#define UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_KEY_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_KEY_MESSAGE_H_INCLUDED
 
 #include "ur_client_library/primary/robot_message.h"
 
@@ -86,6 +86,6 @@ public:
   std::string text_;
 };
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl
 
-#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/key_message.h
+++ b/include/ur_client_library/primary/robot_message/key_message.h
@@ -28,9 +28,9 @@
 #ifndef UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
 #define UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
 
-#include "ur_robot_driver/primary/robot_message.h"
+#include "ur_client_library/primary/robot_message.h"
 
-namespace ur_driver
+namespace urcl
 {
 namespace primary_interface
 {

--- a/include/ur_client_library/primary/robot_message/key_message.h
+++ b/include/ur_client_library/primary/robot_message/key_message.h
@@ -1,0 +1,82 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_KEY_MESSAGE_H_INCLUDED
+
+#include "ur_robot_driver/primary/robot_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief The KeyMessage class handles the key messages sent via the primary UR interface.
+ */
+class KeyMessage : public RobotMessage
+{
+public:
+  KeyMessage() = delete;
+  /*!
+   * \brief Creates a new KeyMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  KeyMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_KEY)
+  {
+  }
+  virtual ~KeyMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t message_code_;
+  int32_t message_argument_;
+  uint8_t title_size_;
+  std::string title_;
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/runtime_exception_message.h
+++ b/include/ur_client_library/primary/robot_message/runtime_exception_message.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_RTDE_DRIVER_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
-#define UR_RTDE_DRIVER_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
 
 #include "ur_client_library/primary/robot_message.h"
 
@@ -84,6 +84,6 @@ public:
   std::string text_;
 };
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl
 
-#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/runtime_exception_message.h
+++ b/include/ur_client_library/primary/robot_message/runtime_exception_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/include/ur_client_library/primary/robot_message/runtime_exception_message.h
+++ b/include/ur_client_library/primary/robot_message/runtime_exception_message.h
@@ -1,0 +1,80 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_RUNTIME_EXCEPTION_MESSAGE_H_INCLUDED
+
+#include "ur_client_library/primary/robot_message.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+/*!
+ * \brief The RuntimeExceptionMessage class handles the runtime exception messages sent via the primary UR interface.
+ */
+class RuntimeExceptionMessage : public RobotMessage
+{
+public:
+  RuntimeExceptionMessage() = delete;
+  /*!
+   * \brief Creates a new RuntimeExceptionMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  RuntimeExceptionMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_RUNTIME_EXCEPTION)
+  {
+  }
+  virtual ~RuntimeExceptionMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t line_number_;
+  int32_t column_number_;
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/text_message.h
+++ b/include/ur_client_library/primary/robot_message/text_message.h
@@ -25,8 +25,8 @@
  */
 //----------------------------------------------------------------------
 
-#ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
-#define UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED
 
 #include "ur_client_library/primary/robot_message.h"
 
@@ -82,6 +82,6 @@ public:
   std::string text_;
 };
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl
 
-#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/text_message.h
+++ b/include/ur_client_library/primary/robot_message/text_message.h
@@ -1,0 +1,78 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-23
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+#define UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
+
+#include "ur_robot_driver/primary/robot_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+/*!
+ * \brief The TextMessage class handles the text messages sent via the primary UR interface.
+ */
+class TextMessage : public RobotMessage
+{
+public:
+  TextMessage() = delete;
+  /*!
+   * \brief Creates a new TextMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  TextMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_TEXT)
+  {
+  }
+  virtual ~TextMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  std::string text_;
+};
+}  // namespace primary_interface
+}  // namespace ur_driver
+
+#endif  // ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/primary/robot_message/text_message.h
+++ b/include/ur_client_library/primary/robot_message/text_message.h
@@ -64,6 +64,15 @@ public:
   virtual bool parseWith(comm::BinParser& bp);
 
   /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
    * \brief Produces a human readable representation of the package object.
    *
    * \returns A string representing the object

--- a/include/ur_client_library/primary/robot_message/text_message.h
+++ b/include/ur_client_library/primary/robot_message/text_message.h
@@ -28,9 +28,9 @@
 #ifndef UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
 #define UR_RTDE_DRIVER_PRIMARY_TEXT_MESSAGE_H_INCLUDED
 
-#include "ur_robot_driver/primary/robot_message.h"
+#include "ur_client_library/primary/robot_message.h"
 
-namespace ur_driver
+namespace urcl
 {
 namespace primary_interface
 {

--- a/include/ur_client_library/primary/robot_message/version_message.h
+++ b/include/ur_client_library/primary/robot_message/version_message.h
@@ -47,7 +47,7 @@ public:
    * \param timestamp Timestamp of the package
    * \param source The package's source
    */
-  VersionMessage(uint64_t timestamp, uint8_t source) : RobotMessage(timestamp, source)
+  VersionMessage(uint64_t timestamp, int8_t source) : RobotMessage(timestamp, source)
   {
   }
   virtual ~VersionMessage() = default;

--- a/include/ur_client_library/primary/robot_message/version_message.h
+++ b/include/ur_client_library/primary/robot_message/version_message.h
@@ -47,7 +47,8 @@ public:
    * \param timestamp Timestamp of the package
    * \param source The package's source
    */
-  VersionMessage(uint64_t timestamp, int8_t source) : RobotMessage(timestamp, source)
+  VersionMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_VERSION)
   {
   }
   virtual ~VersionMessage() = default;

--- a/include/ur_client_library/ur/calibration_checker.h
+++ b/include/ur_client_library/ur/calibration_checker.h
@@ -27,18 +27,17 @@
 #ifndef UR_CLIENT_LIBRARY_UR_CALIBRATION_CHECKER_H_INCLUDED
 #define UR_CLIENT_LIBRARY_UR_CALIBRATION_CHECKER_H_INCLUDED
 
-#include <ur_client_library/comm/pipeline.h>
-
+#include <ur_client_library/primary/primary_package_handler.h>
 #include <ur_client_library/primary/robot_state/kinematics_info.h>
 
 namespace urcl
 {
 /*!
- * \brief The CalibrationChecker class consumes primary packages ignoring all but KinematicsInfo
- * packages. These are then checked against the used kinematics to see if the correct calibration
- * is used.
+ * \brief The CalibrationChecker checks a received KinematicsInfo package against a registered calibration hash
+ * value. This way we know whether the robot that sent the KinematicsInfo package matches the
+ * expected calibration.
  */
-class CalibrationChecker : public comm::IConsumer<primary_interface::PrimaryPackage>
+class CalibrationChecker : public primary_interface::IPrimaryPackageHandler<primary_interface::KinematicsInfo>
 {
 public:
   /*!
@@ -51,31 +50,6 @@ public:
   virtual ~CalibrationChecker() = default;
 
   /*!
-   * \brief Empty setup function, as no setup is needed.
-   */
-  virtual void setupConsumer()
-  {
-  }
-  /*!
-   * \brief Tears down the consumer.
-   */
-  virtual void teardownConsumer()
-  {
-  }
-  /*!
-   * \brief Stops the consumer.
-   */
-  virtual void stopConsumer()
-  {
-  }
-  /*!
-   * \brief Handles timeouts.
-   */
-  virtual void onTimeout()
-  {
-  }
-
-  /*!
    * \brief Consumes a package, checking its hash if it is a KinematicsInfo package. If the hash
    * does not match the expected hash, an error is logged.
    *
@@ -83,7 +57,7 @@ public:
    *
    * \returns True, if the package was consumed correctly
    */
-  virtual bool consume(std::shared_ptr<primary_interface::PrimaryPackage> product);
+  virtual void handle(primary_interface::KinematicsInfo& kin_info) override;
 
   /*!
    * \brief Used to make sure the calibration check is not performed several times.

--- a/include/ur_client_library/ur/dashboard_client.h
+++ b/include/ur_client_library/ur/dashboard_client.h
@@ -24,8 +24,8 @@
  *
  */
 //----------------------------------------------------------------------
-#ifndef UR_ROBOT_DRIVER_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
-#define UR_ROBOT_DRIVER_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
+#ifndef UR_CLIENT_LIBRARY_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
+#define UR_CLIENT_LIBRARY_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
 
 #include <ur_client_library/comm/tcp_socket.h>
 
@@ -97,4 +97,4 @@ private:
   std::mutex write_mutex_;
 };
 }  // namespace urcl
-#endif  // ifndef UR_ROBOT_DRIVER_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -35,6 +35,7 @@
 #include "ur_client_library/ur/tool_communication.h"
 #include "ur_client_library/ur/version_information.h"
 #include "ur_client_library/primary/robot_message/version_message.h"
+#include "ur_client_library/primary/primary_client.h"
 #include "ur_client_library/rtde/rtde_writer.h"
 
 namespace urcl
@@ -185,7 +186,7 @@ public:
    *
    * \param checksum Hash of the used kinematics information
    */
-  void checkCalibration(const std::string& checksum);
+  // void checkCalibration(const std::string& checksum);
 
   /*!
    * \brief Getter for the RTDE writer used to write to the robot's RTDE interface.
@@ -231,8 +232,10 @@ private:
   std::unique_ptr<rtde_interface::RTDEClient> rtde_client_;
   std::unique_ptr<comm::ReverseInterface> reverse_interface_;
   std::unique_ptr<comm::ScriptSender> script_sender_;
-  std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> primary_stream_;
-  std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> secondary_stream_;
+
+  primary_interface::PrimaryClient primary_client_;
+  // std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> primary_stream_;
+  // std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> secondary_stream_;
 
   double servoj_time_;
   uint32_t servoj_gain_;

--- a/src/primary/primary_client.cpp
+++ b/src/primary/primary_client.cpp
@@ -25,6 +25,9 @@
  */
 //----------------------------------------------------------------------
 
+#include <chrono>
+#include <thread>
+
 #include <ur_client_library/primary/primary_client.h>
 #include <ur_client_library/primary/primary_shell_consumer.h>
 
@@ -32,16 +35,65 @@ namespace urcl
 {
 namespace primary_interface
 {
-PrimaryClient::PrimaryClient(const std::string& robot_ip) : robot_ip_(robot_ip)
+PrimaryClient::PrimaryClient(const std::string& robot_ip, const std::string& calibration_checksum) : robot_ip_(robot_ip)
 {
   stream_.reset(new comm::URStream<PrimaryPackage>(robot_ip_, UR_PRIMARY_PORT));
   producer_.reset(new comm::URProducer<PrimaryPackage>(*stream_, parser_));
   producer_->setupProducer();
 
-  consumer_.reset(new PrimaryShellConsumer());
+  consumer_.reset(new PrimaryConsumer());
+  std::shared_ptr<CalibrationChecker> calibration_checker(new CalibrationChecker(calibration_checksum));
+  consumer_->setKinematicsInfoHandler(calibration_checker);
 
   pipeline_.reset(new comm::Pipeline<PrimaryPackage>(*producer_, consumer_.get(), "primary pipeline", notifier_));
   pipeline_->run();
+
+  calibration_checker->isChecked();
+  while (!calibration_checker->isChecked())
+  {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+  LOG_DEBUG("Got calibration information from robot.");
+}
+
+bool PrimaryClient::sendScript(const std::string& script_code)
+{
+  if (stream_ == nullptr)
+  {
+    throw std::runtime_error("Sending script to robot requested while there is no primary interface established. This "
+                             "should not happen.");
+  }
+
+  // urscripts (snippets) must end with a newline, or otherwise the controller's runtime will
+  // not execute them. To avoid problems, we always just append a newline here, even if
+  // there may already be one.
+  auto program_with_newline = script_code + '\n';
+
+  size_t len = program_with_newline.size();
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
+  size_t written;
+
+  if (stream_->write(data, len, written))
+  {
+    LOG_INFO("Sent program to robot:\n%s", program_with_newline.c_str());
+    return true;
+  }
+  LOG_ERROR("Could not send program to robot");
+  return false;
+}
+
+void PrimaryClient::checkCalibration(const std::string& checksum)
+{
+  // if (stream_ == nullptr)
+  //{
+  // throw std::runtime_error("checkCalibration() called without a primary interface connection being established.");
+  //}
+
+  // while (!consumer.isChecked())
+  //{
+  // ros::Duration(1).sleep();
+  //}
+  // ROS_DEBUG_STREAM("Got calibration information from robot.");
 }
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl

--- a/src/primary/primary_client.cpp
+++ b/src/primary/primary_client.cpp
@@ -1,0 +1,47 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Text 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <ur_client_library/primary/primary_client.h>
+#include <ur_client_library/primary/primary_shell_consumer.h>
+
+namespace urcl
+{
+namespace primary_interface
+{
+PrimaryClient::PrimaryClient(const std::string& robot_ip) : robot_ip_(robot_ip)
+{
+  stream_.reset(new comm::URStream<PrimaryPackage>(robot_ip_, UR_PRIMARY_PORT));
+  producer_.reset(new comm::URProducer<PrimaryPackage>(*stream_, parser_));
+  producer_->setupProducer();
+
+  consumer_.reset(new PrimaryShellConsumer());
+
+  pipeline_.reset(new comm::Pipeline<PrimaryPackage>(*producer_, consumer_.get(), "primary pipeline", notifier_));
+  pipeline_->run();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/src/primary/primary_client.cpp
+++ b/src/primary/primary_client.cpp
@@ -41,19 +41,21 @@ PrimaryClient::PrimaryClient(const std::string& robot_ip, const std::string& cal
   producer_.reset(new comm::URProducer<PrimaryPackage>(*stream_, parser_));
   producer_->setupProducer();
 
-  consumer_.reset(new PrimaryConsumer());
-  std::shared_ptr<CalibrationChecker> calibration_checker(new CalibrationChecker(calibration_checksum));
-  consumer_->setKinematicsInfoHandler(calibration_checker);
+  //consumer_.reset(new PrimaryConsumer());
+  //std::shared_ptr<CalibrationChecker> calibration_checker(new CalibrationChecker(calibration_checksum));
+  //consumer_->setKinematicsInfoHandler(calibration_checker);
 
+  std::unique_ptr<comm::IConsumer<primary_interface::PrimaryPackage>> consumer;
+  consumer.reset(new primary_interface::PrimaryShellConsumer());
   pipeline_.reset(new comm::Pipeline<PrimaryPackage>(*producer_, consumer_.get(), "primary pipeline", notifier_));
   pipeline_->run();
 
-  calibration_checker->isChecked();
-  while (!calibration_checker->isChecked())
-  {
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-  }
-  LOG_DEBUG("Got calibration information from robot.");
+  //calibration_checker->isChecked();
+  //while (!calibration_checker->isChecked())
+  //{
+    //std::this_thread::sleep_for(std::chrono::seconds(1));
+  //}
+  //LOG_DEBUG("Got calibration information from robot.");
 }
 
 bool PrimaryClient::sendScript(const std::string& script_code)

--- a/src/primary/program_state_message.cpp
+++ b/src/primary/program_state_message.cpp
@@ -1,0 +1,56 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2020 FZI Forschungszentrum Informatik (ur_robot_driver)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2022-02-21
+ *
+ */
+//----------------------------------------------------------------------
+#include <sstream>
+
+#include "ur_client_library/primary/program_state_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+bool ProgramStateMessage::parseWith(comm::BinParser& bp)
+{
+  return true;
+}
+
+bool ProgramStateMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+
+std::string ProgramStateMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "timestamp: " << timestamp_ << std::endl;
+  ss << "Type: " << static_cast<int>(state_type_) << std::endl;
+  ss << PrimaryPackage::toString();
+  return ss.str();
+}
+
+}  // namespace primary_interface
+}  // namespace urcl

--- a/src/primary/program_state_message/global_variables_update_message.cpp
+++ b/src/primary/program_state_message/global_variables_update_message.cpp
@@ -1,0 +1,65 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2022-02-21
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_client_library/log.h"
+#include "ur_client_library/primary/program_state_message/global_variables_update_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+bool GlobalVariablesUpdateMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(start_index_);
+  bp.parseRemainder(variables_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+bool GlobalVariablesUpdateMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+
+std::string GlobalVariablesUpdateMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "start index: " << start_index_ << std::endl;
+  ss << "variables: (" << variables_.length() << ")";
+  for (const char& c : variables_)
+  {
+    ss << std::hex << static_cast<int>(c) << " ";
+  }
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace urcl
+

--- a/src/primary/robot_message/error_code_message.cpp
+++ b/src/primary/robot_message/error_code_message.cpp
@@ -67,4 +67,4 @@ std::string ErrorCodeMessage::toString() const
   return ss.str();
 }
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl

--- a/src/primary/robot_message/error_code_message.cpp
+++ b/src/primary/robot_message/error_code_message.cpp
@@ -1,0 +1,62 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_client_library/log.h"
+#include "ur_client_library/primary/robot_message/error_code_message.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+bool ErrorCodeMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(message_code_);
+  bp.parse(message_argument_);
+  bp.parse(report_level_);
+  bp.parse(data_type_);
+  bp.parse(data_);
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string ErrorCodeMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "Message code: " << message_code_ << std::endl;
+  ss << "Message argument: " << message_argument_ << std::endl;
+  ss << "Report level: " << report_level_ << std::endl;
+  ss << "Datatype: " << static_cast<int>(data_type_) << std::endl;
+  ss << "Data: " << data_ << std::endl;
+  ss << "Text: " << text_;
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/src/primary/robot_message/error_code_message.cpp
+++ b/src/primary/robot_message/error_code_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/primary/robot_message/error_code_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
 
 namespace urcl
 {
@@ -45,6 +46,11 @@ bool ErrorCodeMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool ErrorCodeMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string ErrorCodeMessage::toString() const

--- a/src/primary/robot_message/error_code_message.cpp
+++ b/src/primary/robot_message/error_code_message.cpp
@@ -40,7 +40,9 @@ bool ErrorCodeMessage::parseWith(comm::BinParser& bp)
 {
   bp.parse(message_code_);
   bp.parse(message_argument_);
-  bp.parse(report_level_);
+  int32_t report_level;
+  bp.parse(report_level);
+  report_level_ = static_cast<ReportLevel>(report_level);
   bp.parse(data_type_);
   bp.parse(data_);
   bp.parseRemainder(text_);
@@ -58,7 +60,7 @@ std::string ErrorCodeMessage::toString() const
   std::stringstream ss;
   ss << "Message code: " << message_code_ << std::endl;
   ss << "Message argument: " << message_argument_ << std::endl;
-  ss << "Report level: " << report_level_ << std::endl;
+  ss << "Report level: " << static_cast<int>(report_level_) << std::endl;
   ss << "Datatype: " << static_cast<int>(data_type_) << std::endl;
   ss << "Data: " << data_ << std::endl;
   ss << "Text: " << text_;

--- a/src/primary/robot_message/key_message.cpp
+++ b/src/primary/robot_message/key_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/primary/robot_message/key_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
 
 namespace urcl
 {
@@ -44,6 +45,11 @@ bool KeyMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool KeyMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string KeyMessage::toString() const

--- a/src/primary/robot_message/key_message.cpp
+++ b/src/primary/robot_message/key_message.cpp
@@ -1,0 +1,58 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2019-04-08
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/robot_message/key_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+bool KeyMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(message_code_);
+  bp.parse(message_argument_);
+  bp.parse(title_size_);
+  bp.parse(title_, title_size_);
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string KeyMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "Message code: " << message_code_ << std::endl;
+  ss << "Title: " << title_ << std::endl;
+  ss << "Text: " << text_;
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/src/primary/robot_message/key_message.cpp
+++ b/src/primary/robot_message/key_message.cpp
@@ -61,4 +61,4 @@ std::string KeyMessage::toString() const
   return ss.str();
 }
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl

--- a/src/primary/robot_message/key_message.cpp
+++ b/src/primary/robot_message/key_message.cpp
@@ -28,10 +28,10 @@
  */
 //----------------------------------------------------------------------
 
-#include "ur_robot_driver/log.h"
-#include "ur_robot_driver/primary/robot_message/key_message.h"
+#include "ur_client_library/log.h"
+#include "ur_client_library/primary/robot_message/key_message.h"
 
-namespace ur_driver
+namespace urcl
 {
 namespace primary_interface
 {

--- a/src/primary/robot_message/runtime_exception_message.cpp
+++ b/src/primary/robot_message/runtime_exception_message.cpp
@@ -59,4 +59,4 @@ std::string RuntimeExceptionMessage::toString() const
   return ss.str();
 }
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl

--- a/src/primary/robot_message/runtime_exception_message.cpp
+++ b/src/primary/robot_message/runtime_exception_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/primary/robot_message/runtime_exception_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
 
 namespace urcl
 {
@@ -42,6 +43,11 @@ bool RuntimeExceptionMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool RuntimeExceptionMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string RuntimeExceptionMessage::toString() const

--- a/src/primary/robot_message/runtime_exception_message.cpp
+++ b/src/primary/robot_message/runtime_exception_message.cpp
@@ -1,0 +1,56 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2020-04-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_client_library/log.h"
+#include "ur_client_library/primary/robot_message/runtime_exception_message.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+bool RuntimeExceptionMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(line_number_);
+  bp.parse(column_number_);
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string RuntimeExceptionMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "Runtime error in line " << line_number_;
+  ss << ", column " << column_number_ << std::endl;
+  ss << "Error: " << text_;
+  return ss.str();
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/src/primary/robot_message/text_message.cpp
+++ b/src/primary/robot_message/text_message.cpp
@@ -53,4 +53,4 @@ std::string TextMessage::toString() const
   return text_;
 }
 }  // namespace primary_interface
-}  // namespace ur_driver
+}  // namespace urcl

--- a/src/primary/robot_message/text_message.cpp
+++ b/src/primary/robot_message/text_message.cpp
@@ -28,10 +28,10 @@
  */
 //----------------------------------------------------------------------
 
-#include "ur_robot_driver/log.h"
-#include "ur_robot_driver/primary/robot_message/text_message.h"
+#include "ur_client_library/log.h"
+#include "ur_client_library/primary/robot_message/text_message.h"
 
-namespace ur_driver
+namespace urcl
 {
 namespace primary_interface
 {

--- a/src/primary/robot_message/text_message.cpp
+++ b/src/primary/robot_message/text_message.cpp
@@ -30,6 +30,7 @@
 
 #include "ur_client_library/log.h"
 #include "ur_client_library/primary/robot_message/text_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
 
 namespace urcl
 {
@@ -40,6 +41,11 @@ bool TextMessage::parseWith(comm::BinParser& bp)
   bp.parseRemainder(text_);
 
   return true;  // not really possible to check dynamic size packets
+}
+
+bool TextMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
 }
 
 std::string TextMessage::toString() const

--- a/src/primary/robot_message/text_message.cpp
+++ b/src/primary/robot_message/text_message.cpp
@@ -1,0 +1,50 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2019 FZI Forschungszentrum Informatik (ur_robot_driver)
+// Copyright 2017, 2018 Simon Rasmussen (refactor)
+//
+// Copyright 2015, 2016 Thomas Timm Andersen (original version)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2019-04-08
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_robot_driver/log.h"
+#include "ur_robot_driver/primary/robot_message/text_message.h"
+
+namespace ur_driver
+{
+namespace primary_interface
+{
+bool TextMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parseRemainder(text_);
+
+  return true;  // not really possible to check dynamic size packets
+}
+
+std::string TextMessage::toString() const
+{
+  return text_;
+}
+}  // namespace primary_interface
+}  // namespace ur_driver

--- a/src/primary/robot_message/version_message.cpp
+++ b/src/primary/robot_message/version_message.cpp
@@ -49,7 +49,7 @@ bool VersionMessage::parseWith(comm::BinParser& bp)
   return true;  // not really possible to check dynamic size packets
 }
 
-bool VersionMessage ::consumeWith(AbstractPrimaryConsumer& consumer)
+bool VersionMessage::consumeWith(AbstractPrimaryConsumer& consumer)
 {
   return consumer.consume(*this);
 }

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -53,7 +53,8 @@ urcl::UrDriver::UrDriver(const std::string& robot_ip, const std::string& script_
                          std::unique_ptr<ToolCommSetup> tool_comm_setup, const std::string& calibration_checksum,
                          const uint32_t reverse_port, const uint32_t script_sender_port, int servoj_gain,
                          double servoj_lookahead_time, bool non_blocking_read)
-  : servoj_time_(0.008)
+  : primary_client_(robot_ip, calibration_checksum)
+  , servoj_time_(0.008)
   , servoj_gain_(servoj_gain)
   , servoj_lookahead_time_(servoj_lookahead_time)
   , reverse_interface_active_(false)
@@ -65,13 +66,14 @@ urcl::UrDriver::UrDriver(const std::string& robot_ip, const std::string& script_
   LOG_DEBUG("Initializing RTDE client");
   rtde_client_.reset(new rtde_interface::RTDEClient(robot_ip_, notifier_, output_recipe_file, input_recipe_file));
 
-  primary_stream_.reset(
-      new comm::URStream<primary_interface::PrimaryPackage>(robot_ip_, urcl::primary_interface::UR_PRIMARY_PORT));
-  secondary_stream_.reset(
-      new comm::URStream<primary_interface::PrimaryPackage>(robot_ip_, urcl::primary_interface::UR_SECONDARY_PORT));
-  secondary_stream_->connect();
-  LOG_INFO("Checking if calibration data matches connected robot.");
-  checkCalibration(calibration_checksum);
+  // primary_stream_.reset(
+  // new comm::URStream<primary_interface::PrimaryPackage>(robot_ip_, ur_driver::primary_interface::UR_PRIMARY_PORT));
+  // secondary_stream_.reset(new comm::URStream<primary_interface::PrimaryPackage>(
+  // robot_ip_, ur_driver::primary_interface::UR_SECONDARY_PORT));
+  // secondary_stream_->connect();
+  // LOG_INFO("Checking if calibration data matches connected robot.");
+  // checkCalibration(calibration_checksum);
+  //
 
   non_blocking_read_ = non_blocking_read;
   get_packet_timeout_ = non_blocking_read_ ? 0 : 100;
@@ -254,30 +256,6 @@ std::string UrDriver::readKeepalive()
   }
 }
 
-void UrDriver::checkCalibration(const std::string& checksum)
-{
-  if (primary_stream_ == nullptr)
-  {
-    throw std::runtime_error("checkCalibration() called without a primary interface connection being established.");
-  }
-  primary_interface::PrimaryParser parser;
-  comm::URProducer<primary_interface::PrimaryPackage> prod(*primary_stream_, parser);
-  prod.setupProducer();
-
-  CalibrationChecker consumer(checksum);
-
-  comm::INotifier notifier;
-
-  comm::Pipeline<primary_interface::PrimaryPackage> pipeline(prod, &consumer, "Pipeline", notifier);
-  pipeline.run();
-
-  while (!consumer.isChecked())
-  {
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-  }
-  LOG_DEBUG("Got calibration information from robot.");
-}
-
 rtde_interface::RTDEWriter& UrDriver::getRTDEWriter()
 {
   return rtde_client_->getWriter();
@@ -285,28 +263,7 @@ rtde_interface::RTDEWriter& UrDriver::getRTDEWriter()
 
 bool UrDriver::sendScript(const std::string& program)
 {
-  if (secondary_stream_ == nullptr)
-  {
-    throw std::runtime_error("Sending script to robot requested while there is no primary interface established. This "
-                             "should not happen.");
-  }
-
-  // urscripts (snippets) must end with a newline, or otherwise the controller's runtime will
-  // not execute them. To avoid problems, we always just append a newline here, even if
-  // there may already be one.
-  auto program_with_newline = program + '\n';
-
-  size_t len = program_with_newline.size();
-  const uint8_t* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
-  size_t written;
-
-  if (secondary_stream_->write(data, len, written))
-  {
-    LOG_DEBUG("Sent program to robot:\n%s", program_with_newline.c_str());
-    return true;
-  }
-  LOG_ERROR("Could not send program to robot");
-  return false;
+  return primary_client_.sendScript(program);
 }
 
 bool UrDriver::sendRobotProgram()


### PR DESCRIPTION
This branch will

* Add a full primary client object structure to the client
* Read more data from the primary interface
* Show users when they send malformed script code to the robot
* Inform users when they are trying to send script code to an e-Series robot which is not in remote control mode
* Output any error messages coming up on the robot

I am not sure yet, to which extent all of those things will be tackled in this MR, but it will definitely be a start from which such features could easily be implemented.