### PR TITLE
Calibration check optional

### DIFF
--- a/include/ur_client_library/ur/calibration_checker.h
+++ b/include/ur_client_library/ur/calibration_checker.h
@@ -95,9 +95,21 @@ public:
     return checked_;
   }
 
+  /*!
+   * \brief Returns whether the calibration check was successful.
+   *
+   * \returns True if the robot's calibration checksum matches the one given to the checker. False
+   * if it doesn't match or the check was not yet performed.
+   */
+  bool checkSuccessful()
+  {
+    return matches_;
+  }
+
 private:
   std::string expected_hash_;
   bool checked_;
+  bool matches_;
 };
 }  // namespace urcl
 

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -74,6 +74,32 @@ public:
    * keepalive signal can be read, program state will be false.
    * \param headless_mode Parameter to control if the driver should be started in headless mode.
    * \param tool_comm_setup Configuration for using the tool communication.
+   * calibration reported by the robot.
+   * \param reverse_port Port that will be opened by the driver to allow direct communication between the driver
+   * and the robot controller.
+   * \param script_sending_port The driver will offer an interface to receive the program's URScript on this port. If
+   * the robot cannot connect to this port, `External Control` will stop immediately.
+   * \param non_blocking_read Enable non-blocking mode for read (useful when used with combined_robot_hw)
+   * \param servoj_gain Proportional gain for arm joints following target position, range [100,2000]
+   * \param servoj_lookahead_time Time [S], range [0.03,0.2] smoothens the trajectory with this lookahead time
+   */
+  UrDriver(const std::string& robot_ip, const std::string& script_file, const std::string& output_recipe_file,
+           const std::string& input_recipe_file, std::function<void(bool)> handle_program_state, bool headless_mode,
+           std::unique_ptr<ToolCommSetup> tool_comm_setup, const uint32_t reverse_port = 50001,
+           const uint32_t script_sender_port = 50002, int servoj_gain = 2000, double servoj_lookahead_time = 0.03,
+           bool non_blocking_read = false);
+
+  /*!
+   * \brief Constructs a new UrDriver object.
+   * \param robot_ip IP-address under which the robot is reachable.
+   * \param script_file URScript file that should be sent to the robot.
+   * \param output_recipe_file Filename where the output recipe is stored in.
+   * \param input_recipe_file Filename where the input recipe is stored in.
+   * \param handle_program_state Function handle to a callback on program state changes. For this to
+   * work, the URScript program will have to send keepalive signals to the \p reverse_port. I no
+   * keepalive signal can be read, program state will be false.
+   * \param headless_mode Parameter to control if the driver should be started in headless mode.
+   * \param tool_comm_setup Configuration for using the tool communication.
    * \param calibration_checksum Expected checksum of calibration. Will be matched against the
    * calibration reported by the robot.
    * \param reverse_port Port that will be opened by the driver to allow direct communication between the driver
@@ -89,6 +115,7 @@ public:
            std::unique_ptr<ToolCommSetup> tool_comm_setup, const std::string& calibration_checksum = "",
            const uint32_t reverse_port = 50001, const uint32_t script_sender_port = 50002, int servoj_gain = 2000,
            double servoj_lookahead_time = 0.03, bool non_blocking_read = false);
+
   /*!
    * \brief Constructs a new UrDriver object.
    *

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -178,8 +178,11 @@ public:
    * \brief Checks if the kinematics information in the used model fits the actual robot.
    *
    * \param checksum Hash of the used kinematics information
+   *
+   * \returns True if the robot's calibration checksum matches the one given to the checker. False
+   * if it doesn't match or the check was not yet performed.
    */
-  void checkCalibration(const std::string& checksum);
+  bool checkCalibration(const std::string& checksum);
 
   /*!
    * \brief Getter for the RTDE writer used to write to the robot's RTDE interface.

--- a/src/ur/calibration_checker.cpp
+++ b/src/ur/calibration_checker.cpp
@@ -30,7 +30,7 @@
 namespace urcl
 {
 CalibrationChecker::CalibrationChecker(const std::string& expected_hash)
-  : expected_hash_(expected_hash), checked_(false)
+  : expected_hash_(expected_hash), checked_(false), matches_(false)
 {
 }
 bool CalibrationChecker::consume(std::shared_ptr<primary_interface::PrimaryPackage> product)
@@ -40,19 +40,7 @@ bool CalibrationChecker::consume(std::shared_ptr<primary_interface::PrimaryPacka
   {
     // URCL_LOG_INFO("%s", product->toString().c_str());
     //
-    if (kin_info->toHash() != expected_hash_)
-    {
-      URCL_LOG_ERROR("The calibration parameters of the connected robot don't match the ones from the given kinematics "
-                     "config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use "
-                     "the ur_calibration tool to extract the correct calibration from the robot and pass that into the "
-                     "description. See "
-                     "[https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] "
-                     "for details.");
-    }
-    else
-    {
-      URCL_LOG_INFO("Calibration checked successfully.");
-    }
+    matches_ = kin_info->toHash() == expected_hash_;
 
     checked_ = true;
   }

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -68,8 +68,6 @@ urcl::UrDriver::UrDriver(const std::string& robot_ip, const std::string& script_
   secondary_stream_.reset(
       new comm::URStream<primary_interface::PrimaryPackage>(robot_ip_, urcl::primary_interface::UR_SECONDARY_PORT));
   secondary_stream_->connect();
-  URCL_LOG_INFO("Checking if calibration data matches connected robot.");
-  checkCalibration(calibration_checksum);
 
   non_blocking_read_ = non_blocking_read;
   get_packet_timeout_ = non_blocking_read_ ? 0 : 100;
@@ -193,7 +191,7 @@ std::string UrDriver::readScriptFile(const std::string& filename)
   return content;
 }
 
-void UrDriver::checkCalibration(const std::string& checksum)
+bool UrDriver::checkCalibration(const std::string& checksum)
 {
   if (primary_stream_ == nullptr)
   {
@@ -215,6 +213,7 @@ void UrDriver::checkCalibration(const std::string& checksum)
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   URCL_LOG_DEBUG("Got calibration information from robot.");
+  return consumer.checkSuccessful();
 }
 
 rtde_interface::RTDEWriter& UrDriver::getRTDEWriter()


### PR DESCRIPTION
As not all downstream packages support extracting calibration information from the robot we make this check optional. This moves calling the calibration check towards the application layer.

@urmahp This should remove the error output from the ISAAC driver.

@urrsk FYI, as we've been talking about that.