### PR TITLE
Use pre-commit for clang-format

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -2,17 +2,6 @@ name: ROS industrial ci
 on: [push, pull_request]
 
 jobs:
-  format_check:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: 'ros-industrial/industrial_ci@master'
-      env:
-        ROS_DISTRO: melodic
-        CLANG_FORMAT_CHECK: file
-        CLANG_FORMAT_VERSION: "9"
-
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,27 @@
+# This is a format job. Pre-commit has a first-party GitHub action, so we use
+# that: https://github.com/pre-commit/action
+
+name: pre-commit
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.10.4
+    - name: Install system hooks
+      run: sudo apt-get install clang-format-14 cppcheck
+    - uses: pre-commit/action@v3.0.0
+      with:
+        extra_args: --all-files --hook-stage manual
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,5 @@
 repos:
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v14.0.6'
     hooks:
-      - id: clang-format
-        name: clang-format
-        description: Format files with ClangFormat.
-        entry: clang-format-14
-        language: system
-        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
-        args: ['-fallback-style=none', '-i']
-
+    -   id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        description: Format files with ClangFormat.
+        entry: clang-format-14
+        language: system
+        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
+        args: ['-fallback-style=none', '-i']
+

--- a/README.md
+++ b/README.md
@@ -381,6 +381,19 @@ int main(int argc, char* argv[])
 }
 ```
 
+## Contributor Guidelines
+* This repo supports [pre-commit](https://pre-commit.com/) e.g. for automatic code formatting. TLDR:
+  This will prevent you from committing falsely formatted code:
+  ```
+  pipx install pre-commit
+  pre-commit install
+  ```
+* Succeeding pipelines are a must on Pull Requests (unless there is a reason, e.g. when there have
+been upstream changes).
+* We try to increase and keep our code coverage high, so PRs with new
+features should also have tests covering them.
+* Parameters of public methods must all be documented.
+
 ## Acknowledgment
 Many parts of this library are forked from the [ur_modern_driver](https://github.com/ros-industrial/ur_modern_driver).
 


### PR DESCRIPTION
It has bothered be for quite a while that we have so many "code formatting" commit inside our PRs. Using pre-commit enables us to check formatting **before** we actually push something.