### PR TITLE
Make depreaction warning for keepalive_counter a warning instead of error

### DIFF
--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -585,11 +585,11 @@ std::vector<std::string> UrDriver::getRTDEOutputRecipe()
 
 void UrDriver::setKeepaliveCount(const uint32_t count)
 {
-  URCL_LOG_ERROR("DEPRECATION NOTICE: Setting the keepalive count has been deprecated. Instead use the "
-                 "RobotReceiveTimeout, to set the timeout directly in the write commands. Please change your code to "
-                 "set the "
-                 "read timeout in the write commands directly. This keepalive count will overwrite the timeout passed "
-                 "to the write functions.");
+  URCL_LOG_WARN("DEPRECATION NOTICE: Setting the keepalive count has been deprecated. Instead use the "
+                "RobotReceiveTimeout, to set the timeout directly in the write commands. Please change your code to "
+                "set the "
+                "read timeout in the write commands directly. This keepalive count will overwrite the timeout passed "
+                "to the write functions.");
   reverse_interface_->setKeepaliveCount(count);
 }
 


### PR DESCRIPTION
As suggested in #180 

I overlooked that when reviewing #178, but noticed that when starting a driver built against the newest version.