### PR TITLE
Run ci also for ROS2 foxy

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -35,6 +35,10 @@ jobs:
           - ROS_DISTRO: foxy
             ROS_REPO: main
             IMMEDIATE_TEST_OUTPUT: true
+            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#main https://raw.githubusercontent.com/UniversalRobots/Universal_Robots_ROS2_Driver/main/Universal_Robots_ROS2_Driver.repos"
+            DOCKER_RUN_OPTS: --network static_test_net
+            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
+            URSIM_VERSION: 5.8.0.10253
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -32,6 +32,9 @@ jobs:
             DOCKER_RUN_OPTS: --network static_test_net
             BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             URSIM_VERSION: 5.8.0.10253
+          - ROS_DISTRO: foxy
+            ROS_REPO: main
+            IMMEDIATE_TEST_OUTPUT: true
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -39,6 +39,7 @@ jobs:
             DOCKER_RUN_OPTS: --network static_test_net
             BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             URSIM_VERSION: 5.8.0.10253
+            NOT_TEST_DOWNSTREAM: true
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Adds a ci pipeline test for ROS2

@puck-fzi @AndyZe I also added triggering downstream builds of the ROS2 driver. As you are currently fetching the client_library from your own fork inside your [`rosinstall file`](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/main/Universal_Robots_ROS2_Driver.repos#L20)

It might be a good idea to remove this once this library is released for foxy (which I will do as soon as this pipeline is running correctly and this MR is finished.)