### PR TITLE
Install the resources folder instead of the script file directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,4 +108,4 @@ if(catkin_FOUND OR ament_cmake_FOUND)
   install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 endif()
 
-install(FILES resources/external_control.urscript DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY resources DESTINATION share/${PROJECT_NAME})


### PR DESCRIPTION
The main problem before was that the resource file got installed into another
relative package location (/) than in the source package (/resources).
This way, other packages searching that file would not work with both, source
builds and installed versions.