### PR TITLE
Removed console_bridge dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,18 +60,6 @@ if(CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(urcl PUBLIC "${CMAKE_THREAD_LIBS_INIT}")
 endif()
 
-find_package(console_bridge)
-if(console_bridge_FOUND)
-  message(STATUS "Building with ROS logging support")
-  add_definitions( -DROS_BUILD )
-  target_include_directories( urcl PRIVATE
-    ${console_bridge_INCLUDE_DIRS}
-  )
-  target_link_libraries(urcl INTERFACE console_bridge)
-else()
-  message(STATUS "Building without ROS logging support")
-endif()
-
 ##
 ## Build testing if enabled by option
 ##

--- a/README.md
+++ b/README.md
@@ -376,19 +376,6 @@ int main(int argc, char* argv[])
 }
 ```
 
-### Console_bridge
-If [`console_bridge`](https://github.com/ros/console_bridge) is found on the system during the
-cmake run, logging commands will be done by `console_bridge`. In this case, the define `ROS_BUILD`
-will be set. When built inside a catkin workspace, logging commands are automatically translated
-into ROS logging commands.
-
-If you compile this library against `console_bridge`, make sure to set the logging level in your
-application, as by default `console_bridge` will only print messages of level WARNING or higher.
-See [`examples/primary_pipeline.cpp`](examples/primary_pipeline.cpp) as an example.
-
-The ROS logger will be moved to the ROS driver in a future release.
-
-
 ## Acknowledgment
 Many parts of this library are forked from the [ur_modern_driver](https://github.com/ros-industrial/ur_modern_driver).
 

--- a/examples/primary_pipeline.cpp
+++ b/examples/primary_pipeline.cpp
@@ -30,10 +30,6 @@
 #include <ur_client_library/comm/shell_consumer.h>
 #include <ur_client_library/primary/primary_parser.h>
 
-#ifdef ROS_BUILD
-#include <console_bridge/console.h>
-#endif
-
 using namespace urcl;
 
 // In a real-world example it would be better to get those values from command line parameters / a better configuration
@@ -42,12 +38,6 @@ const std::string ROBOT_IP = "192.168.56.101";
 
 int main(int argc, char* argv[])
 {
-#ifdef ROS_BUILD
-  // When compiled with ROS support we have to set the logging level in order to see output with a
-  // lower level than WARNING
-  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_DEBUG);
-#endif
-
   // First of all, we need a stream that connects to the robot
   comm::URStream<primary_interface::PrimaryPackage> primary_stream(ROBOT_IP, urcl::primary_interface::UR_PRIMARY_PORT);
 

--- a/include/ur_client_library/log.h
+++ b/include/ur_client_library/log.h
@@ -20,24 +20,11 @@
 #include <inttypes.h>
 #include <memory>
 
-#ifdef ROS_BUILD
-#include <console_bridge/console.h>
-
-#define URCL_LOG_DEBUG CONSOLE_BRIDGE_logDebug
-#define URCL_LOG_WARN CONSOLE_BRIDGE_logWarn
-#define URCL_LOG_INFO CONSOLE_BRIDGE_logInform
-#define URCL_LOG_ERROR CONSOLE_BRIDGE_logError
-#define URCL_LOG_FATAL CONSOLE_BRIDGE_logError
-
-#else
-
 #define URCL_LOG_DEBUG(...) urcl::log(__FILE__, __LINE__, urcl::LogLevel::DEBUG, __VA_ARGS__)
 #define URCL_LOG_WARN(...) urcl::log(__FILE__, __LINE__, urcl::LogLevel::WARN, __VA_ARGS__)
 #define URCL_LOG_INFO(...) urcl::log(__FILE__, __LINE__, urcl::LogLevel::INFO, __VA_ARGS__)
 #define URCL_LOG_ERROR(...) urcl::log(__FILE__, __LINE__, urcl::LogLevel::ERROR, __VA_ARGS__)
 #define URCL_LOG_FATAL(...) urcl::log(__FILE__, __LINE__, urcl::LogLevel::FATAL, __VA_ARGS__)
-
-#endif
 
 namespace urcl
 {

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,6 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>libconsole-bridge-dev</depend>
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
 


### PR DESCRIPTION
As log handlers for the client library has been created in the drivers, the console bridge dependency is no longer needed.

As a log handler has been created for the ROS2 Driver and the ROS Driver, the console bridge dependency is no longer needed. Also in order for the handlers to actually work, we need to build the client library without console bridge. 

This shouldn't be merged before the two PR's https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/pull/398 and https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/126 has been merged
