### PR TITLE
Add a prerelease check that calls `bloom-generate`

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,30 @@
+name: ROS prerelease test
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  prerelease_test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [humble, rolling]
+        OS_VERSION: [jammy]
+        include:
+          - ROS_DISTRO: melodic
+            OS_VERSION: bionic
+          - ROS_DISTRO: noetic
+            OS_VERSION: focal
+          - ROS_DISTRO: foxy
+            OS_VERSION: focal
+
+    steps:
+      - uses: actions/checkout@v1
+      - run: sudo apt-get install -y python3-pip
+      - run: sudo pip3 install bloom rosdep
+      - run: sudo rosdep init
+      - run: rosdep update
+      - run: bloom-generate rosdebian --ros-distro ${{ matrix.ROS_DISTRO }} --os-name ubuntu --os-version ${{ matrix.OS_VERSION }}

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,6 @@
   <license file="LICENSE_apache_2_0">Apache-2.0</license>
   <license file="include/ur_client_library/queue/LICENSE.md">BSD-2-Clause</license>
   <license file="include/ur_client_library/queue/atomicops.h">Zlib</license>
-  <license file="tests/resources/dockerursim/Dockerfile">MIT</license>
 
   <url type="website">http://wiki.ros.org/ur_client_library</url>
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues</url>


### PR DESCRIPTION
Since I had problems in the `bloom-generate` step when releasing 1.3.0 and similar things have happened in the past, I think it is a good idea to add a check to new PRs to prevent such things in the future.

This PR also contains a fix for the regression currently living on the master branch introduced in #127.