### PR TITLE
Remove Foxy from CI

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -38,16 +38,6 @@ jobs:
             URSIM_VERSION: '5.5.1'
             ROBOT_MODEL: 'ur5e'
             PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
-          - ROS_DISTRO: foxy
-            ROS_REPO: main
-            IMMEDIATE_TEST_OUTPUT: true
-            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#foxy"
-            DOCKER_RUN_OPTS: --network ursim_net
-            BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
-            URSIM_VERSION: '5.5.1'
-            ROBOT_MODEL: 'ur5e'
-            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
-            NOT_TEST_DOWNSTREAM: true
           - ROS_DISTRO: galactic
             ROS_REPO: main
             IMMEDIATE_TEST_OUTPUT: true

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -18,8 +18,6 @@ jobs:
             OS_VERSION: bionic
           - ROS_DISTRO: noetic
             OS_VERSION: focal
-          - ROS_DISTRO: foxy
-            OS_VERSION: focal
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Since the Foxy prerelease tests start throwing errors and Foxy is EOL, I think we can drop Foxy from our CI.