### PR TITLE
Add downstream workspace for melodic

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -21,11 +21,23 @@ jobs:
           - ROS_DISTRO: melodic
             ROS_REPO: main
             IMMEDIATE_TEST_OUTPUT: true
+            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS_Driver#master https://raw.githubusercontent.com/UniversalRobots/Universal_Robots_ROS_Driver/master/.ci.rosinstall"
+            DOCKER_RUN_OPTS: --network static_test_net
+            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
+            URSIM_VERSION: 5.8.0.10253
           - ROS_DISTRO: noetic
             ROS_REPO: main
             IMMEDIATE_TEST_OUTPUT: true
+            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS_Driver#master https://raw.githubusercontent.com/UniversalRobots/Universal_Robots_ROS_Driver/master/.ci.rosinstall"
+            DOCKER_RUN_OPTS: --network static_test_net
+            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
+            URSIM_VERSION: 5.8.0.10253
 
     steps:
       - uses: actions/checkout@v1
+      - name: start ursim
+        run: |
+          tests/resources/dockerursim/build_and_run_docker_ursim.sh $URSIM_VERSION
+        env: ${{matrix.env}}
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}


### PR DESCRIPTION
Include building and testing the ROS driver in CI pipelines of the library.

This is related to #54 