### PR TITLE
Always install package.xml file

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -30,6 +30,7 @@ jobs:
             ROS_REPO: main
             IMMEDIATE_TEST_OUTPUT: true
             DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS_Driver#master https://raw.githubusercontent.com/UniversalRobots/Universal_Robots_ROS_Driver/master/.noetic.rosinstall"
+            BUILDER: catkin_tools
             DOCKER_RUN_OPTS: --network static_test_net
             BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             URSIM_VERSION: 5.8.0.10253

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,9 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ur_client_libraryCo
 install(FILES ur_client_libraryConfig.cmake
   DESTINATION lib/cmake/ur_client_library)
 
-# When built with catkin available, install package.xml
-find_package(catkin QUIET)
-find_package(ament_cmake QUIET)
-if(catkin_FOUND OR ament_cmake_FOUND)
-  install(FILES package.xml DESTINATION share/${PROJECT_NAME})
-endif()
+# Install package.xml file so this package can be processed by ROS toolings
+# See REP 136 for details
+# Installing this in non-ROS environments won't have any effect, but it won't harm, either.
+install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 
 install(DIRECTORY resources DESTINATION share/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,4 +109,20 @@ install(FILES ur_client_libraryConfig.cmake
 # Installing this in non-ROS environments won't have any effect, but it won't harm, either.
 install(FILES package.xml DESTINATION share/${PROJECT_NAME})
 
+#### Begin import ####
+# Imported from ros-industrial/ros_industrial_cmake_boilerplate
+# https://github.com/ros-industrial/ros_industrial_cmake_boilerplate/blob/master/ros_industrial_cmake_boilerplate/cmake/cmake_tools.cmake
+# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+# Copyright (c) 2020, Southwest Research Institute
+# Licensed under Apache-2.0 license
+
+# Allows Colcon to find non-Ament packages when using workspace underlays
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ros_package_path.dsv "prepend-non-duplicate;ROS_PACKAGE_PATH;")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ros_package_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
+#### End iport ####
+
 install(DIRECTORY resources DESTINATION share/${PROJECT_NAME})


### PR DESCRIPTION
As this package's build type is plain cmake, catkin is not necessarily
available at build time. Hence, checking for catkin before installing the
package.xml doesn't make any sense as this will never work for the buildfarm builds.

Installig the package.xml file in every case won't hurt in non-ROS environments.

When the package.xml file is not installed, toolings like rospack will not be
able to find the package.

@puck-fzi @urmahp opinions on this?