### PR TITLE
Fixed parsing of incomming packages when using rtde protocol v1

### DIFF
--- a/include/ur_client_library/rtde/control_package_setup_outputs.h
+++ b/include/ur_client_library/rtde/control_package_setup_outputs.h
@@ -46,8 +46,11 @@ class ControlPackageSetupOutputs : public RTDEPackage
 public:
   /*!
    * \brief Creates a new ControlPackageSetupOutputs object.
+   *
+   * \param protocol_version Protocol version used for the RTDE communication
    */
-  ControlPackageSetupOutputs() : RTDEPackage(PackageType::RTDE_CONTROL_PACKAGE_SETUP_OUTPUTS)
+  ControlPackageSetupOutputs(uint16_t protocol_version)
+    : RTDEPackage(PackageType::RTDE_CONTROL_PACKAGE_SETUP_OUTPUTS), protocol_version_(protocol_version)
   {
   }
   virtual ~ControlPackageSetupOutputs() = default;
@@ -70,6 +73,7 @@ public:
 
   uint8_t output_recipe_id_;
   std::string variable_types_;
+  uint16_t protocol_version_;
 };
 
 /*!

--- a/include/ur_client_library/rtde/data_package.h
+++ b/include/ur_client_library/rtde/data_package.h
@@ -68,14 +68,18 @@ public:
   DataPackage(const DataPackage& other) : DataPackage(other.recipe_)
   {
     this->data_ = other.data_;
+    this->protocol_version_ = other.protocol_version_;
   }
 
   /*!
    * \brief Creates a new DataPackage object, based on a given recipe.
    *
    * \param recipe The used recipe
+   *
+   * \param protocol_version Protocol version used for the RTDE communication
    */
-  DataPackage(const std::vector<std::string>& recipe) : RTDEPackage(PackageType::RTDE_DATA_PACKAGE), recipe_(recipe)
+  DataPackage(const std::vector<std::string>& recipe, const uint16_t& protocol_version = 2)
+    : RTDEPackage(PackageType::RTDE_DATA_PACKAGE), recipe_(recipe), protocol_version_(protocol_version)
   {
   }
   virtual ~DataPackage() = default;
@@ -200,6 +204,7 @@ private:
   uint8_t recipe_id_;
   std::unordered_map<std::string, _rtde_type_variant> data_;
   std::vector<std::string> recipe_;
+  uint16_t protocol_version_;
 };
 
 }  // namespace rtde_interface

--- a/include/ur_client_library/rtde/rtde_parser.h
+++ b/include/ur_client_library/rtde/rtde_parser.h
@@ -83,7 +83,7 @@ public:
     {
       case PackageType::RTDE_DATA_PACKAGE:
       {
-        std::unique_ptr<RTDEPackage> package(new DataPackage(recipe_));
+        std::unique_ptr<RTDEPackage> package(new DataPackage(recipe_, protocol_version_));
 
         if (!package->parseWith(bp))
         {
@@ -143,7 +143,7 @@ private:
         return new ControlPackageSetupInputs;
         break;
       case PackageType::RTDE_CONTROL_PACKAGE_SETUP_OUTPUTS:
-        return new ControlPackageSetupOutputs;
+        return new ControlPackageSetupOutputs(protocol_version_);
         break;
       case PackageType::RTDE_CONTROL_PACKAGE_START:
         return new ControlPackageStart;

--- a/src/rtde/control_package_setup_outputs.cpp
+++ b/src/rtde/control_package_setup_outputs.cpp
@@ -34,16 +34,30 @@ namespace rtde_interface
 {
 bool ControlPackageSetupOutputs::parseWith(comm::BinParser& bp)
 {
-  bp.parse(output_recipe_id_);
-  bp.parseRemainder(variable_types_);
+  if (protocol_version_ == 2)
+  {
+    bp.parse(output_recipe_id_);
+    bp.parseRemainder(variable_types_);
+  }
+  else if (protocol_version_ == 1)
+  {
+    bp.parseRemainder(variable_types_);
+  }
 
   return true;
 }
 std::string ControlPackageSetupOutputs::toString() const
 {
   std::stringstream ss;
-  ss << "output recipe id: " << static_cast<int>(output_recipe_id_) << std::endl;
-  ss << "variable types: " << variable_types_;
+  if (protocol_version_ == 2)
+  {
+    ss << "output recipe id: " << static_cast<int>(output_recipe_id_) << std::endl;
+    ss << "variable types: " << variable_types_;
+  }
+  else if (protocol_version_ == 1)
+  {
+    ss << "variable types: " << variable_types_;
+  }
 
   return ss.str();
 }

--- a/src/rtde/control_package_setup_outputs.cpp
+++ b/src/rtde/control_package_setup_outputs.cpp
@@ -43,6 +43,13 @@ bool ControlPackageSetupOutputs::parseWith(comm::BinParser& bp)
   {
     bp.parseRemainder(variable_types_);
   }
+  else
+  {
+    std::stringstream ss;
+    ss << "Unknown protocol version, protocol version is " << protocol_version_;
+    URCL_LOG_ERROR(ss.str().c_str());
+    return false;
+  }
 
   return true;
 }
@@ -57,6 +64,10 @@ std::string ControlPackageSetupOutputs::toString() const
   else if (protocol_version_ == 1)
   {
     ss << "variable types: " << variable_types_;
+  }
+  else
+  {
+    ss << "Unknown protocol version, protocol version is " << protocol_version_ << std::endl;
   }
 
   return ss.str();

--- a/src/rtde/data_package.cpp
+++ b/src/rtde/data_package.cpp
@@ -569,7 +569,10 @@ void rtde_interface::DataPackage::initEmpty()
 
 bool rtde_interface::DataPackage::parseWith(comm::BinParser& bp)
 {
-  bp.parse(recipe_id_);
+  if (protocol_version_ == 2)
+  {
+    bp.parse(recipe_id_);
+  }
   for (auto& item : recipe_)
   {
     if (g_type_list.find(item) != g_type_list.end())


### PR DESCRIPTION
The received rtde packages should be parsed slightly different whether we use protocol v1 or v2.

This will fix issue #113 