### PR TITLE
Fix unique_ptr type

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -108,7 +108,7 @@ void log(const char* file, int line, LogLevel level, const char* fmt, ...)
   if (level >= g_logger.getLogLevel())
   {
     size_t buffer_size = 1024;
-    std::unique_ptr<char> buffer;
+    std::unique_ptr<char[]> buffer;
     buffer.reset(new char[buffer_size]);
 
     va_list args;


### PR DESCRIPTION
gcc 12 warns about this:

```
In file included from /usr/include/c++/12/memory:76,
                 from /home/wilbrandt/FZI/robot_folders/checkout/ur_humble/colcon_ws/src/Universal_Robots_Client_Library/include/ur_client_library/log.h:21,
                 from /home/wilbrandt/FZI/robot_folders/checkout/ur_humble/colcon_ws/src/Universal_Robots_Client_Library/src/log.cpp:31:
In member function ‘void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = char]’,
    inlined from ‘void std::__uniq_ptr_impl<_Tp, _Dp>::reset(pointer) [with _Tp = char; _Dp = std::default_delete<char>]’ at /usr/include/c++/12/bits/unique_ptr.h:203:16,
    inlined from ‘void std::unique_ptr<_Tp, _Dp>::reset(pointer) [with _Tp = char; _Dp = std::default_delete<char>]’ at /usr/include/c++/12/bits/unique_ptr.h:501:12,
    inlined from ‘void urcl::log(const char*, int, LogLevel, const char*, ...)’ at /home/wilbrandt/FZI/robot_folders/checkout/ur_humble/colcon_ws/src/Universal_Robots_Client_Library/src/log.cpp:124:19:
/usr/include/c++/12/bits/unique_ptr.h:95:9: warning: ‘void operator delete(void*, std::size_t)’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
   95 |         delete __ptr;
      |         ^~~~~~~~~~~~
/home/wilbrandt/FZI/robot_folders/checkout/ur_humble/colcon_ws/src/Universal_Robots_Client_Library/src/log.cpp: In function ‘void urcl::log(const char*, int, LogLevel, const char*, ...)’:
/home/wilbrandt/FZI/robot_folders/checkout/ur_humble/colcon_ws/src/Universal_Robots_Client_Library/src/log.cpp:112:38: note: returned from ‘void* operator new [](std::size_t)’
  112 |     buffer.reset(new char[buffer_size]);
      |
```