### PR TITLE
Clear the queue when consumer reads from it

### DIFF
--- a/include/ur_client_library/comm/pipeline.h
+++ b/include/ur_client_library/comm/pipeline.h
@@ -319,7 +319,7 @@ public:
   }
 
   /*!
-   * \brief Returns the most recent package in the queue. Can be used instead of registering a consumer.
+   * \brief Returns the most recent package in the queue. Can be used instead of registering a consumer. If the queue already contains one or more items, the queue will be flushed and the newest item will be returned. If there is no item inside the queue, the function will wait for \p timeout for a new package
    *
    * \param product Unique pointer to be set to the package
    * \param timeout Time to wait if no package is in the queue before returning

--- a/include/ur_client_library/comm/pipeline.h
+++ b/include/ur_client_library/comm/pipeline.h
@@ -319,7 +319,7 @@ public:
   }
 
   /*!
-   * \brief Returns the next package in the queue. Can be used instead of registering a consumer.
+   * \brief Returns the most recent package in the queue. Can be used instead of registering a consumer.
    *
    * \param product Unique pointer to be set to the package
    * \param timeout Time to wait if no package is in the queue before returning
@@ -328,7 +328,15 @@ public:
    */
   bool getLatestProduct(std::unique_ptr<T>& product, std::chrono::milliseconds timeout)
   {
-    return queue_.waitDequeTimed(product, timeout);
+    // If the queue has more than one package, get the latest one.
+    bool res = false;
+    while (queue_.tryDequeue(product))
+    {
+      res = true;
+    }
+
+    // If the queue is empty, wait for a package.
+    return res || queue_.waitDequeTimed(product, timeout);
   }
 
 private:


### PR DESCRIPTION
Currently, `getLatestProduct` calls `queue_.waitDequeTimed` to retrieve a package from the queue, which means that it always retrieves the oldest package from the queue (when the queue contains more than one package).  The additional packages remain in the queue, which can cause the queue to fill up over time and lead to `Pipeline producer overflowed!` errors:
https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/8f20b42205f645bba406d5cf3b1163ea0a42fbc9/include/ur_client_library/comm/pipeline.h#L410-L413

This PR modifies `getLatestProduct` so that it always returns the most recent package from the queue, and discards older ones.