### PR TITLE
Install package XML for ROS2 installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,9 @@ install(FILES ur_client_libraryConfig.cmake
   DESTINATION lib/cmake/ur_client_library)
 
 # When built with catkin available, install package.xml
-find_package(catkin)
-if(catkin_FOUND)
+find_package(catkin QUIET)
+find_package(ament_cmake QUIET)
+if(catkin_FOUND OR ament_cmake_FOUND)
   install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 endif()
 

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>ur_client_library</name>
   <version>0.1.1</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
@@ -22,7 +22,8 @@
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>libconsole-bridge-dev</depend>
-  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
This PR installs the package.xml for ROS2 builds.

This is similar to the REP 137 for catkin, since a corresponding REP for colcon is currently missing.

For the package.xml condition attribute the package.xml format has to be bumped to version 3 ( as specified in REP 149)