### PR TITLE
Try reconnecting shut down connections

### DIFF
--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -321,11 +321,19 @@ bool TCPServer::write(const int fd, const uint8_t* buf, const size_t buf_len, si
   // handle partial sends
   while (written < buf_len)
   {
-    ssize_t sent = ::send(fd, buf + written, remaining, 0);
+    ssize_t sent = ::send(fd, buf + written, remaining, MSG_NOSIGNAL);
 
     if (sent <= 0)
     {
-      URCL_LOG_ERROR("Sending data through socket failed.");
+      if (errno == EPIPE)
+      {
+        URCL_LOG_ERROR("Sending data through socket failed because the connection was shut down");
+        handleDisconnect(fd);
+      }
+      else
+      {
+        URCL_LOG_ERROR("Sending data through socket failed");
+      }
       return false;
     }
 

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -184,11 +184,19 @@ bool TCPSocket::write(const uint8_t* buf, const size_t buf_len, size_t& written)
   // handle partial sends
   while (written < buf_len)
   {
-    ssize_t sent = ::send(socket_fd_, buf + written, remaining, 0);
+    ssize_t sent = ::send(socket_fd_, buf + written, remaining, MSG_NOSIGNAL);
 
     if (sent <= 0)
     {
-      URCL_LOG_ERROR("Sending data through socket failed.");
+      if (errno == EPIPE)
+      {
+        state_ = SocketState::Disconnected;
+        URCL_LOG_ERROR("Sending data through socket failed because the connection was shut down");
+      }
+      else
+      {
+        URCL_LOG_ERROR("Sending data through socket failed");
+      }
       return false;
     }
 


### PR DESCRIPTION
For now this only concerns the primary/secondary interface, but revisiting the RTDE handling might make sense later.

- [x] Correctly detect shut down connections using `MSG_NOSIGNAL` and `EPIPE`
- [ ] Add reconnecting `URStream<>` abstraction to replace `URProducer<>` special handling
- [ ] Use reconnecting `URStream<>` for script sending

Fixes #104 