### PR TITLE
Use foxy branch of driver for downstream builds

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -37,7 +37,7 @@ jobs:
           - ROS_DISTRO: foxy
             ROS_REPO: main
             IMMEDIATE_TEST_OUTPUT: true
-            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#main https://raw.githubusercontent.com/UniversalRobots/Universal_Robots_ROS2_Driver/main/Universal_Robots_ROS2_Driver.repos"
+            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#foxy https://raw.githubusercontent.com/UniversalRobots/Universal_Robots_ROS2_Driver/foxy/Universal_Robots_ROS2_Driver-not-released.foxy.repos"
             DOCKER_RUN_OPTS: --network static_test_net
             BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
             URSIM_VERSION: 5.8.0.10253


### PR DESCRIPTION
As the ROS2 driver forked out for foxy a while ago, we need to adapt this repo's downstream workspace for foxy.