### PR TITLE
Prerelease/1.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Dashboard commands, Docker Image and CI step for running the examples `#127 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/127>`_
+* Added tests for the rtde interface clasess (`#125 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/125>`_)
+* Fix unique_ptr type (`#124 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/124>`_)
+* Fix 'BEGIN_REPLACE' - used in tool_communication (copy `#101 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/101>`_) (`#120 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/120>`_)
+  (cherry picked from commit f7ce9f73181848f3957c660647fac0e5325862b9)
+  Co-authored-by: rxjia <60809735+rxjia@users.noreply.github.com>
+* Contributors: Felix Exner, Mads Holm Peters, RobertWilbrandt, Rune Søe-Knudsen, mergify[bot], urmarp, urrsk
+
 1.2.0 (2022-10-04)
 ------------------
 * Initialized receive timeout and changed exception to warning (`#118 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/118>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.3.0 (2022-11-28)
+------------------
 * Dashboard commands, Docker Image and CI step for running the examples `#127 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/127>`_
 * Added tests for the rtde interface clasess (`#125 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/125>`_)
 * Fix unique_ptr type (`#124 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/124>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
As usual, let's rebase-merge this and push the tag to the master branch manually.

Note: Humble currently fails due to #132 