### PR TITLE
Ignore debian folder in check_links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             --exclude=package.xml \
             --exclude-dir=CMakeModules \
             --exclude=tcp_socket.cpp \
+            --exclude-dir=debian \
             --exclude=real_time.md
 
   rosdoc_lite_check:


### PR DESCRIPTION
Otherwise this job raises an error in the release repository.

See https://github.com/ros2-gbp/Universal_Robots_Client_Library-release/runs/6128147728?check_suite_focus=true