### PR TITLE
Move script file to resources folder instead of examples/resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,3 +106,5 @@ find_package(catkin)
 if(catkin_FOUND)
   install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 endif()
+
+install(FILES resources/external_control.urscript DESTINATION share/${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ instance of the `UrDriver` class and prints the RTDE values read from the contro
 sure to
  * have an instance of a robot controller / URSim running at the configured IP address (or adapt the
    address to your needs)
- * run it from its source folder, as for simplicity reasons it doesn't use any sophisticated method
-   to locate the required files.
+ * run it from the package's main folder (the one where this README.md file is stored), as for
+   simplicity reasons it doesn't use any sophisticated method to locate the required files.
 
 ## Architecture
 The image below shows a rough architecture overview that should help developers to use the different
@@ -197,8 +197,8 @@ An example of a standalone RTDE-client can be found in the `examples` subfolder.
 sure to
  * have an instance of a robot controller / URSim running at the configured IP address (or adapt the
    address to your needs)
- * run it from its source folder, as for simplicity reasons it doesn't use any sophisticated method
-   to locate the required recipe files.
+ * run it from the package's main folder (the one where this README.md file is stored), as for
+   simplicity reasons it doesn't use any sophisticated method to locate the required files.
 
 #### RTDEWriter
 The `RTDEWriter` class provides an interface to write data to the RTDE interface. Data fields that

--- a/examples/full_driver.cpp
+++ b/examples/full_driver.cpp
@@ -39,9 +39,9 @@ using namespace urcl;
 // In a real-world example it would be better to get those values from command line parameters / a
 // better configuration system such as Boost.Program_options
 const std::string ROBOT_IP = "192.168.56.101";
-const std::string SCRIPT_FILE = "resources/scriptfile.urscript";
-const std::string OUTPUT_RECIPE = "resources/rtde_output_recipe.txt";
-const std::string INPUT_RECIPE = "resources/rtde_input_recipe.txt";
+const std::string SCRIPT_FILE = "resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "examples/resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "examples/resources/rtde_input_recipe.txt";
 const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
 
 std::unique_ptr<UrDriver> g_my_driver;

--- a/examples/rtde_client.cpp
+++ b/examples/rtde_client.cpp
@@ -35,8 +35,8 @@ using namespace urcl;
 // In a real-world example it would be better to get those values from command line parameters / a better configuration
 // system such as Boost.Program_options
 const std::string ROBOT_IP = "192.168.56.101";
-const std::string OUTPUT_RECIPE = "resources/rtde_output_recipe.txt";
-const std::string INPUT_RECIPE = "resources/rtde_input_recipe.txt";
+const std::string OUTPUT_RECIPE = "examples/resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "examples/resources/rtde_input_recipe.txt";
 const std::chrono::milliseconds READ_TIMEOUT{ 100 };
 
 int main(int argc, char* argv[])

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -98,8 +98,8 @@ socket_open("{{SERVER_IP_REPLACE}}", {{SERVER_PORT_REPLACE}}, "reverse_socket")
 control_mode = MODE_UNINITIALIZED
 thread_move = 0
 global keepalive = -2
+params_mult = socket_read_binary_integer(1+6+1, "reverse_socket", 0)
 textmsg("ExternalControl: External control active")
-params_mult = socket_read_binary_integer(1+6+1, "reverse_socket")
 keepalive = params_mult[1]
 while keepalive > 0 and control_mode > MODE_STOPPED:
   enter_critical


### PR DESCRIPTION
As with the reverse interface we establish a protocol between UrScript and the
library, we aim for keeping the default external control file inside the library.

Therefore, we move it out of the examples subfolder.

This basically implements the library part of the script part of #31