### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 project(ur_client_library)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/" ${CMAKE_MODULE_PATH})

--- a/CMakeModules/FindGTest.CMakeLists.txt.in
+++ b/CMakeModules/FindGTest.CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(gtest-download NONE)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
 ```cmake
 # CMakeLists.txt
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 project(minimal_example)
 
 find_package(ur_client_library REQUIRED)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 project(ur_driver_examples)
 
 #find_package(ur_client_library REQUIRED)

--- a/examples/full_driver.cpp
+++ b/examples/full_driver.cpp
@@ -54,20 +54,6 @@ void handleRobotProgramState(bool program_running)
   std::cout << "\033[1;32mProgram running: " << std::boolalpha << program_running << "\033[0m\n" << std::endl;
 }
 
-void jogging()
-{
-  vector6d_t joint_position_command;
-
-  char c;
-
-  std::cout << "Press a key" << std::endl;
-  while (true)
-  {
-    c = getchar();
-    std::cout << "pressed " << c << std::endl;
-  }
-}
-
 int main(int argc, char* argv[])
 {
   std::unique_ptr<ToolCommSetup> tool_comm_setup;

--- a/include/ur_client_library/comm/reverse_interface.h
+++ b/include/ur_client_library/comm/reverse_interface.h
@@ -128,7 +128,7 @@ public:
    */
   std::string readKeepalive()
   {
-    size_t buf_len = 16;
+    const size_t buf_len = 16;
     char buffer[buf_len];
 
     bool read_successful = server_.readLine(buffer, buf_len);

--- a/include/ur_client_library/comm/script_sender.h
+++ b/include/ur_client_library/comm/script_sender.h
@@ -92,7 +92,7 @@ private:
 
   bool requestRead()
   {
-    size_t buf_len = 1024;
+    const size_t buf_len = 1024;
     char buffer[buf_len];
 
     bool read_successful = server_.readLine(buffer, buf_len);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../CMakeModules/" ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
There have been a number of warnings slipping through that the ROS buildfarm has been [complaining about](http://build.ros.org/job/Ndev__ur_client_library__ubuntu_focal_amd64/1/).

This PR fixes them by
 * Removing unused code
 * Bumping the minimum required cmake version to 3.0.2
 * Using const qualifiers for size_t variables used to initialize arrays