### PR TITLE
Wait after docker kill to prevent name conflicts

### DIFF
--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -180,7 +180,15 @@ docker run --rm -d --net ursim_net --ip 192.168.56.101\
   --name ursim \
   universalrobots/ursim_${ROBOT_SERIES}:$URSIM_VERSION || exit
 
-trap "echo killing; docker container kill ursim; exit" SIGINT SIGTERM
+# Stop container when interrupted
+TRAP_CMD="
+echo \"killing ursim\";
+docker container kill ursim >> /dev/null;
+docker container wait ursim >> /dev/null;
+echo \"done\";
+exit
+"
+trap "$TRAP_CMD" SIGINT SIGTERM
 
 echo "Docker URSim is running"
 printf "\nTo access Polyscope, open the following URL in a web browser.\n\thttp://192.168.56.101:6080/vnc.html\n\n"


### PR DESCRIPTION
While working on ros2 driver unit tests, i noticed sporadically failing tests with the error message

```
2: [INFO] [start_ursim-15]: process started with pid [88538]
2: [start_ursim-15] ursim_net already exists
2: [start_ursim-15] docker: Error response from daemon: Conflict. The container name "/ursim" is already in use by container "f3ac67680b8da8c476966ac9b3ee2a4193b273379fa584647663bf5eb478c590". You have to remove (or rename) that container to be able to reuse that name.
2: [start_ursim-15] See 'docker run --help'.
2: [ERROR] [start_ursim-15]: process has died [pid 88538, exit code 125, cmd '/home/wilbrandt/robot_folders/checkout/ur_rolling/colcon_ws/install/ur_client_library/lib/ur_client_library/start_ursim.sh -m  ur5e'].
```

I also found examples for this in our CI, e.g. https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/runs/6464858675/job/17550136726

Using `docker wait` after `docker kill` seems to fix this for me.