### PR TITLE
Added support for force_mode, freedrive and tool contact

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,3 +34,8 @@ add_executable(dashboard_example
   dashboard_example.cpp)
 target_compile_options(dashboard_example PUBLIC ${CXX17_FLAG})
 target_link_libraries(dashboard_example ur_client_library::urcl)
+
+add_executable(tool_contact_example
+tool_contact_example.cpp)
+target_compile_options(tool_contact_example PUBLIC ${CXX17_FLAG})
+target_link_libraries(tool_contact_example ur_client_library::urcl)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -39,3 +39,13 @@ add_executable(tool_contact_example
 tool_contact_example.cpp)
 target_compile_options(tool_contact_example PUBLIC ${CXX17_FLAG})
 target_link_libraries(tool_contact_example ur_client_library::urcl)
+
+add_executable(freedrive_example
+freedrive_example.cpp)
+target_compile_options(freedrive_example PUBLIC ${CXX17_FLAG})
+target_link_libraries(freedrive_example ur_client_library::urcl)
+
+add_executable(force_mode_example
+force_mode_example.cpp)
+target_compile_options(force_mode_example PUBLIC ${CXX17_FLAG})
+target_link_libraries(force_mode_example ur_client_library::urcl)

--- a/examples/force_mode_example.cpp
+++ b/examples/force_mode_example.cpp
@@ -1,0 +1,168 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2022 Universal Robots A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -- END LICENSE BLOCK ------------------------------------------------
+
+// In a real-world example it would be better to get those values from command line parameters / a
+// better configuration system such as Boost.Program_options
+
+#include <ur_client_library/ur/dashboard_client.h>
+#include <ur_client_library/ur/ur_driver.h>
+#include <ur_client_library/types.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include "ur_client_library/control/reverse_interface.h"
+
+using namespace urcl;
+
+const std::string DEFAULT_ROBOT_IP = "192.168.56.101";
+const std::string SCRIPT_FILE = "resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "examples/resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "examples/resources/rtde_input_recipe.txt";
+const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
+
+std::unique_ptr<UrDriver> g_my_driver;
+std::unique_ptr<DashboardClient> g_my_dashboard;
+
+// We need a callback function to register. See UrDriver's parameters for details.
+void handleRobotProgramState(bool program_running)
+{
+  // Print the text in green so we see it better
+  std::cout << "\033[1;32mProgram running: " << std::boolalpha << program_running << "\033[0m\n" << std::endl;
+}
+
+void sendFreedriveMessageOrDie(const control::FreedriveControlMessage freedrive_action)
+{
+  bool ret = g_my_driver->writeFreedriveControlMessage(freedrive_action);
+  if (!ret)
+  {
+    URCL_LOG_ERROR("Could not send joint command. Is the robot in remote control?");
+    exit(1);
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  urcl::setLogLevel(urcl::LogLevel::INFO);
+  // Parse the ip arguments if given
+  std::string robot_ip = DEFAULT_ROBOT_IP;
+  if (argc > 1)
+  {
+    robot_ip = std::string(argv[1]);
+  }
+
+  // Parse how many seconds to run
+  auto second_to_run = std::chrono::seconds(0);
+  if (argc > 2)
+  {
+    second_to_run = std::chrono::seconds(std::stoi(argv[2]));
+  }
+
+  // Making the robot ready for the program by:
+  // Connect the robot Dashboard
+  g_my_dashboard.reset(new DashboardClient(robot_ip));
+  if (!g_my_dashboard->connect())
+  {
+    URCL_LOG_ERROR("Could not connect to dashboard");
+    return 1;
+  }
+
+  // // Stop program, if there is one running
+  if (!g_my_dashboard->commandStop())
+  {
+    URCL_LOG_ERROR("Could not send stop program command");
+    return 1;
+  }
+
+  // Power it off
+  // if (!g_my_dashboard->commandPowerOff())
+  //{
+  // URCL_LOG_ERROR("Could not send Power off command");
+  // return 1;
+  //}
+
+  // Power it on
+  // if (!g_my_dashboard->commandPowerOn())
+  //{
+  // URCL_LOG_ERROR("Could not send Power on command");
+  // return 1;
+  //}
+
+  // Release the brakes
+  // if (!g_my_dashboard->commandBrakeRelease())
+  //{
+  // URCL_LOG_ERROR("Could not send BrakeRelease command");
+  // return 1;
+  //}
+
+  // Now the robot is ready to receive a program
+  std::unique_ptr<ToolCommSetup> tool_comm_setup;
+  const bool HEADLESS = true;
+  g_my_driver.reset(new UrDriver(robot_ip, SCRIPT_FILE, OUTPUT_RECIPE, INPUT_RECIPE, &handleRobotProgramState, HEADLESS,
+                                 std::move(tool_comm_setup), CALIBRATION_CHECKSUM));
+
+  // Once RTDE communication is started, we have to make sure to read from the interface buffer, as
+  // otherwise we will get pipeline overflows. Therefore, do this directly before starting your main
+  // loop.
+  g_my_driver->startRTDECommunication();
+
+  std::chrono::duration<double> time_done(0);
+  std::chrono::duration<double> timeout(second_to_run);
+  auto stopwatch_last = std::chrono::steady_clock::now();
+  auto stopwatch_now = stopwatch_last;
+  g_my_driver->writeKeepalive();
+  // Task frame at the robot's base with limits being large enough to cover the whole workspace
+  // Compliance in z axis and rotation around z axis
+  g_my_driver->startForceMode({ 0, 0, 0, 0, 0, 0 },                 // Task frame at the robot's base
+                              { 0, 0, 1, 0, 0, 1 },                 // Compliance in z axis and rotation around z axis
+                              { 0, 0, 0, 0, 0, 0 },                 // do not apply any active wrench
+                              2,                                    // do not transform the force frame at all
+                              { 0.1, 0.1, 1.5, 3.14, 3.14, 0.5 });  // limits. See ScriptManual for
+                                                                    // details.
+
+  while (true)
+  {
+    // Read latest RTDE package. This will block for a hard-coded timeout (see UrDriver), so the
+    // robot will effectively be in charge of setting the frequency of this loop.
+    // In a real-world application this thread should be scheduled with real-time priority in order
+    // to ensure that this is called in time.
+    std::unique_ptr<rtde_interface::DataPackage> data_pkg = g_my_driver->getDataPackage();
+    if (data_pkg)
+    {
+      g_my_driver->writeKeepalive();
+
+      if (time_done > timeout && second_to_run.count() != 0)
+      {
+        URCL_LOG_INFO("Timeout reached.");
+        break;
+      }
+    }
+    else
+    {
+      URCL_LOG_WARN("Could not get fresh data package from robot");
+    }
+
+    stopwatch_now = std::chrono::steady_clock::now();
+    time_done += stopwatch_now - stopwatch_last;
+    stopwatch_last = stopwatch_now;
+  }
+  g_my_driver->endForceMode();
+}

--- a/examples/freedrive_example.cpp
+++ b/examples/freedrive_example.cpp
@@ -1,0 +1,161 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2022 Universal Robots A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -- END LICENSE BLOCK ------------------------------------------------
+
+// In a real-world example it would be better to get those values from command line parameters / a
+// better configuration system such as Boost.Program_options
+
+#include <ur_client_library/ur/dashboard_client.h>
+#include <ur_client_library/ur/ur_driver.h>
+#include <ur_client_library/types.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include "ur_client_library/control/reverse_interface.h"
+
+using namespace urcl;
+
+const std::string DEFAULT_ROBOT_IP = "192.168.56.101";
+const std::string SCRIPT_FILE = "resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "examples/resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "examples/resources/rtde_input_recipe.txt";
+const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
+
+std::unique_ptr<UrDriver> g_my_driver;
+std::unique_ptr<DashboardClient> g_my_dashboard;
+
+// We need a callback function to register. See UrDriver's parameters for details.
+void handleRobotProgramState(bool program_running)
+{
+  // Print the text in green so we see it better
+  std::cout << "\033[1;32mProgram running: " << std::boolalpha << program_running << "\033[0m\n" << std::endl;
+}
+
+void sendFreedriveMessageOrDie(const control::FreedriveControlMessage freedrive_action)
+{
+  bool ret = g_my_driver->writeFreedriveControlMessage(freedrive_action);
+  if (!ret)
+  {
+    URCL_LOG_ERROR("Could not send joint command. Is the robot in remote control?");
+    exit(1);
+  }
+}
+
+int main(int argc, char* argv[])
+{
+  urcl::setLogLevel(urcl::LogLevel::INFO);
+  // Parse the ip arguments if given
+  std::string robot_ip = DEFAULT_ROBOT_IP;
+  if (argc > 1)
+  {
+    robot_ip = std::string(argv[1]);
+  }
+
+  // Parse how many seconds to run
+  auto second_to_run = std::chrono::seconds(0);
+  if (argc > 2)
+  {
+    second_to_run = std::chrono::seconds(std::stoi(argv[2]));
+  }
+
+  // Making the robot ready for the program by:
+  // Connect the robot Dashboard
+  g_my_dashboard.reset(new DashboardClient(robot_ip));
+  if (!g_my_dashboard->connect())
+  {
+    URCL_LOG_ERROR("Could not connect to dashboard");
+    return 1;
+  }
+
+  // // Stop program, if there is one running
+  if (!g_my_dashboard->commandStop())
+  {
+    URCL_LOG_ERROR("Could not send stop program command");
+    return 1;
+  }
+
+  // Power it off
+  if (!g_my_dashboard->commandPowerOff())
+  {
+    URCL_LOG_ERROR("Could not send Power off command");
+    return 1;
+  }
+
+  // Power it on
+  if (!g_my_dashboard->commandPowerOn())
+  {
+    URCL_LOG_ERROR("Could not send Power on command");
+    return 1;
+  }
+
+  // Release the brakes
+  if (!g_my_dashboard->commandBrakeRelease())
+  {
+    URCL_LOG_ERROR("Could not send BrakeRelease command");
+    return 1;
+  }
+
+  // Now the robot is ready to receive a program
+  std::unique_ptr<ToolCommSetup> tool_comm_setup;
+  const bool HEADLESS = true;
+  g_my_driver.reset(new UrDriver(robot_ip, SCRIPT_FILE, OUTPUT_RECIPE, INPUT_RECIPE, &handleRobotProgramState, HEADLESS,
+                                 std::move(tool_comm_setup), CALIBRATION_CHECKSUM));
+
+  // Once RTDE communication is started, we have to make sure to read from the interface buffer, as
+  // otherwise we will get pipeline overflows. Therefore, do this directly before starting your main
+  // loop.
+  g_my_driver->startRTDECommunication();
+
+  std::chrono::duration<double> time_done(0);
+  std::chrono::duration<double> timeout(second_to_run);
+  auto stopwatch_last = std::chrono::steady_clock::now();
+  auto stopwatch_now = stopwatch_last;
+  g_my_driver->writeKeepalive();
+  sendFreedriveMessageOrDie(control::FreedriveControlMessage::FREEDRIVE_START);
+
+  while (true)
+  {
+    // Read latest RTDE package. This will block for a hard-coded timeout (see UrDriver), so the
+    // robot will effectively be in charge of setting the frequency of this loop.
+    // In a real-world application this thread should be scheduled with real-time priority in order
+    // to ensure that this is called in time.
+    std::unique_ptr<rtde_interface::DataPackage> data_pkg = g_my_driver->getDataPackage();
+    if (data_pkg)
+    {
+      sendFreedriveMessageOrDie(control::FreedriveControlMessage::FREEDRIVE_NOOP);
+
+      if (time_done > timeout && second_to_run.count() != 0)
+      {
+        URCL_LOG_INFO("Timeout reached.");
+        break;
+      }
+    }
+    else
+    {
+      URCL_LOG_WARN("Could not get fresh data package from robot");
+    }
+
+    stopwatch_now = std::chrono::steady_clock::now();
+    time_done += stopwatch_now - stopwatch_last;
+    stopwatch_last = stopwatch_now;
+  }
+  sendFreedriveMessageOrDie(control::FreedriveControlMessage::FREEDRIVE_STOP);
+}

--- a/examples/tool_contact_example.cpp
+++ b/examples/tool_contact_example.cpp
@@ -1,0 +1,172 @@
+// this is for emacs file handling -*- mode: c++; indent-tabs-mode: nil -*-
+
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2022 Universal Robots A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -- END LICENSE BLOCK ------------------------------------------------
+
+// In a real-world example it would be better to get those values from command line parameters / a
+// better configuration system such as Boost.Program_options
+
+#include <ur_client_library/ur/dashboard_client.h>
+#include <ur_client_library/ur/ur_driver.h>
+#include <ur_client_library/types.h>
+
+#include <iostream>
+#include <memory>
+
+using namespace urcl;
+
+const std::string DEFAULT_ROBOT_IP = "192.168.56.101";
+const std::string SCRIPT_FILE = "resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "examples/resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "examples/resources/rtde_input_recipe.txt";
+const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
+
+std::unique_ptr<UrDriver> g_my_driver;
+std::unique_ptr<DashboardClient> g_my_dashboard;
+bool g_tool_contact_result_triggered;
+control::ToolContactResult g_tool_contact_result;
+
+// We need a callback function to register. See UrDriver's parameters for details.
+void handleRobotProgramState(bool program_running)
+{
+  // Print the text in green so we see it better
+  std::cout << "\033[1;32mProgram running: " << std::boolalpha << program_running << "\033[0m\n" << std::endl;
+}
+
+void handleToolContactResult(control::ToolContactResult result)
+{
+  // Print the text in green so we see it better
+  std::cout << "\033[1;32mTool contact result: " << toUnderlying(result) << "\033[0m\n" << std::endl;
+  g_tool_contact_result = result;
+  g_tool_contact_result_triggered = true;
+}
+
+int main(int argc, char* argv[])
+{
+  urcl::setLogLevel(urcl::LogLevel::INFO);
+  // Parse the ip arguments if given
+  std::string robot_ip = DEFAULT_ROBOT_IP;
+  if (argc > 1)
+  {
+    robot_ip = std::string(argv[1]);
+  }
+
+  // Parse how many seconds to run
+  int second_to_run = -1;
+  if (argc > 2)
+  {
+    second_to_run = std::stoi(argv[2]);
+  }
+
+  // Making the robot ready for the program by:
+  // Connect the the robot Dashboard
+  g_my_dashboard.reset(new DashboardClient(robot_ip));
+  if (!g_my_dashboard->connect())
+  {
+    URCL_LOG_ERROR("Could not connect to dashboard");
+    return 1;
+  }
+
+  // // Stop program, if there is one running
+  if (!g_my_dashboard->commandStop())
+  {
+    URCL_LOG_ERROR("Could not send stop program command");
+    return 1;
+  }
+
+  // Power it off
+  if (!g_my_dashboard->commandPowerOff())
+  {
+    URCL_LOG_ERROR("Could not send Power off command");
+    return 1;
+  }
+
+  // Power it on
+  if (!g_my_dashboard->commandPowerOn())
+  {
+    URCL_LOG_ERROR("Could not send Power on command");
+    return 1;
+  }
+
+  // Release the brakes
+  if (!g_my_dashboard->commandBrakeRelease())
+  {
+    URCL_LOG_ERROR("Could not send BrakeRelease command");
+    return 1;
+  }
+
+  // Now the robot is ready to receive a program
+  std::unique_ptr<ToolCommSetup> tool_comm_setup;
+  const bool HEADLESS = true;
+  g_my_driver.reset(new UrDriver(robot_ip, SCRIPT_FILE, OUTPUT_RECIPE, INPUT_RECIPE, &handleRobotProgramState, HEADLESS,
+                                 std::move(tool_comm_setup), CALIBRATION_CHECKSUM));
+
+  g_my_driver->registerToolContactResultCallback(&handleToolContactResult);
+
+  // Once RTDE communication is started, we have to make sure to read from the interface buffer, as
+  // otherwise we will get pipeline overflows. Therefor, do this directly before starting your main
+  // loop.
+  g_my_driver->startRTDECommunication();
+
+  // This will move the robot downward in the z direction of the base until a tool contact is detected or seconds_to_run
+  // is reached
+  std::chrono::duration<double> time_done(0);
+  std::chrono::duration<double> timeout(second_to_run);
+  vector6d_t tcp_speed = { 0.0, 0.0, -0.02, 0.0, 0.0, 0.0 };
+  auto stopwatch_last = std::chrono::steady_clock::now();
+  auto stopwatch_now = stopwatch_last;
+  g_my_driver->startToolContact();
+
+  while (true)
+  {
+    // Read latest RTDE package. This will block for a hard-coded timeout (see UrDriver), so the
+    // robot will effectively be in charge of setting the frequency of this loop.
+    // In a real-world application this thread should be scheduled with real-time priority in order
+    // to ensure that this is called in time.
+    std::unique_ptr<rtde_interface::DataPackage> data_pkg = g_my_driver->getDataPackage();
+    if (data_pkg)
+    {
+      bool ret = g_my_driver->writeJointCommand(tcp_speed, comm::ControlMode::MODE_SPEEDL);
+      if (!ret)
+      {
+        URCL_LOG_ERROR("Could not send joint command. Is the robot in remote control?");
+        return 1;
+      }
+
+      if (g_tool_contact_result_triggered)
+      {
+        URCL_LOG_INFO("Tool contact result triggered. Received tool contact result %i.",
+                      toUnderlying(g_tool_contact_result));
+        break;
+      }
+
+      if (time_done > timeout && second_to_run != -1)
+      {
+        URCL_LOG_INFO("Timed out before reaching tool contact.");
+        break;
+      }
+    }
+    else
+    {
+      URCL_LOG_WARN("Could not get fresh data package from robot");
+    }
+
+    stopwatch_now = std::chrono::steady_clock::now();
+    time_done += std::chrono::duration<double>((stopwatch_now - stopwatch_last).count());
+    stopwatch_last = stopwatch_now;
+  }
+}

--- a/examples/tool_contact_example.cpp
+++ b/examples/tool_contact_example.cpp
@@ -66,10 +66,10 @@ int main(int argc, char* argv[])
   }
 
   // Parse how many seconds to run
-  int second_to_run = -1;
+  auto second_to_run = std::chrono::seconds(0);
   if (argc > 2)
   {
-    second_to_run = std::stoi(argv[2]);
+    second_to_run = std::chrono::seconds(std::stoi(argv[2]));
   }
 
   // Making the robot ready for the program by:
@@ -154,7 +154,7 @@ int main(int argc, char* argv[])
         break;
       }
 
-      if (time_done > timeout && second_to_run != -1)
+      if (time_done > timeout && second_to_run.count() != 0)
       {
         URCL_LOG_INFO("Timed out before reaching tool contact.");
         break;
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
     }
 
     stopwatch_now = std::chrono::steady_clock::now();
-    time_done += std::chrono::duration<double>((stopwatch_now - stopwatch_last).count());
+    time_done += stopwatch_now - stopwatch_last;
     stopwatch_last = stopwatch_now;
   }
 }

--- a/include/ur_client_library/comm/control_mode.h
+++ b/include/ur_client_library/comm/control_mode.h
@@ -48,7 +48,7 @@ enum class ControlMode : int32_t
   MODE_POSE = 5,            ///< Set when cartesian pose control is active.
   MODE_FREEDRIVE = 6,       ///< Set when freedrive mode is active.
   MODE_TOOL_IN_CONTACT =
-      7  ///< Used by the internally in the script, when robot is in tool contact, clear by endToolContact()
+      7  ///< Used only internally in the script, when robot is in tool contact, clear by endToolContact()
 };
 }  // namespace comm
 }  // namespace urcl

--- a/include/ur_client_library/comm/control_mode.h
+++ b/include/ur_client_library/comm/control_mode.h
@@ -45,7 +45,10 @@ enum class ControlMode : int32_t
   MODE_SPEEDJ = 2,          ///< Set when speedj control is active.
   MODE_FORWARD = 3,         ///< Set when trajectory forwarding is active.
   MODE_SPEEDL = 4,          ///< Set when cartesian velocity control is active.
-  MODE_POSE = 5             ///< Set when cartesian pose control is active.
+  MODE_POSE = 5,            ///< Set when cartesian pose control is active.
+  MODE_FREEDRIVE = 6,       ///< Set when freedrive mode is active.
+  MODE_TOOL_IN_CONTACT =
+      7  ///< Used by the internally in the script, when robot is in tool contact, clear by endToolContact()
 };
 }  // namespace comm
 }  // namespace urcl

--- a/include/ur_client_library/control/reverse_interface.h
+++ b/include/ur_client_library/control/reverse_interface.h
@@ -52,6 +52,16 @@ enum class TrajectoryControlMessage : int32_t
 };
 
 /*!
+ * \brief Control messages for starting and stopping freedrive mode.
+ */
+enum class FreedriveControlMessage : int32_t
+{
+  FREEDRIVE_STOP = -1,  ///< Represents command to stop freedrive mode.
+  FREEDRIVE_NOOP = 0,   ///< Represents keep running in freedrive mode.
+  FREEDRIVE_START = 1,  ///< Represents command to start freedrive mode.
+};
+
+/*!
  * \brief The ReverseInterface class handles communication to the robot. It starts a server and
  * waits for the robot to connect via its URCaps program.
  */
@@ -96,6 +106,15 @@ public:
   bool writeTrajectoryControlMessage(const TrajectoryControlMessage trajectory_action, const int point_number = 0);
 
   /*!
+   * \brief Writes needed information to the robot to be read by the URScript program.
+   *
+   * \param freedrive_action 1 if freedrive mode is to be started, -1 if it should be stopped and 0 to keep it running
+   *
+   * \returns True, if the write was performed successfully, false otherwise.
+   */
+  bool writeFreedriveControlMessage(const FreedriveControlMessage freedrive_action);
+
+  /*!
    * \brief Set the Keepalive count. This will set the number of allowed timeout reads on the robot.
    *
    * \param count Number of allowed timeout reads on the robot.
@@ -122,6 +141,8 @@ protected:
     std::memcpy(buffer, &val, s);
     return s;
   }
+
+  static const int MAX_MESSAGE_LENGTH = 8;
 
   std::function<void(bool)> handle_program_state_;
   uint32_t keepalive_count_;

--- a/include/ur_client_library/queue/atomicops.h
+++ b/include/ur_client_library/queue/atomicops.h
@@ -45,7 +45,7 @@
 #if defined(AE_VCPP) || defined(AE_ICC)
 #define AE_FORCEINLINE __forceinline
 #elif defined(AE_GCC)
-//#define AE_FORCEINLINE __attribute__((always_inline))
+// #define AE_FORCEINLINE __attribute__((always_inline))
 #define AE_FORCEINLINE inline
 #else
 #define AE_FORCEINLINE inline

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -277,18 +277,18 @@ public:
    * \param task_frame A pose vector that defines the force frame relative to the base frame
    * \param selection_vector A 6d vector of 0s and 1s. 1 means that the robot will be compliant in the corresponding
    * axis of the task frame
-   * \param wrench The forces/torques the robot will apply to its environment. The robot adjusts its position
-   * along/about compliant axis in order to achieve the specified force/torque. Values have no effect for non-compliant
-   * axes
+   * \param wrench 6d vector of forces/torques [x,y,z,rotX,rotY,rotZ] that the robot will apply to its environment. The
+   * robot adjusts its position along/about compliant axis in order to achieve the specified force/torque. Values have
+   * no effect for non-compliant axes.
    * \param type An integer [1;3] specifying how the robot interprets the force frame.
    *  1: The force frame is transformed in a way such that its y-axis is aligned with a vector pointing from the robot
    *  tcp towards the origin of the force frame
    *  2: The force frame is not transformed
    *  3: The force frame is transformed in a way such that its x-axis is the projection of the robot tcp velocity vector
    *  onto the x-y plane of the force frame
-   * \param limits (Float) 6d vector. For compliant axes, these values are the maximum allowed tcp speed along/about the
-   * axis. For non-compliant axes, these values are the maximum allowed deviation along/about an axis between the actual
-   * tcp position and the one set by the program
+   * \param limits (double) 6d vector. For compliant axes, these values are the maximum allowed tcp speed
+   * along/about the axis. For non-compliant axes, these values are the maximum allowed deviation along/about an axis
+   * between the actual tcp position and the one set by the program
    *
    * \returns True, if the write was performed successfully, false otherwise.
    */

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -21,6 +21,10 @@ MODE_SPEEDJ = 2
 MODE_FORWARD = 3
 MODE_SPEEDL = 4
 MODE_POSE = 5
+MODE_FREEDRIVE = 6
+MODE_TOOL_IN_CONTACT = 7
+# Data dimensions of the message received on the reverse interface
+REVERSE_INTERFACE_DATA_DIMENSION = 8
 
 TRAJECTORY_MODE_RECEIVE = 1
 TRAJECTORY_MODE_CANCEL = -1
@@ -36,7 +40,17 @@ TRAJECTORY_RESULT_FAILURE = 2
 ZERO_FTSENSOR = 0
 SET_PAYLOAD = 1
 SET_TOOL_VOLTAGE = 2
-SCRIPT_COMMAND_DATA_DIMENSION = 5
+START_FORCE_MODE = 3
+END_FORCE_MODE = 4
+START_TOOL_CONTACT = 5
+END_TOOL_CONTACT = 6
+SCRIPT_COMMAND_DATA_DIMENSION = 26
+
+FREEDRIVE_MODE_START = 1
+FREEDRIVE_MODE_STOP = -1
+
+UNTIL_TOOL_CONTACT_RESULT_SUCCESS = 0
+UNTIL_TOOL_CONTACT_RESULT_CANCELED = 1
 
 #Global variables are also showed in the Teach pendants variable list
 global cmd_servo_state = SERVO_UNINITIALIZED
@@ -48,6 +62,12 @@ global extrapolate_count = 0
 global extrapolate_max_count = 0
 global control_mode = MODE_UNINITIALIZED
 global trajectory_points_left = 0
+global tool_contact_running = False
+
+# Global thread variables
+thread_move = 0
+thread_trajectory = 0
+thread_script_commands = 0
 
 def set_servo_setpoint(q):
   cmd_servo_state = SERVO_RUNNING
@@ -218,7 +238,34 @@ def set_servo_pose(pose):
   cmd_servo_q = get_inverse_kin(pose, cmd_servo_q)
 end
 
-# Thread to receive script commands
+def tool_contact_detection():
+  # Detect tool contact in the directions that the TCP is moving
+  step_back = tool_contact(direction = get_actual_tcp_speed())
+
+  # If tool contact is detected stop movement and move back to intial contact point
+  if step_back > 0:
+    if control_mode == MODE_FORWARD:
+      kill thread_trajectory
+      clear_remaining_trajectory_points()
+    elif control_mode == MODE_FREEDRIVE:
+      end_freedrive_mode()
+    else:
+      kill thread_move
+    end
+
+    # Set control mode to tool in contact, should be cleared by stopping tool contact detection
+    control_mode = MODE_TOOL_IN_CONTACT
+    stopl(3)
+
+    # Move to initial contact point
+    q = get_actual_joint_positions_history(step_back)
+    movel(q)
+    socket_send_int(UNTIL_TOOL_CONTACT_RESULT_SUCCESS, "script_command_socket")
+    textmsg("tool contact detected")
+  end
+end
+
+# Thread to receive one shot script commands, the commands shouldn't be blocking
 thread script_commands():
   while control_mode > MODE_STOPPED:
     raw_command = socket_read_binary_integer(SCRIPT_COMMAND_DATA_DIMENSION, "script_command_socket", 0)
@@ -233,41 +280,71 @@ thread script_commands():
       elif command == SET_TOOL_VOLTAGE:
         tool_voltage = raw_command[2] / MULT_jointstate
         set_tool_voltage(tool_voltage)
+      elif command == START_FORCE_MODE:
+        task_frame = p[raw_command[2] / MULT_jointstate, raw_command[3] / MULT_jointstate, raw_command[4] / MULT_jointstate, raw_command[5] / MULT_jointstate, raw_command[6] / MULT_jointstate, raw_command[7] / MULT_jointstate]
+        selection_vector = [raw_command[8] / MULT_jointstate, raw_command[9] / MULT_jointstate, raw_command[10] / MULT_jointstate, raw_command[11] / MULT_jointstate, raw_command[12] / MULT_jointstate, raw_command[13] / MULT_jointstate]
+        wrench = [raw_command[14] / MULT_jointstate, raw_command[15] / MULT_jointstate, raw_command[16] / MULT_jointstate, raw_command[17] / MULT_jointstate, raw_command[18] / MULT_jointstate, raw_command[19] / MULT_jointstate]
+        force_type = raw_command[20] / MULT_jointstate
+        force_limits = [raw_command[21] / MULT_jointstate, raw_command[22] / MULT_jointstate, raw_command[23] / MULT_jointstate, raw_command[24] / MULT_jointstate, raw_command[25] / MULT_jointstate, raw_command[26] / MULT_jointstate]
+        force_mode(task_frame, selection_vector, wrench, force_type, force_limits)
+      elif command == END_FORCE_MODE:
+        end_force_mode()
+      elif command == START_TOOL_CONTACT:
+        tool_contact_running = True
+      elif command == END_TOOL_CONTACT:
+        if control_mode != MODE_TOOL_IN_CONTACT:
+          # If tool contact hasn't been detected send canceled result
+          socket_send_int(UNTIL_TOOL_CONTACT_RESULT_CANCELED, "script_command_socket")
+        end
+        tool_contact_running = False
       end
     end
   end
 end
 
-
 # HEADER_END
 
 # NODE_CONTROL_LOOP_BEGINS
-
 socket_open("{{SERVER_IP_REPLACE}}", {{SERVER_PORT_REPLACE}}, "reverse_socket")
 socket_open("{{SERVER_IP_REPLACE}}", {{TRAJECTORY_SERVER_PORT_REPLACE}}, "trajectory_socket")
 socket_open("{{SERVER_IP_REPLACE}}", {{SCRIPT_COMMAND_SERVER_PORT_REPLACE}}, "script_command_socket")
+
+force_mode_set_damping({{FORCE_MODE_SET_DAMPING_REPLACE}})
+force_mode_set_gain_scaling({{FORCE_MODE_SET_GAIN_SCALING_REPLACE}})
 
 control_mode = MODE_UNINITIALIZED
 thread_move = 0
 thread_trajectory = 0
 trajectory_points_left = 0
 global keepalive = -2
-params_mult = socket_read_binary_integer(1+6+1, "reverse_socket", 0)
+params_mult = socket_read_binary_integer(REVERSE_INTERFACE_DATA_DIMENSION, "reverse_socket", 0)
 textmsg("ExternalControl: External control active")
 keepalive = params_mult[1]
 thread_script_commands = run script_commands()
 while keepalive > 0 and control_mode > MODE_STOPPED:
   enter_critical
-  params_mult = socket_read_binary_integer(1+6+1, "reverse_socket", 0.02) # steptime could work as well, but does not work in simulation
+  params_mult = socket_read_binary_integer(REVERSE_INTERFACE_DATA_DIMENSION, "reverse_socket", 0.02) # steptime could work as well, but does not work in simulation
   if params_mult[0] > 0:
     keepalive = params_mult[1]
-    if control_mode != params_mult[8]:
+    if control_mode != params_mult[REVERSE_INTERFACE_DATA_DIMENSION]:
+      # Clear remaining trajectory points
       if control_mode == MODE_FORWARD:
         kill thread_trajectory
         clear_remaining_trajectory_points()
+      # Stop freedrive
+      elif control_mode == MODE_FREEDRIVE:
+        end_freedrive_mode()
       end
-      control_mode = params_mult[8]
-      join thread_move
+
+      # If tool is in contact, tool contact should be ended before switching control mode
+      if control_mode == MODE_TOOL_IN_CONTACT:
+        if tool_contact_running == False:
+          control_mode = params_mult[REVERSE_INTERFACE_DATA_DIMENSION]
+        end
+      else:
+        control_mode = params_mult[REVERSE_INTERFACE_DATA_DIMENSION]
+        join thread_move
+      end
       if control_mode == MODE_SERVOJ:
         thread_move = run servoThread()
       elif control_mode == MODE_SPEEDJ:
@@ -304,6 +381,16 @@ while keepalive > 0 and control_mode > MODE_STOPPED:
     elif control_mode == MODE_POSE:
       pose = p[params_mult[2] / MULT_jointstate, params_mult[3] / MULT_jointstate, params_mult[4] / MULT_jointstate, params_mult[5] / MULT_jointstate, params_mult[6] / MULT_jointstate, params_mult[7] / MULT_jointstate]
       set_servo_pose(pose)
+    elif control_mode == MODE_FREEDRIVE:
+      if params_mult[2] == FREEDRIVE_MODE_START:
+        freedrive_mode()
+      elif params_mult[2] == FREEDRIVE_MODE_STOP:
+        end_freedrive_mode()
+      end
+    end
+    # Tool contact is running, but hasn't been detected
+    if tool_contact_running == True and control_mode != MODE_TOOL_IN_CONTACT:
+      tool_contact_detection()
     end
   else:
     keepalive = keepalive - 1

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -248,6 +248,7 @@ def tool_contact_detection():
       kill thread_trajectory
       clear_remaining_trajectory_points()
     elif control_mode == MODE_FREEDRIVE:
+      textmsg("Leaving freedrive mode")
       end_freedrive_mode()
     else:
       kill thread_move
@@ -333,6 +334,7 @@ while keepalive > 0 and control_mode > MODE_STOPPED:
         clear_remaining_trajectory_points()
       # Stop freedrive
       elif control_mode == MODE_FREEDRIVE:
+        textmsg("Leaving freedrive mode")
         end_freedrive_mode()
       end
 
@@ -383,8 +385,10 @@ while keepalive > 0 and control_mode > MODE_STOPPED:
       set_servo_pose(pose)
     elif control_mode == MODE_FREEDRIVE:
       if params_mult[2] == FREEDRIVE_MODE_START:
+        textmsg("Entering freedrive mode")
         freedrive_mode()
       elif params_mult[2] == FREEDRIVE_MODE_STOP:
+        textmsg("Leaving freedrive mode")
         end_freedrive_mode()
       end
     end

--- a/src/control/script_command_interface.cpp
+++ b/src/control/script_command_interface.cpp
@@ -106,6 +106,114 @@ bool ScriptCommandInterface::setToolVoltage(const ToolVoltage voltage)
   return server_.write(client_fd_, buffer, sizeof(buffer), written);
 }
 
+bool ScriptCommandInterface::startForceMode(const vector6d_t* task_frame, const vector6uint32_t* selection_vector,
+                                            const vector6d_t* wrench, const unsigned int type, const vector6d_t* limits)
+{
+  const int message_length = 26;
+  uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];
+  uint8_t* b_pos = buffer;
+
+  int32_t val = htobe32(toUnderlying(ScriptCommand::START_FORCE_MODE));
+  b_pos += append(b_pos, val);
+
+  for (auto const& frame : *task_frame)
+  {
+    val = htobe32(static_cast<int32_t>(frame * MULT_JOINTSTATE));
+    b_pos += append(b_pos, val);
+  }
+
+  for (auto const& selection : *selection_vector)
+  {
+    val = htobe32(static_cast<int32_t>(selection * MULT_JOINTSTATE));
+    b_pos += append(b_pos, val);
+  }
+
+  for (auto const& force_torque : *wrench)
+  {
+    val = htobe32(static_cast<int32_t>(force_torque * MULT_JOINTSTATE));
+    b_pos += append(b_pos, val);
+  }
+
+  val = htobe32(static_cast<int32_t>(type * MULT_JOINTSTATE));
+  b_pos += append(b_pos, val);
+
+  for (auto const& lim : *limits)
+  {
+    val = htobe32(static_cast<int32_t>(lim * MULT_JOINTSTATE));
+    b_pos += append(b_pos, val);
+  }
+
+  // writing zeros to allow usage with other script commands
+  for (size_t i = message_length; i < MAX_MESSAGE_LENGTH; i++)
+  {
+    val = htobe32(0);
+    b_pos += append(b_pos, val);
+  }
+  size_t written;
+
+  return server_.write(client_fd_, buffer, sizeof(buffer), written);
+}
+
+bool ScriptCommandInterface::endForceMode()
+{
+  const int message_length = 1;
+  uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];
+  uint8_t* b_pos = buffer;
+
+  int32_t val = htobe32(toUnderlying(ScriptCommand::END_FORCE_MODE));
+  b_pos += append(b_pos, val);
+
+  // writing zeros to allow usage with other script commands
+  for (size_t i = message_length; i < MAX_MESSAGE_LENGTH; i++)
+  {
+    val = htobe32(0);
+    b_pos += append(b_pos, val);
+  }
+  size_t written;
+
+  return server_.write(client_fd_, buffer, sizeof(buffer), written);
+}
+
+bool ScriptCommandInterface::startToolContact()
+{
+  const int message_length = 1;
+  uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];
+  uint8_t* b_pos = buffer;
+
+  int32_t val = htobe32(toUnderlying(ScriptCommand::START_TOOL_CONTACT));
+  b_pos += append(b_pos, val);
+
+  // writing zeros to allow usage with other script commands
+  for (size_t i = message_length; i < MAX_MESSAGE_LENGTH; i++)
+  {
+    val = htobe32(0);
+    b_pos += append(b_pos, val);
+  }
+  size_t written;
+
+  return server_.write(client_fd_, buffer, sizeof(buffer), written);
+}
+
+bool ScriptCommandInterface::endToolContact()
+{
+  const int message_length = 1;
+  uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];
+  uint8_t* b_pos = buffer;
+
+  int32_t val = htobe32(toUnderlying(ScriptCommand::END_TOOL_CONTACT));
+  b_pos += append(b_pos, val);
+
+  // writing zeros to allow usage with other script commands
+  for (size_t i = message_length; i < MAX_MESSAGE_LENGTH; i++)
+  {
+    val = htobe32(0);
+    b_pos += append(b_pos, val);
+  }
+  size_t written;
+
+  return server_.write(client_fd_, buffer, sizeof(buffer), written);
+}
+
 bool ScriptCommandInterface::clientConnected()
 {
   return client_connected_;
@@ -135,8 +243,25 @@ void ScriptCommandInterface::disconnectionCallback(const int filedescriptor)
 
 void ScriptCommandInterface::messageCallback(const int filedescriptor, char* buffer, int nbytesrecv)
 {
-  URCL_LOG_WARN("Message on script command interface received. The script command interfacee currently does not "
-                "support any message handling. This message will be ignored.");
+  if (nbytesrecv == 4)
+  {
+    int32_t* status = reinterpret_cast<int*>(buffer);
+    URCL_LOG_DEBUG("Received message %d on Script command interface", be32toh(*status));
+
+    if (handle_tool_contact_result_)
+    {
+      handle_tool_contact_result_(static_cast<ToolContactResult>(be32toh(*status)));
+    }
+    else
+    {
+      URCL_LOG_DEBUG("Tool contact execution finished with result %d, but no callback was given.", be32toh(*status));
+    }
+  }
+  else
+  {
+    URCL_LOG_WARN("Received %d bytes on script command interface. Expecting 4 bytes, so ignoring this message",
+                  nbytesrecv);
+  }
 }
 
 }  // namespace control

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -134,10 +134,10 @@ urcl::UrDriver::UrDriver(const std::string& robot_ip, const std::string& script_
     if (force_mode_damping < 0 || force_mode_damping > 1)
     {
       std::stringstream ss;
-      ss << "Force mode damping, should be between 0 and 1, but it is " << force_mode_damping
-         << " setting it to default 0.5";
-      URCL_LOG_ERROR(ss.str().c_str());
+      ss << "Force mode damping, should be between 0 and 1, but it is " << force_mode_damping;
       force_mode_damping = 0.025;
+      ss << " setting it to default " << force_mode_damping;
+      URCL_LOG_ERROR(ss.str().c_str());
     }
     prog.replace(prog.find(FORCE_MODE_SET_DAMPING_REPLACE), FORCE_MODE_SET_DAMPING_REPLACE.length(),
                  std::to_string(force_mode_damping));
@@ -158,10 +158,10 @@ urcl::UrDriver::UrDriver(const std::string& robot_ip, const std::string& script_
       if (force_mode_gain_scaling < 0 || force_mode_gain_scaling > 2)
       {
         std::stringstream ss;
-        ss << "Force mode gain scaling, should be between 0 and 2, but it is " << force_mode_gain_scaling
-           << " setting it to default 0.5";
-        URCL_LOG_ERROR(ss.str().c_str());
+        ss << "Force mode gain scaling, should be between 0 and 2, but it is " << force_mode_gain_scaling;
         force_mode_gain_scaling = 0.5;
+        ss << " setting it to default " << force_mode_gain_scaling;
+        URCL_LOG_ERROR(ss.str().c_str());
       }
       prog.replace(prog.find(FORCE_MODE_SET_GAIN_SCALING_REPLACE), FORCE_MODE_SET_GAIN_SCALING_REPLACE.length(),
                    std::to_string(force_mode_gain_scaling));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,6 +194,7 @@ target_compile_options(pipeline_tests PRIVATE ${CXX17_FLAG})
 target_include_directories(pipeline_tests PRIVATE ${GTEST_INCLUDE_DIRS})
 target_link_libraries(pipeline_tests PRIVATE ur_client_library::urcl ${GTEST_LIBRARIES})
 gtest_add_tests(TARGET pipeline_tests
+)
 
 add_executable(script_command_interface_tests test_script_command_interface.cpp)
 target_compile_options(script_command_interface_tests PRIVATE ${CXX17_FLAG})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,4 +194,10 @@ target_compile_options(pipeline_tests PRIVATE ${CXX17_FLAG})
 target_include_directories(pipeline_tests PRIVATE ${GTEST_INCLUDE_DIRS})
 target_link_libraries(pipeline_tests PRIVATE ur_client_library::urcl ${GTEST_LIBRARIES})
 gtest_add_tests(TARGET pipeline_tests
+
+add_executable(script_command_interface_tests test_script_command_interface.cpp)
+target_compile_options(script_command_interface_tests PRIVATE ${CXX17_FLAG})
+target_include_directories(script_command_interface_tests PRIVATE ${GTEST_INCLUDE_DIRS})
+target_link_libraries(script_command_interface_tests PRIVATE ur_client_library::urcl ${GTEST_LIBRARIES})
+gtest_add_tests(TARGET script_command_interface_tests
 )

--- a/tests/test_reverse_interface.cpp
+++ b/tests/test_reverse_interface.cpp
@@ -136,6 +136,16 @@ protected:
       return pos[1];
     }
 
+    int32_t getFreedriveControlMode()
+    {
+      // received_pos[0]=control::FreedriveControlMessage, when writing a trajectory control message
+      int32_t keep_alive_signal;
+      int32_t control_mode;
+      vector6int32_t pos;
+      readMessage(keep_alive_signal, pos, control_mode);
+      return pos[0];
+    }
+
   protected:
     virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
     {
@@ -358,6 +368,30 @@ TEST_F(ReverseIntefaceTest, write_control_mode)
   received_control_mode = client_->getControlMode();
 
   EXPECT_EQ(toUnderlying(expected_control_mode), received_control_mode);
+}
+
+TEST_F(ReverseIntefaceTest, write_freedrive_control_message)
+{
+  // Wait for the client to connect to the server
+  EXPECT_TRUE(waitForProgramState(1000, true));
+
+  control::FreedriveControlMessage written_freedrive_message = control::FreedriveControlMessage::FREEDRIVE_STOP;
+  reverse_interface_->writeFreedriveControlMessage(written_freedrive_message);
+  int32_t received_freedrive_message = client_->getFreedriveControlMode();
+
+  EXPECT_EQ(toUnderlying(written_freedrive_message), received_freedrive_message);
+
+  written_freedrive_message = control::FreedriveControlMessage::FREEDRIVE_NOOP;
+  reverse_interface_->writeFreedriveControlMessage(written_freedrive_message);
+  received_freedrive_message = client_->getFreedriveControlMode();
+
+  EXPECT_EQ(toUnderlying(written_freedrive_message), received_freedrive_message);
+
+  written_freedrive_message = control::FreedriveControlMessage::FREEDRIVE_START;
+  reverse_interface_->writeFreedriveControlMessage(written_freedrive_message);
+  received_freedrive_message = client_->getFreedriveControlMode();
+
+  EXPECT_EQ(toUnderlying(written_freedrive_message), received_freedrive_message);
 }
 
 int main(int argc, char* argv[])

--- a/tests/test_script_command_interface.cpp
+++ b/tests/test_script_command_interface.cpp
@@ -1,0 +1,385 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2022 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#include <gtest/gtest.h>
+#include <iterator>
+#include <numeric>
+
+#include <ur_client_library/control/script_command_interface.h>
+#include <ur_client_library/comm/tcp_socket.h>
+
+using namespace urcl;
+
+class ScriptCommandInterfaceTest : public ::testing::Test
+{
+protected:
+  class Client : public comm::TCPSocket
+  {
+  public:
+    Client(const int& port)
+    {
+      std::string host = "127.0.0.1";
+      TCPSocket::setup(host, port);
+      timeval tv;
+      tv.tv_sec = 1;
+      tv.tv_usec = 0;
+      TCPSocket::setReceiveTimeout(tv);
+    }
+
+    void send(const int32_t& result)
+    {
+      uint8_t buffer[sizeof(int32_t)];
+      int32_t val = htobe32(result);
+      std::memcpy(buffer, &val, sizeof(int32_t));
+      size_t written = 0;
+      TCPSocket::write(buffer, sizeof(buffer), written);
+    }
+
+    void readMessage(int32_t& command, std::vector<int32_t>& message)
+    {
+      // Max message length is 26
+      uint8_t buf[sizeof(int32_t) * 26];
+      uint8_t* b_pos = buf;
+      size_t read = 0;
+      size_t remainder = sizeof(int32_t) * 26;
+      while (remainder > 0)
+      {
+        if (!TCPSocket::read(b_pos, remainder, read))
+        {
+          std::cout << "Failed to read from socket, this should not happen during a test!" << std::endl;
+          break;
+        }
+        b_pos += read;
+        remainder -= read;
+      }
+
+      // Reset buffer pos for parsing
+      b_pos = buf;
+      uint8_t* b_end = b_pos + read;
+
+      // Decode command signal
+      int32_t val;
+      std::memcpy(&val, b_pos, sizeof(int32_t));
+      command = be32toh(val);
+      b_pos += sizeof(int32_t);
+
+      // Decode remainder of message
+      while (b_pos < b_end)
+      {
+        std::memcpy(&val, b_pos, sizeof(int32_t));
+        message.push_back(be32toh(val));
+        b_pos += sizeof(int32_t);
+      }
+    }
+
+  protected:
+    virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
+    {
+      return ::connect(socket_fd, address, address_len) == 0;
+    }
+  };
+
+  void SetUp()
+  {
+    script_command_interface_.reset(new control::ScriptCommandInterface(50004));
+    client_.reset(new Client(50004));
+  }
+
+  void TearDown()
+  {
+    if (script_command_interface_->clientConnected() == true)
+    {
+      client_->close();
+      waitForClientConnection(false);
+    }
+  }
+
+  bool waitForClientConnection(bool client_connected = true,
+                               std::chrono::duration<double> timeout = std::chrono::milliseconds(1000))
+  {
+    const std::chrono::duration<double> wait_period = std::chrono::milliseconds(50);
+    std::chrono::duration<double> time_done(0);
+    while (time_done < timeout)
+    {
+      if (script_command_interface_->clientConnected() == client_connected)
+      {
+        return true;
+      }
+      std::this_thread::sleep_for(wait_period);
+      time_done += wait_period;
+    }
+    return false;
+  }
+
+  bool waitToolContactResult(control::ToolContactResult result, int milliseconds = 1000)
+  {
+    std::unique_lock<std::mutex> lk(tool_contact_result_mutex_);
+    if (tool_contact_result_.wait_for(lk, std::chrono::milliseconds(milliseconds)) == std::cv_status::no_timeout ||
+        received_result_ == result)
+    {
+      if (received_result_ == result)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::unique_ptr<control::ScriptCommandInterface> script_command_interface_;
+  std::unique_ptr<Client> client_;
+  control::ToolContactResult received_result_;
+
+public:
+  void handleToolContactResult(control::ToolContactResult result)
+  {
+    std::lock_guard<std::mutex> lk(tool_contact_result_mutex_);
+    tool_contact_result_.notify_one();
+    received_result_ = result;
+  }
+
+private:
+  std::condition_variable tool_contact_result_;
+  std::mutex tool_contact_result_mutex_;
+};
+
+TEST_F(ScriptCommandInterfaceTest, test_zero_ft_sensor)
+{
+  // Wait for the client to connect to the server
+  waitForClientConnection();
+
+  script_command_interface_->zeroFTSensor();
+  int32_t command;
+  std::vector<int32_t> message;
+  client_->readMessage(command, message);
+
+  // 0 is zero ft sensor
+  int32_t expected_command = 0;
+  EXPECT_EQ(command, expected_command);
+
+  // The rest of the message should be zero
+  int32_t message_sum = std::accumulate(std::begin(message), std::end(message), 0);
+  int32_t expected_message_sum = 0;
+  EXPECT_EQ(message_sum, expected_message_sum);
+}
+
+TEST_F(ScriptCommandInterfaceTest, test_set_payload)
+{
+  // Wait for the client to connect to the server
+  waitForClientConnection();
+
+  double mass = 1.0;
+  vector3d_t cog = { 0.2, 0.3, 0.1 };
+  script_command_interface_->setPayload(mass, &cog);
+  int32_t command;
+  std::vector<int32_t> message;
+  client_->readMessage(command, message);
+
+  // 1 is set payload
+  int32_t expected_command = 1;
+  EXPECT_EQ(command, expected_command);
+
+  // Test mass
+  double received_mass = (double)message[0] / script_command_interface_->MULT_JOINTSTATE;
+  EXPECT_EQ(received_mass, mass);
+
+  // Test cog
+  vector3d_t received_cog;
+  for (unsigned int i = 0; i < cog.size(); ++i)
+  {
+    received_cog[i] = (double)message[i + 1] / script_command_interface_->MULT_JOINTSTATE;
+    EXPECT_EQ(received_cog[i], cog[i]);
+  }
+
+  // The rest of the message should be zero
+  int32_t message_sum = std::accumulate(std::begin(message) + 4, std::end(message), 0);
+  int32_t expected_message_sum = 0;
+  EXPECT_EQ(message_sum, expected_message_sum);
+}
+
+TEST_F(ScriptCommandInterfaceTest, test_set_tool_voltage)
+{
+  // Wait for the client to connect to the server
+  waitForClientConnection();
+
+  ToolVoltage tool_voltage = ToolVoltage::_12V;
+  script_command_interface_->setToolVoltage(tool_voltage);
+  int32_t command;
+  std::vector<int32_t> message;
+  client_->readMessage(command, message);
+
+  // 2 is set tool voltage
+  int32_t expected_command = 2;
+  EXPECT_EQ(command, expected_command);
+
+  // Test tool voltage
+  int received_tool_voltage = message[0] / script_command_interface_->MULT_JOINTSTATE;
+  EXPECT_EQ(received_tool_voltage, toUnderlying(tool_voltage));
+
+  // The rest of the message should be zero
+  int32_t message_sum = std::accumulate(std::begin(message) + 1, std::end(message), 0);
+  int32_t expected_message_sum = 0;
+  EXPECT_EQ(message_sum, expected_message_sum);
+}
+
+TEST_F(ScriptCommandInterfaceTest, test_force_mode)
+{
+  // Wait for the client to connect to the server
+  waitForClientConnection();
+
+  urcl::vector6d_t task_frame = { 0.1, 0, 0, 0, 0, 0.785 };
+  urcl::vector6uint32_t selection_vector = { 0, 0, 1, 0, 0, 0 };
+  urcl::vector6d_t wrench = { 20, 0, 40, 0, 0, 0 };
+  int32_t force_mode_type = 2;
+  urcl::vector6d_t limits = { 0.1, 0.1, 0.1, 0.785, 0.785, 1.57 };
+  script_command_interface_->startForceMode(&task_frame, &selection_vector, &wrench, force_mode_type, &limits);
+
+  int32_t command;
+  std::vector<int32_t> message;
+  client_->readMessage(command, message);
+
+  // 3 is start force mode
+  int32_t expected_command = 3;
+  EXPECT_EQ(command, expected_command);
+
+  // Test task frame
+  vector6d_t received_task_frame;
+  for (unsigned int i = 0; i < task_frame.size(); ++i)
+  {
+    received_task_frame[i] = (double)message[i] / script_command_interface_->MULT_JOINTSTATE;
+    EXPECT_EQ(received_task_frame[i], task_frame[i]);
+  }
+
+  // Test selection vector
+  vector6uint32_t received_selection_vector;
+  for (unsigned int i = 0; i < selection_vector.size(); ++i)
+  {
+    received_selection_vector[i] = message[i + 6] / script_command_interface_->MULT_JOINTSTATE;
+    EXPECT_EQ(received_selection_vector[i], selection_vector[i]);
+  }
+
+  // Test wrench
+  vector6d_t received_wrench;
+  for (unsigned int i = 0; i < wrench.size(); ++i)
+  {
+    received_wrench[i] = (double)message[i + 12] / script_command_interface_->MULT_JOINTSTATE;
+    EXPECT_EQ(received_wrench[i], wrench[i]);
+  }
+
+  // Test force mode type
+  int32_t received_force_mode_type = message[18] / script_command_interface_->MULT_JOINTSTATE;
+  EXPECT_EQ(received_force_mode_type, force_mode_type);
+
+  // Test limits
+  vector6d_t received_limits;
+  for (unsigned int i = 0; i < wrench.size(); ++i)
+  {
+    received_limits[i] = (double)message[i + 19] / script_command_interface_->MULT_JOINTSTATE;
+    EXPECT_EQ(received_limits[i], limits[i]);
+  }
+
+  // The rest of the message should be zero
+  int32_t message_sum = std::accumulate(std::begin(message) + 25, std::end(message), 0);
+  int32_t expected_message_sum = 0;
+  EXPECT_EQ(message_sum, expected_message_sum);
+
+  // End force mode
+  script_command_interface_->endForceMode();
+  message.clear();
+  client_->readMessage(command, message);
+
+  // 4 is end force mode
+  expected_command = 4;
+  EXPECT_EQ(command, expected_command);
+
+  // The rest of the message should be zero
+  message_sum = std::accumulate(std::begin(message), std::end(message), 0);
+  EXPECT_EQ(message_sum, expected_message_sum);
+}
+
+TEST_F(ScriptCommandInterfaceTest, test_tool_contact)
+{
+  // Wait for the client to connect to the server
+  waitForClientConnection();
+
+  script_command_interface_->startToolContact();
+
+  int32_t command;
+  std::vector<int32_t> message;
+  client_->readMessage(command, message);
+
+  // 5 is start tool contact
+  int32_t expected_command = 5;
+  EXPECT_EQ(command, expected_command);
+
+  // The rest of the message should be zero
+  int32_t message_sum = std::accumulate(std::begin(message) + 25, std::end(message), 0);
+  int32_t expected_message_sum = 0;
+  EXPECT_EQ(message_sum, expected_message_sum);
+
+  // End tool contact
+  script_command_interface_->endToolContact();
+
+  message.clear();
+  client_->readMessage(command, message);
+  // 6 is end tool contact
+  expected_command = 6;
+  EXPECT_EQ(command, expected_command);
+
+  // The rest of the message should be zero
+  message_sum = std::accumulate(std::begin(message) + 25, std::end(message), 0);
+  EXPECT_EQ(message_sum, expected_message_sum);
+}
+
+TEST_F(ScriptCommandInterfaceTest, test_tool_contact_callback)
+{
+  // Wait for the client to connect to the server
+  waitForClientConnection();
+  script_command_interface_->setToolContactResultCallback(
+      std::bind(&ScriptCommandInterfaceTest::handleToolContactResult, this, std::placeholders::_1));
+
+  control::ToolContactResult send_result = control::ToolContactResult::UNTIL_TOOL_CONTACT_RESULT_CANCELED;
+  client_->send(toUnderlying(send_result));
+  waitToolContactResult(send_result);
+
+  EXPECT_EQ(toUnderlying(received_result_), toUnderlying(send_result));
+
+  send_result = control::ToolContactResult::UNTIL_TOOL_CONTACT_RESULT_SUCCESS;
+  client_->send(toUnderlying(send_result));
+  waitToolContactResult(send_result);
+
+  EXPECT_EQ(toUnderlying(received_result_), toUnderlying(send_result));
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit includes following changes:
 * New control mode for freedrive
 * New control mode for when the tool is in contact
 * Commands for stopping and starting tool contact
 * Commands for stopping and starting force mode
 * Added force_mode_damping and force_mode_gain_scaling to the constructor
 * Force mode gain scaling is only available for e-series and therefore it is removed from the control script, when the robot is not e-series
 * Tool contact example
 * Test for script command interface
 * Updated test for reverse interface

This PR will require some changes to the ROS and ROS2 drivers, in order for them to use the added commands. 