### PR TITLE
Prerelease/1.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* CI: Add a prerelease check that calls `bloom-generate` (`#134 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/134>`_)
+* Contributors: Felix Exner
+
 1.3.0 (2022-11-28)
 ------------------
 * Dashboard commands, Docker Image and CI step for running the examples `#127 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/127>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.3.1 (2022-11-30)
+------------------
 * CI: Add a prerelease check that calls `bloom-generate` (`#134 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/134>`_)
 * Contributors: Felix Exner
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
Since the 1.3.0 release could not be done because of an additional line in the package.xml, this is the consecutive release for that.

As usual, please merge with rebase strategy.