### PR TITLE
Add a colcon.pkg file for proper ament integration

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,6 @@
+{
+  "hooks": [
+    "share/ur_client_library/hook/ament_prefix_path.dsv",
+    "share/ur_client_library/hook/ros_package_path.dsv",
+  ]
+}


### PR DESCRIPTION
This will help making the package available in the ament build system. This will effecticely advertise the hooks that we install in our `CMakeLists.txt`

This will effectively enable https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/316 to work properly.