### PR TITLE
Changed num_retries from static to an unsigned int

### DIFF
--- a/src/rtde/rtde_client.cpp
+++ b/src/rtde/rtde_client.cpp
@@ -61,7 +61,7 @@ bool RTDEClient::init()
     return true;
   }
 
-  static unsigned attempts = 0;
+  unsigned int attempts = 0;
   while (attempts < MAX_INITIALIZE_ATTEMPTS)
   {
     setupCommunication();
@@ -144,7 +144,7 @@ bool RTDEClient::negotiateProtocolVersion(const uint16_t protocol_version)
 {
   // Protocol version should always be 1 before starting negotiation
   parser_.setProtocolVersion(1);
-  static unsigned num_retries = 0;
+  unsigned int num_retries = 0;
   uint8_t buffer[4096];
   size_t size;
   size_t written;
@@ -190,7 +190,7 @@ bool RTDEClient::negotiateProtocolVersion(const uint16_t protocol_version)
 
 void RTDEClient::queryURControlVersion()
 {
-  static unsigned num_retries = 0;
+  unsigned int num_retries = 0;
   uint8_t buffer[4096];
   size_t size;
   size_t written;
@@ -236,7 +236,7 @@ void RTDEClient::queryURControlVersion()
 
 void RTDEClient::setupOutputs(const uint16_t protocol_version)
 {
-  static unsigned num_retries = 0;
+  unsigned int num_retries = 0;
   size_t size;
   size_t written;
   uint8_t buffer[4096];
@@ -316,7 +316,7 @@ void RTDEClient::setupOutputs(const uint16_t protocol_version)
 
 void RTDEClient::setupInputs()
 {
-  static unsigned num_retries = 0;
+  unsigned int num_retries = 0;
   size_t size;
   size_t written;
   uint8_t buffer[4096];
@@ -487,7 +487,7 @@ bool RTDEClient::sendStart()
   }
 
   std::unique_ptr<RTDEPackage> package;
-  static unsigned num_retries = 0;
+  unsigned int num_retries = 0;
   while (num_retries < MAX_REQUEST_RETRIES)
   {
     if (!pipeline_.getLatestProduct(package, std::chrono::milliseconds(1000)))


### PR DESCRIPTION
The num_retries wouldn't be reset within each function, but it will now so the correct number of retries is performed in each function, before throwing an exception.