### PR TITLE
Fix 'BEGIN_REPLACE' - used in tool_communication

### DIFF
--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -1,6 +1,6 @@
-{{BEGIN_REPLACE}}
-
 # HEADER_BEGIN
+
+{{BEGIN_REPLACE}}
 
 steptime = get_steptime()
 


### PR DESCRIPTION
Fix the position of 'BEGIN_REPLACE' - used in tool_communication