### PR TITLE
Fixed links in README (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ string from this function. If no answer is received, a `UrException` is thrown.
 
 Note: In order to make this more useful developers are expected to wrap this bare interface into
 something that checks the returned string for something that is expected. See the
-[DashboardClientROS](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/include/ur_robot_driver/ros/dashboard_client_ros.h) as an example.
+[DashboardClientROS](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.h) as an example.
 
 ## A word on the primary / secondary interface
 Currently, this library doesn't support the primary interface very well, as the [Universal Robots
@@ -277,7 +277,7 @@ for details on how to set this up.
 The RTDE receive thread will be scheduled to real-time priority automatically, if applicable. If
 this doesn't work, an error is raised at startup. The main thread calling `getDataPackage` should be
 scheduled to real-time priority by the application. See the
-[ur_robot_driver](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/src/ros/hardware_interface_node.cpp)
+[ur_robot_driver](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/src/hardware_interface_node.cpp)
 as an example.
 
 ## Producer / Consumer architecture


### PR DESCRIPTION
After merging in the separation on the driver, those links got outdated.