### PR TITLE
Install start ursim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,15 @@ install(EXPORT urcl_targets
   FILE urclTargets.cmake
   NAMESPACE ur_client_library::)
 
-install(PROGRAMS scripts/start_ursim.sh
-  DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+if(COMMAND catkin_install_python)
+  catkin_install_python(PROGRAMS scripts/start_ursim.sh
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  )
+else()
+  install(PROGRAMS scripts/start_ursim.sh
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ur_client_libraryConfigVersion.cmake VERSION 0.0.3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,8 @@ install(EXPORT urcl_targets
   FILE urclTargets.cmake
   NAMESPACE ur_client_library::)
 
-if(COMMAND catkin_install_python)
-  catkin_install_python(PROGRAMS scripts/start_ursim.sh
+if(CATKIN_PACKAGE_BIN_DESTINATION)
+  install(PROGRAMS scripts/start_ursim.sh
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,10 @@ install(EXPORT urcl_targets
   FILE urclTargets.cmake
   NAMESPACE ur_client_library::)
 
+install(FILES scripts/start_ursim.sh
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ur_client_libraryConfigVersion.cmake VERSION 0.0.3
   COMPATIBILITY SameMajorVersion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ install(EXPORT urcl_targets
   FILE urclTargets.cmake
   NAMESPACE ur_client_library::)
 
-install(FILES scripts/start_ursim.sh
+install(PROGRAMS scripts/start_ursim.sh
   DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 PERSISTENT_BASE="${HOME}/.ursim"
+URCAP_VERSION="1.0.5"
 
 help()
 {
@@ -137,6 +138,12 @@ mkdir -p "${URCAP_STORAGE}"
 mkdir -p "${PROGRAM_STORAGE}"
 URCAP_STORAGE=$(realpath "$URCAP_STORAGE")
 PROGRAM_STORAGE=$(realpath "$PROGRAM_STORAGE")
+
+# Download external_control URCap
+if [[ ! -f "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" ]]; then
+  curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" \
+    "https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/releases/download/v${URCAP_VERSION}/externalcontrol-${URCAP_VERSION}.jar"
+fi
 
 
 # Check whether network already exists


### PR DESCRIPTION
This PR installs the start_ursim script to the package's install space. This way, it can be reused in downstream packages such as the ROS drivers.