### PR TITLE
Refactor reverse interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 add_library(urcl SHARED
     src/comm/tcp_socket.cpp
     src/comm/tcp_server.cpp
+    src/control/reverse_interface.cpp
+    src/control/script_sender.cpp
     src/primary/primary_package.cpp
     src/primary/robot_message.cpp
     src/primary/robot_state.cpp

--- a/doc/dataflow.graphml
+++ b/doc/dataflow.graphml
@@ -54,7 +54,7 @@
                   <y:Geometry height="97.4609375" width="192.0" x="995.0" y="404.84375"/>
                   <y:Fill color="#F2F0D8" transparent="false"/>
                   <y:BorderStyle color="#000000" type="line" width="1.0"/>
-                  <y:NodeLabel alignment="right" autoSizePolicy="node_width" backgroundColor="#B7B69E" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="21.4609375" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="192.0" x="0.0" xml:space="preserve" y="0.0">comm::ReverseInterface</y:NodeLabel>
+                  <y:NodeLabel alignment="right" autoSizePolicy="node_width" backgroundColor="#B7B69E" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="21.4609375" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="192.0" x="0.0" xml:space="preserve" y="0.0">control::ReverseInterface</y:NodeLabel>
                   <y:Shape type="rectangle"/>
                   <y:DropShadow color="#D2D2D2" offsetX="4" offsetY="4"/>
                   <y:State closed="false" closedHeight="50.0" closedWidth="50.0" innerGraphDisplayEnabled="false"/>
@@ -98,7 +98,7 @@
                   <y:Geometry height="97.4609375" width="192.0" x="5.0" y="264.84375"/>
                   <y:Fill color="#F2F0D8" transparent="false"/>
                   <y:BorderStyle color="#000000" type="line" width="1.0"/>
-                  <y:NodeLabel alignment="right" autoSizePolicy="node_width" backgroundColor="#B7B69E" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="21.4609375" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="192.0" x="0.0" xml:space="preserve" y="0.0">comm::ScriptSender</y:NodeLabel>
+                  <y:NodeLabel alignment="right" autoSizePolicy="node_width" backgroundColor="#B7B69E" borderDistance="0.0" fontFamily="Dialog" fontSize="15" fontStyle="plain" hasLineColor="false" height="21.4609375" horizontalTextPosition="center" iconTextGap="4" modelName="internal" modelPosition="t" textColor="#000000" verticalTextPosition="bottom" visible="true" width="192.0" x="0.0" xml:space="preserve" y="0.0">control::ScriptSender</y:NodeLabel>
                   <y:Shape type="rectangle"/>
                   <y:DropShadow color="#D2D2D2" offsetX="4" offsetY="4"/>
                   <y:State closed="false" closedHeight="50.0" closedWidth="50.0" innerGraphDisplayEnabled="false"/>

--- a/doc/dataflow.svg
+++ b/doc/dataflow.svg
@@ -63,7 +63,7 @@
       <rect x="995" y="404.8438" clip-path="url(#clipPath2)" fill="rgb(183,182,158)" width="192" height="21.4609" stroke="none"/>
     </g>
     <g font-size="15px" stroke-linecap="butt" transform="matrix(1,0,0,1,15,15)" text-rendering="geometricPrecision" font-family="sans-serif" shape-rendering="geometricPrecision" stroke-miterlimit="1.45">
-      <text x="1000.1221" xml:space="preserve" y="420.7671" clip-path="url(#clipPath2)" stroke="none">comm::ReverseInterface</text>
+      <text x="1000.1221" xml:space="preserve" y="420.7671" clip-path="url(#clipPath2)" stroke="none">control::ReverseInterface</text>
       <rect fill="none" x="995" width="192" height="97.4609" y="404.8438" clip-path="url(#clipPath2)"/>
     </g>
     <g fill="rgb(255,204,0)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,15,15)" stroke="rgb(255,204,0)">
@@ -81,7 +81,7 @@
       <rect x="5" y="264.8438" clip-path="url(#clipPath2)" fill="rgb(183,182,158)" width="192" height="21.4609" stroke="none"/>
     </g>
     <g font-size="15px" stroke-linecap="butt" transform="matrix(1,0,0,1,15,15)" text-rendering="geometricPrecision" font-family="sans-serif" shape-rendering="geometricPrecision" stroke-miterlimit="1.45">
-      <text x="41.5649" xml:space="preserve" y="280.7671" clip-path="url(#clipPath2)" stroke="none">comm::ScriptSender</text>
+      <text x="41.5649" xml:space="preserve" y="280.7671" clip-path="url(#clipPath2)" stroke="none">control::ScriptSender</text>
       <rect fill="none" x="5" width="192" height="97.4609" y="264.8438" clip-path="url(#clipPath2)"/>
     </g>
     <g fill="rgb(255,204,0)" text-rendering="geometricPrecision" shape-rendering="geometricPrecision" transform="matrix(1,0,0,1,15,15)" stroke="rgb(255,204,0)">

--- a/examples/full_driver.cpp
+++ b/examples/full_driver.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
         increment = 0.02;
       }
       g_joint_positions[5] += increment;
-      g_my_driver->writeJointCommand(g_joint_positions, comm::ControlMode::MODE_SERVOJ);
+      g_my_driver->writeJointCommand(g_joint_positions, control::ControlMode::MODE_SERVOJ);
       std::cout << data_pkg->toString() << std::endl;
     }
     else

--- a/examples/full_driver.cpp
+++ b/examples/full_driver.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
         increment = 0.02;
       }
       g_joint_positions[5] += increment;
-      g_my_driver->writeJointCommand(g_joint_positions, control::ControlMode::MODE_SERVOJ);
+      g_my_driver->writeJointCommand(g_joint_positions, comm::ControlMode::MODE_SERVOJ);
       std::cout << data_pkg->toString() << std::endl;
     }
     else

--- a/include/ur_client_library/comm/control_mode.h
+++ b/include/ur_client_library/comm/control_mode.h
@@ -1,0 +1,48 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2021 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner mauch@fzi.de
+ * \date    2021-06-01
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_CONTROL_MODE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_CONTROL_MODE_H_INCLUDED
+#endif  // ifndef UR_CLIENT_LIBRARY_CONTROL_MODE_H_INCLUDED
+
+namespace urcl
+{
+namespace comm
+{
+/*!
+ * \brief Control modes as interpreted from the script runnning on the robot.
+ */
+enum class ControlMode : int32_t
+{
+  MODE_STOPPED = -2,        ///< When this is set, the program is expected to stop and exit.
+  MODE_UNINITIALIZED = -1,  ///< Startup default until another mode is sent to the script.
+  MODE_IDLE = 0,            ///< Set when no controller is currently active controlling the robot.
+  MODE_SERVOJ = 1,          ///< Set when servoj control is active.
+  MODE_SPEEDJ = 2           ///< Set when speedj control is active.
+};
+}  // namespace comm
+}  // namespace urcl

--- a/include/ur_client_library/control/reverse_interface.h
+++ b/include/ur_client_library/control/reverse_interface.h
@@ -29,6 +29,7 @@
 #define UR_CLIENT_LIBRARY_REVERSE_INTERFACE_H_INCLUDED
 
 #include "ur_client_library/comm/tcp_server.h"
+#include "ur_client_library/comm/control_mode.h"
 #include "ur_client_library/types.h"
 #include "ur_client_library/log.h"
 #include <cstring>
@@ -39,18 +40,6 @@ namespace urcl
 {
 namespace control
 {
-/*!
- * \brief Control modes as interpreted from the script runnning on the robot.
- */
-enum class ControlMode : int32_t
-{
-  MODE_STOPPED = -2,        ///< When this is set, the program is expected to stop and exit.
-  MODE_UNINITIALIZED = -1,  ///< Startup default until another mode is sent to the script.
-  MODE_IDLE = 0,            ///< Set when no controller is currently active controlling the robot.
-  MODE_SERVOJ = 1,          ///< Set when servoj control is active.
-  MODE_SPEEDJ = 2           ///< Set when speedj control is active.
-};
-
 /*!
  * \brief The ReverseInterface class handles communication to the robot. It starts a server and
  * waits for the robot to connect via its URCaps program.
@@ -76,12 +65,12 @@ public:
    * \brief Writes needed information to the robot to be read by the URCaps program.
    *
    * \param positions A vector of joint targets for the robot
-   * \param control_mode Control mode assigned to this command. See documentation of ::ControlMode
+   * \param control_mode Control mode assigned to this command. See documentation of comm::ControlMode
    * for details on possible values.
    *
    * \returns True, if the write was performed successfully, false otherwise.
    */
-  bool write(const vector6d_t* positions, const ControlMode control_mode = ControlMode::MODE_IDLE);
+  bool write(const vector6d_t* positions, const comm::ControlMode control_mode = comm::ControlMode::MODE_IDLE);
 
   /*!
    * \brief Set the Keepalive count. This will set the number of allowed timeout reads on the robot.

--- a/include/ur_client_library/control/reverse_interface.h
+++ b/include/ur_client_library/control/reverse_interface.h
@@ -37,7 +37,7 @@
 
 namespace urcl
 {
-namespace comm
+namespace control
 {
 /*!
  * \brief Control modes as interpreted from the script runnning on the robot.
@@ -65,23 +65,12 @@ public:
    * \param port Port the Server is started on
    * \param handle_program_state Function handle to a callback on program state changes.
    */
-  ReverseInterface(uint32_t port, std::function<void(bool)> handle_program_state)
-    : client_fd_(-1), server_(port), handle_program_state_(handle_program_state), keepalive_count_(1)
-  {
-    handle_program_state_(false);
-    server_.setMessageCallback(
-        std::bind(&ReverseInterface::messageCallback, this, std::placeholders::_1, std::placeholders::_2));
-    server_.setConnectCallback(std::bind(&ReverseInterface::connectionCallback, this, std::placeholders::_1));
-    server_.setDisconnectCallback(std::bind(&ReverseInterface::disconnectionCallback, this, std::placeholders::_1));
-    server_.setMaxClientsAllowed(1);
-    server_.start();
-  }
+  ReverseInterface(uint32_t port, std::function<void(bool)> handle_program_state);
+
   /*!
    * \brief Disconnects possible clients so the reverse interface object can be safely destroyed.
    */
-  ~ReverseInterface()
-  {
-  }
+  ~ReverseInterface() = default;
 
   /*!
    * \brief Writes needed information to the robot to be read by the URCaps program.
@@ -92,40 +81,7 @@ public:
    *
    * \returns True, if the write was performed successfully, false otherwise.
    */
-  bool write(const vector6d_t* positions, const ControlMode control_mode = ControlMode::MODE_IDLE)
-  {
-    if (client_fd_ == -1)
-    {
-      return false;
-    }
-    uint8_t buffer[sizeof(int32_t) * 8];
-    uint8_t* b_pos = buffer;
-
-    // The first element is always the keepalive signal.
-    int32_t val = htobe32(keepalive_count_);
-    b_pos += append(b_pos, val);
-
-    if (positions != nullptr)
-    {
-      for (auto const& pos : *positions)
-      {
-        int32_t val = static_cast<int32_t>(pos * MULT_JOINTSTATE);
-        val = htobe32(val);
-        b_pos += append(b_pos, val);
-      }
-    }
-    else
-    {
-      b_pos += 6 * sizeof(int32_t);
-    }
-
-    val = htobe32(toUnderlying(control_mode));
-    b_pos += append(b_pos, val);
-
-    size_t written;
-
-    return server_.write(client_fd_, buffer, sizeof(buffer), written);
-  }
+  bool write(const vector6d_t* positions, const ControlMode control_mode = ControlMode::MODE_IDLE);
 
   /*!
    * \brief Set the Keepalive count. This will set the number of allowed timeout reads on the robot.
@@ -138,36 +94,14 @@ public:
   }
 
 private:
-  void connectionCallback(const int filedescriptor)
-  {
-    if (client_fd_ < 0)
-    {
-      URCL_LOG_INFO("Robot connected to reverse interface. Ready to receive control commands.");
-      client_fd_ = filedescriptor;
-      handle_program_state_(true);
-    }
-    else
-    {
-      URCL_LOG_ERROR("Connection request to ReverseInterface received while connection already established. Only one "
-                     "connection is allowed at a time. Ignoring this request.");
-    }
-  }
+  void connectionCallback(const int filedescriptor);
 
-  void disconnectionCallback(const int filedescriptor)
-  {
-    URCL_LOG_INFO("Connection to reverse interface dropped.", filedescriptor);
-    client_fd_ = -1;
-    handle_program_state_(false);
-  }
+  void disconnectionCallback(const int filedescriptor);
 
-  void messageCallback(const int filedescriptor, char* buffer)
-  {
-    URCL_LOG_WARN("Messge on ReverseInterface received. The reverse interface currently does not support any message "
-                  "handling. This message will be ignored.");
-  }
+  void messageCallback(const int filedescriptor, char* buffer);
 
   int client_fd_;
-  TCPServer server_;
+  comm::TCPServer server_;
 
   static const int32_t MULT_JOINTSTATE = 1000000;
 
@@ -183,7 +117,7 @@ private:
   uint32_t keepalive_count_;
 };
 
-}  // namespace comm
+}  // namespace control
 }  // namespace urcl
 
 #endif  // UR_CLIENT_LIBRARY_REVERSE_INTERFACE_H_INCLUDED

--- a/include/ur_client_library/control/script_sender.h
+++ b/include/ur_client_library/control/script_sender.h
@@ -36,7 +36,7 @@
 
 namespace urcl
 {
-namespace comm
+namespace control
 {
 /*!
  * \brief The ScriptSender class starts a TCPServer for a robot to connect to and waits for a
@@ -52,59 +52,25 @@ public:
    * \param port Port to start the server on
    * \param program Program to send to the robot upon request
    */
-  ScriptSender(uint32_t port, const std::string& program) : server_(port), script_thread_(), program_(program)
-  {
-    server_.setMessageCallback(
-        std::bind(&ScriptSender::messageCallback, this, std::placeholders::_1, std::placeholders::_2));
-    server_.setConnectCallback(std::bind(&ScriptSender::connectionCallback, this, std::placeholders::_1));
-    server_.setDisconnectCallback(std::bind(&ScriptSender::disconnectionCallback, this, std::placeholders::_1));
-    server_.start();
-  }
+  ScriptSender(uint32_t port, const std::string& program);
 
 private:
-  TCPServer server_;
+  comm::TCPServer server_;
   std::thread script_thread_;
   std::string program_;
 
   const std::string PROGRAM_REQUEST_ = std::string("request_program\n");
 
-  void connectionCallback(const int filedescriptor)
-  {
-    URCL_LOG_DEBUG("New client connected at FD %d.", filedescriptor);
-  }
+  void connectionCallback(const int filedescriptor);
 
-  void disconnectionCallback(const int filedescriptor)
-  {
-    URCL_LOG_DEBUG("Client at FD %d disconnected.", filedescriptor);
-  }
+  void disconnectionCallback(const int filedescriptor);
 
-  void messageCallback(const int filedescriptor, char* buffer)
-  {
-    if (std::string(buffer) == PROGRAM_REQUEST_)
-    {
-      URCL_LOG_INFO("Robot requested program");
-      sendProgram(filedescriptor);
-    }
-  }
+  void messageCallback(const int filedescriptor, char* buffer);
 
-  void sendProgram(const int filedescriptor)
-  {
-    size_t len = program_.size();
-    const uint8_t* data = reinterpret_cast<const uint8_t*>(program_.c_str());
-    size_t written;
-
-    if (server_.write(filedescriptor, data, len, written))
-    {
-      URCL_LOG_INFO("Sent program to robot");
-    }
-    else
-    {
-      URCL_LOG_ERROR("Could not send program to robot");
-    }
-  }
+  void sendProgram(const int filedescriptor);
 };
 
-}  // namespace comm
+}  // namespace control
 }  // namespace urcl
 
 #endif  // UR_CLIENT_LIBRARY_SCRIPT_SENDER_H_INCLUDED

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -30,8 +30,8 @@
 #include <functional>
 
 #include "ur_client_library/rtde/rtde_client.h"
-#include "ur_client_library/comm/reverse_interface.h"
-#include "ur_client_library/comm/script_sender.h"
+#include "ur_client_library/control/reverse_interface.h"
+#include "ur_client_library/control/script_sender.h"
 #include "ur_client_library/ur/tool_communication.h"
 #include "ur_client_library/ur/version_information.h"
 #include "ur_client_library/primary/robot_message/version_message.h"
@@ -178,7 +178,7 @@ public:
    *
    * \returns True on successful write.
    */
-  bool writeJointCommand(const vector6d_t& values, const comm::ControlMode control_mode);
+  bool writeJointCommand(const vector6d_t& values, const control::ControlMode control_mode);
 
   /*!
    * \brief Write a keepalive signal only.
@@ -271,8 +271,8 @@ private:
   int rtde_frequency_;
   comm::INotifier notifier_;
   std::unique_ptr<rtde_interface::RTDEClient> rtde_client_;
-  std::unique_ptr<comm::ReverseInterface> reverse_interface_;
-  std::unique_ptr<comm::ScriptSender> script_sender_;
+  std::unique_ptr<control::ReverseInterface> reverse_interface_;
+  std::unique_ptr<control::ScriptSender> script_sender_;
   std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> primary_stream_;
   std::unique_ptr<comm::URStream<primary_interface::PrimaryPackage>> secondary_stream_;
 

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -178,7 +178,7 @@ public:
    *
    * \returns True on successful write.
    */
-  bool writeJointCommand(const vector6d_t& values, const control::ControlMode control_mode);
+  bool writeJointCommand(const vector6d_t& values, const comm::ControlMode control_mode);
 
   /*!
    * \brief Write a keepalive signal only.

--- a/src/control/reverse_interface.cpp
+++ b/src/control/reverse_interface.cpp
@@ -43,7 +43,7 @@ ReverseInterface::ReverseInterface(uint32_t port, std::function<void(bool)> hand
   server_.start();
 }
 
-bool ReverseInterface::write(const vector6d_t* positions, const ControlMode control_mode)
+bool ReverseInterface::write(const vector6d_t* positions, const comm::ControlMode control_mode)
 {
   if (client_fd_ == -1)
   {

--- a/src/control/reverse_interface.cpp
+++ b/src/control/reverse_interface.cpp
@@ -1,0 +1,109 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2021 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2021-06-01
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <ur_client_library/control/reverse_interface.h>
+
+namespace urcl
+{
+namespace control
+{
+ReverseInterface::ReverseInterface(uint32_t port, std::function<void(bool)> handle_program_state)
+  : client_fd_(-1), server_(port), handle_program_state_(handle_program_state), keepalive_count_(1)
+{
+  handle_program_state_(false);
+  server_.setMessageCallback(
+      std::bind(&ReverseInterface::messageCallback, this, std::placeholders::_1, std::placeholders::_2));
+  server_.setConnectCallback(std::bind(&ReverseInterface::connectionCallback, this, std::placeholders::_1));
+  server_.setDisconnectCallback(std::bind(&ReverseInterface::disconnectionCallback, this, std::placeholders::_1));
+  server_.setMaxClientsAllowed(1);
+  server_.start();
+}
+
+bool ReverseInterface::write(const vector6d_t* positions, const ControlMode control_mode)
+{
+  if (client_fd_ == -1)
+  {
+    return false;
+  }
+  uint8_t buffer[sizeof(int32_t) * 8];
+  uint8_t* b_pos = buffer;
+
+  // The first element is always the keepalive signal.
+  int32_t val = htobe32(keepalive_count_);
+  b_pos += append(b_pos, val);
+
+  if (positions != nullptr)
+  {
+    for (auto const& pos : *positions)
+    {
+      int32_t val = static_cast<int32_t>(pos * MULT_JOINTSTATE);
+      val = htobe32(val);
+      b_pos += append(b_pos, val);
+    }
+  }
+  else
+  {
+    b_pos += 6 * sizeof(int32_t);
+  }
+
+  val = htobe32(toUnderlying(control_mode));
+  b_pos += append(b_pos, val);
+
+  size_t written;
+
+  return server_.write(client_fd_, buffer, sizeof(buffer), written);
+}
+
+void ReverseInterface::connectionCallback(const int filedescriptor)
+{
+  if (client_fd_ < 0)
+  {
+    URCL_LOG_INFO("Robot connected to reverse interface. Ready to receive control commands.");
+    client_fd_ = filedescriptor;
+    handle_program_state_(true);
+  }
+  else
+  {
+    URCL_LOG_ERROR("Connection request to ReverseInterface received while connection already established. Only one "
+                   "connection is allowed at a time. Ignoring this request.");
+  }
+}
+
+void ReverseInterface::disconnectionCallback(const int filedescriptor)
+{
+  URCL_LOG_INFO("Connection to reverse interface dropped.", filedescriptor);
+  client_fd_ = -1;
+  handle_program_state_(false);
+}
+
+void ReverseInterface::messageCallback(const int filedescriptor, char* buffer)
+{
+  URCL_LOG_WARN("Message on ReverseInterface received. The reverse interface currently does not support any message "
+                "handling. This message will be ignored.");
+}
+}  // namespace control
+}  // namespace urcl

--- a/src/control/script_sender.cpp
+++ b/src/control/script_sender.cpp
@@ -1,0 +1,80 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2021 FZI Forschungszentrum Informatik
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2021-06-01
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <ur_client_library/control/script_sender.h>
+
+namespace urcl
+{
+namespace control
+{
+ScriptSender::ScriptSender(uint32_t port, const std::string& program)
+  : server_(port), script_thread_(), program_(program)
+{
+  server_.setMessageCallback(
+      std::bind(&ScriptSender::messageCallback, this, std::placeholders::_1, std::placeholders::_2));
+  server_.setConnectCallback(std::bind(&ScriptSender::connectionCallback, this, std::placeholders::_1));
+  server_.setDisconnectCallback(std::bind(&ScriptSender::disconnectionCallback, this, std::placeholders::_1));
+  server_.start();
+}
+
+void ScriptSender::connectionCallback(const int filedescriptor)
+{
+  URCL_LOG_DEBUG("New client connected at FD %d.", filedescriptor);
+}
+
+void ScriptSender::disconnectionCallback(const int filedescriptor)
+{
+  URCL_LOG_DEBUG("Client at FD %d disconnected.", filedescriptor);
+}
+
+void ScriptSender::messageCallback(const int filedescriptor, char* buffer)
+{
+  if (std::string(buffer) == PROGRAM_REQUEST_)
+  {
+    URCL_LOG_INFO("Robot requested program");
+    sendProgram(filedescriptor);
+  }
+}
+
+void ScriptSender::sendProgram(const int filedescriptor)
+{
+  size_t len = program_.size();
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(program_.c_str());
+  size_t written;
+
+  if (server_.write(filedescriptor, data, len, written))
+  {
+    URCL_LOG_INFO("Sent program to robot");
+  }
+  else
+  {
+    URCL_LOG_ERROR("Could not send program to robot");
+  }
+}
+
+}  // namespace control
+}  // namespace urcl

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -191,7 +191,7 @@ std::unique_ptr<rtde_interface::DataPackage> urcl::UrDriver::getDataPackage()
   return rtde_client_->getDataPackage(timeout);
 }
 
-bool UrDriver::writeJointCommand(const vector6d_t& values, const control::ControlMode control_mode)
+bool UrDriver::writeJointCommand(const vector6d_t& values, const comm::ControlMode control_mode)
 {
   return reverse_interface_->write(&values, control_mode);
 }
@@ -199,7 +199,7 @@ bool UrDriver::writeJointCommand(const vector6d_t& values, const control::Contro
 bool UrDriver::writeKeepalive()
 {
   vector6d_t* fake = nullptr;
-  return reverse_interface_->write(fake, control::ControlMode::MODE_IDLE);
+  return reverse_interface_->write(fake, comm::ControlMode::MODE_IDLE);
 }
 
 void UrDriver::startRTDECommunication()
@@ -210,7 +210,7 @@ void UrDriver::startRTDECommunication()
 bool UrDriver::stopControl()
 {
   vector6d_t* fake = nullptr;
-  return reverse_interface_->write(fake, control::ControlMode::MODE_STOPPED);
+  return reverse_interface_->write(fake, comm::ControlMode::MODE_STOPPED);
 }
 
 std::string UrDriver::readScriptFile(const std::string& filename)

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -143,11 +143,11 @@ urcl::UrDriver::UrDriver(const std::string& robot_ip, const std::string& script_
   }
   else
   {
-    script_sender_.reset(new comm::ScriptSender(script_sender_port, prog));
+    script_sender_.reset(new control::ScriptSender(script_sender_port, prog));
     URCL_LOG_DEBUG("Created script sender");
   }
 
-  reverse_interface_.reset(new comm::ReverseInterface(reverse_port, handle_program_state));
+  reverse_interface_.reset(new control::ReverseInterface(reverse_port, handle_program_state));
 
   URCL_LOG_DEBUG("Initialization done");
 }
@@ -191,7 +191,7 @@ std::unique_ptr<rtde_interface::DataPackage> urcl::UrDriver::getDataPackage()
   return rtde_client_->getDataPackage(timeout);
 }
 
-bool UrDriver::writeJointCommand(const vector6d_t& values, const comm::ControlMode control_mode)
+bool UrDriver::writeJointCommand(const vector6d_t& values, const control::ControlMode control_mode)
 {
   return reverse_interface_->write(&values, control_mode);
 }
@@ -199,7 +199,7 @@ bool UrDriver::writeJointCommand(const vector6d_t& values, const comm::ControlMo
 bool UrDriver::writeKeepalive()
 {
   vector6d_t* fake = nullptr;
-  return reverse_interface_->write(fake, comm::ControlMode::MODE_IDLE);
+  return reverse_interface_->write(fake, control::ControlMode::MODE_IDLE);
 }
 
 void UrDriver::startRTDECommunication()
@@ -210,7 +210,7 @@ void UrDriver::startRTDECommunication()
 bool UrDriver::stopControl()
 {
   vector6d_t* fake = nullptr;
-  return reverse_interface_->write(fake, comm::ControlMode::MODE_STOPPED);
+  return reverse_interface_->write(fake, control::ControlMode::MODE_STOPPED);
 }
 
 std::string UrDriver::readScriptFile(const std::string& filename)


### PR DESCRIPTION
This moves the ReverseInteface and the ScriptSender from the `comm` namespace to the `control` namespace. As we plan to extend the control protocol structure with the changes from the beta-testing branch, I think it makes sense to clean up things a little beforehand.

Note: I decided to keep the `ControlMode` enums inside the `comm` namespace first because of backwards compatibility, as they are used on application level, and second because they actually define the communication protocol and therefore seem to be not too wrong inside the comm namespace.