### PR TITLE
Add function to set keepalive counter.

### DIFF
--- a/include/ur_client_library/comm/reverse_interface.h
+++ b/include/ur_client_library/comm/reverse_interface.h
@@ -62,7 +62,7 @@ public:
    *
    * \param port Port the Server is started on
    */
-  ReverseInterface(uint32_t port) : server_(port)
+  ReverseInterface(uint32_t port) : server_(port), keepalive_count_(1)
   {
     if (!server_.bind())
     {
@@ -96,7 +96,7 @@ public:
     uint8_t* b_pos = buffer;
 
     // The first element is always the keepalive signal.
-    int32_t val = htobe32(1);
+    int32_t val = htobe32(keepalive_count_);
     b_pos += append(b_pos, val);
 
     if (positions != nullptr)
@@ -143,9 +143,20 @@ public:
     }
   }
 
+  /*!
+   * \brief Set the Keepalive count. This will set the number of allowed timeout reads on the robot.
+   *
+   * \param count Number of allowed timeout reads on the robot.
+   */
+  void setKeepaliveCount(const uint32_t& count)
+  {
+    keepalive_count_ = count;
+  }
+
 private:
   URServer server_;
   static const int32_t MULT_JOINTSTATE = 1000000;
+  uint32_t keepalive_count_;
 
   template <typename T>
   size_t append(uint8_t* buffer, T& val)

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -222,6 +222,13 @@ public:
     return robot_version_;
   }
 
+  /*!
+   * \brief Set the Keepalive count. This will set the number of allowed timeout reads on the robot.
+   *
+   * \param count Number of allowed timeout reads on the robot.
+   */
+  void setKeepaliveCount(const uint32_t& count);
+
 private:
   std::string readScriptFile(const std::string& filename);
   std::string readKeepalive();

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -321,4 +321,16 @@ bool UrDriver::sendRobotProgram()
     return false;
   }
 }
+
+void UrDriver::setKeepaliveCount(const uint32_t& count)
+{
+  if (reverse_interface_active_)
+  {
+    reverse_interface_->setKeepaliveCount(count);
+  }
+  else
+  {
+    URCL_LOG_WARN("Unable to set keepalive counter, reverse interface is not active");
+  }
+}
 }  // namespace urcl


### PR DESCRIPTION
This enables the possibility to set the number of timeout reads on the robot. 

The functions to set the keepalive count should probably be changed a bit once #46 has been merged. 