### PR TITLE
Add interface function to receive configured RTDE output recipe from driver

### DIFF
--- a/include/ur_client_library/rtde/rtde_client.h
+++ b/include/ur_client_library/rtde/rtde_client.h
@@ -151,6 +151,16 @@ public:
    */
   RTDEWriter& getWriter();
 
+  /*!
+   * \brief Getter for the RTDE output recipe.
+   *
+   * \returns The output recipe
+   */
+  std::vector<std::string> getOutputRecipe()
+  {
+    return output_recipe_;
+  }
+
 private:
   comm::URStream<RTDEPackage> stream_;
   std::vector<std::string> output_recipe_;

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -222,6 +222,13 @@ public:
     return robot_version_;
   }
 
+  /*!
+   * \brief Getter for the RTDE output recipe used in the RTDE client.
+   *
+   * \returns The used RTDE output recipe
+   */
+  std::vector<std::string> getRTDEOutputRecipe();
+
 private:
   std::string readScriptFile(const std::string& filename);
   std::string readKeepalive();

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -321,4 +321,9 @@ bool UrDriver::sendRobotProgram()
     return false;
   }
 }
+
+std::vector<std::string> UrDriver::getRTDEOutputRecipe()
+{
+  return rtde_client_->getOutputRecipe();
+}
 }  // namespace urcl


### PR DESCRIPTION
I'd like to revive https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/35 and some of the files changed have been moved to this repository.

Original implementation by @t-schnell 