### PR TITLE
Added tcp_offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ implemented in order to create external applications leveraging the versatility 
 robotic manipulators.
 
 ## Requirements
+ * **Polyscope** (The software running on the robot controller) version **3.12.0** (for CB3-Series),
+   or **5.5.1** (for e-Series) or higher. If you use an older Polyscope version it is suggested to
+   update your robot. If for some reason (please tell us in the issues why) you cannot upgrade your
+   robot, please see the [version compatibility table](doc/polyscope_compatibility.md) for a
+   compatible tag.
  * The library requires an implementation of **POSIX threads** such as the `pthread` library
  * Socket communication is currently based on Linux sockets. Thus, this library will require Linux
    for building and using.

--- a/doc/polyscope_compatibility.md
+++ b/doc/polyscope_compatibility.md
@@ -1,0 +1,17 @@
+# Polyscope version compatibility
+The table below shows breaking changes in the library compared to Polyscope versions. Compatibility
+is listed for CB3 robots (versions 3.x.y) and e-Series robots (versions 5.x.y) respectively.
+
+It might be possible to use the library in a more recent version than the compatible versions listed
+below, but that might either require some manual modifications or not using a subset of features.
+For that reason the breaking changes are also listed inside the table. Please note that choosing a
+higher library version than recommended happens on your own risk and will not be supported.
+
+If your Polyscope version is less than the minimum required version for the latest library version,
+we suggest to upgrade your robot's software. Please refer to the robot's user manual how to update
+your robot.
+
+
+|Polyscope version | Maximum tag | Breaking changes |
+|------------------|-------------|------------------|
+| < 3.12.0 / 5.5.1 | [polyscope_compat_break_1](https://github.com/UniversalRobots/Universal_Robots_Client_Library/tree/polyscope_compat_break_1) | [tcp_offset in RTDE interface](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/110)|

--- a/examples/resources/rtde_output_recipe.txt
+++ b/examples/resources/rtde_output_recipe.txt
@@ -25,3 +25,4 @@ safety_mode
 robot_status_bits
 safety_status_bits
 actual_current
+tcp_offset

--- a/src/rtde/data_package.cpp
+++ b/src/rtde/data_package.cpp
@@ -553,6 +553,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "standard_analog_output_type", uint8_t() },
   { "standard_analog_output_0", double() },
   { "standard_analog_output_1", double() },
+  { "tcp_offset", vector6d_t() },
 };
 
 void rtde_interface::DataPackage::initEmpty()

--- a/tests/resources/rtde_output_recipe.txt
+++ b/tests/resources/rtde_output_recipe.txt
@@ -25,3 +25,4 @@ safety_mode
 robot_status_bits
 safety_status_bits
 actual_current
+tcp_offset


### PR DESCRIPTION
The function tcp_offset isn't available before software version 3.12.0 and 5.5.1. It is needed in the ROS driver to transform the the force/torque measurements to the tcp frame.  