### PR TITLE
Ignore atomicops.h in check_links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
             --exclude-dir=CMakeModules \
             --exclude=tcp_socket.cpp \
             --exclude-dir=debian \
-            --exclude=real_time.md
+            --exclude=real_time.md \
+            --exclude=atomicops.h
 
   rosdoc_lite_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since this is a 3rd-party file I don't really see any point in going deeper
into that.