### PR TITLE
Changed spline interpolation to use the last commanded joint velocity…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
             --exclude=tcp_socket.cpp \
             --exclude-dir=debian \
             --exclude=real_time.md \
+            --exclude=dataflow.graphml \
             --exclude=start_ursim.sh
 
   rosdoc_lite_check:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: sudo apt-get install -y python3-pip
+      - run: sudo pip3 install empy==3.3.4  # Added as bloom not yet support empy v4
       - run: sudo pip3 install bloom rosdep
       - run: sudo rosdep init
       - run: rosdep update --rosdistro=${{ matrix.ROS_DISTRO }}

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -68,8 +68,8 @@ global extrapolate_count = 0
 global extrapolate_max_count = 0
 global control_mode = MODE_UNINITIALIZED
 global trajectory_points_left = 0
-global last_spline_qdd = [0, 0, 0, 0, 0, 0]
-global last_spline_qd = [0, 0, 0, 0, 0, 0]
+global spline_qdd = [0, 0, 0, 0, 0, 0]
+global spline_qd = [0, 0, 0, 0, 0, 0]
 global tool_contact_running = False
 
 # Global thread variables
@@ -151,7 +151,7 @@ def cubicSplineRun(end_q, end_qd, time, is_last_point=False):
   # Zero time means zero length and therefore no motion to execute
   if time > 0.0:
     local start_q = get_target_joint_positions()
-    local start_qd = last_spline_qd
+    local start_qd = spline_qd
 
     # Coefficients0 is not included, since we do not need to calculate the position
     local coefficients1 = start_qd
@@ -170,8 +170,8 @@ def quinticSplineRun(end_q, end_qd, end_qdd, time, is_last_point=False):
   # Zero time means zero length and therefore no motion to execute
   if time > 0.0:
     local start_q = get_target_joint_positions()
-    local start_qd = last_spline_qd
-    local start_qdd = last_spline_qdd
+    local start_qd = spline_qd
+    local start_qdd = spline_qdd
 
     # Pre-calculate coefficients
     local TIME2 = pow(time, 2)
@@ -265,16 +265,15 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
 end
 
 def jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, timestep, scaling_factor, is_slowing_down=False):
-  last_spline_qd = coefficients1 + 2.0 * splineTimerTraveled * coefficients2 + 3.0 * pow(splineTimerTraveled, 2) * coefficients3 + 4.0 * pow(splineTimerTraveled, 3) * coefficients4 + 5.0 * pow(splineTimerTraveled, 4) * coefficients5
-  last_spline_qdd = 2.0 * coefficients2 + 6.0 * splineTimerTraveled * coefficients3 + 12.0 * pow(splineTimerTraveled, 2) * coefficients4 + 20.0 * pow(splineTimerTraveled, 3) * coefficients5
+  local last_spline_qd = spline_qd
+  spline_qd = coefficients1 + 2.0 * splineTimerTraveled * coefficients2 + 3.0 * pow(splineTimerTraveled, 2) * coefficients3 + 4.0 * pow(splineTimerTraveled, 3) * coefficients4 + 5.0 * pow(splineTimerTraveled, 4) * coefficients5
+  spline_qdd = 2.0 * coefficients2 + 6.0 * splineTimerTraveled * coefficients3 + 12.0 * pow(splineTimerTraveled, 2) * coefficients4 + 20.0 * pow(splineTimerTraveled, 3) * coefficients5
 
-  if is_slowing_down:
-    last_spline_qd = last_spline_qd * scaling_factor
-    speedj(last_spline_qd, 15.0, timestep)
-  else:
-    max_qdd = list_max_norm(last_spline_qdd)
-    speedj(last_spline_qd, max_qdd, timestep)
-  end
+  spline_qd = spline_qd * scaling_factor
+
+  # Calculate the max needed qdd arg for speedj to distribute the velocity change over the whole timestep no matter the speed slider value
+  qdd_max = list_max_norm((spline_qd - last_spline_qd) / timestep)
+  speedj(spline_qd, qdd_max, timestep)
 end
 
 # Helper function to see what the velocity will be if we take a full step
@@ -312,13 +311,14 @@ end
 def list_max_norm(list):
   # ensure we have something to iterate over
   local length = get_list_length(list)
-  if  length == 0:
+  if  length < 1:
       popup("Getting the maximum of an empty list is impossible in list_max().", error = True, blocking = True)
+      textmsg("Getting the maximum of an empty list is impossible in list_max()")
       halt
   end
 
   # search for maximum
-  local i = 0
+  local i = 1
   local max = norm(list[0])
   while i < length:
       if norm(list[i]) > max:
@@ -337,8 +337,8 @@ thread trajectoryThread():
   # same index as blend parameter, depending on point type
   local INDEX_SPLINE_TYPE = INDEX_BLEND
   local INDEX_POINT_TYPE = INDEX_BLEND + 1
-  last_spline_qdd = [0, 0, 0, 0, 0, 0]
-  last_spline_qd = [0, 0, 0, 0, 0, 0]
+  spline_qdd = [0, 0, 0, 0, 0, 0]
+  spline_qd = [0, 0, 0, 0, 0, 0]
   enter_critical
   while trajectory_points_left > 0:
     #reading trajectory point + blend radius + type of point (cartesian/joint based)
@@ -359,16 +359,16 @@ thread trajectoryThread():
         movej(q, t=tmptime, r=blend_radius)
 
         # reset old acceleration
-        last_spline_qdd = [0, 0, 0, 0, 0, 0]
-        last_spline_qd = [0, 0, 0, 0, 0, 0]
+        spline_qdd = [0, 0, 0, 0, 0, 0]
+        spline_qd = [0, 0, 0, 0, 0, 0]
 
       # Movel point
       elif raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_CARTESIAN:
         movel(p[q[0], q[1], q[2], q[3], q[4], q[5]], t=tmptime, r=blend_radius)
 
         # reset old acceleration
-        last_spline_qdd = [0, 0, 0, 0, 0, 0]
-        last_spline_qd = [0, 0, 0, 0, 0, 0]
+        spline_qdd = [0, 0, 0, 0, 0, 0]
+        spline_qd = [0, 0, 0, 0, 0, 0]
 
       # Joint spline point
       elif raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_JOINT_SPLINE:
@@ -378,7 +378,7 @@ thread trajectoryThread():
           qd = [ raw_point[7] / MULT_jointstate, raw_point[8] / MULT_jointstate, raw_point[9] / MULT_jointstate, raw_point[10] / MULT_jointstate, raw_point[11] / MULT_jointstate, raw_point[12] / MULT_jointstate]
           cubicSplineRun(q, qd, tmptime, is_last_point)
           # reset old acceleration
-          last_spline_qdd = [0, 0, 0, 0, 0, 0]
+          spline_qdd = [0, 0, 0, 0, 0, 0]
 
         # Quintic spline
         elif raw_point[INDEX_SPLINE_TYPE] == SPLINE_QUINTIC:

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -230,7 +230,6 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
     end
 
     splineTimerTraveled = splineTimerTraveled + scaled_step_time
-    # USED_IN_TEST_SPLINE_INTERPOLATION write_output_float_register(1, splineTimerTraveled)
     jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor, is_slowing_down)
   end
 
@@ -245,7 +244,6 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
       scaled_step_time = get_steptime() * scaling_factor
 
       splineTimerTraveled = splineTimerTraveled + scaled_step_time
-      # USED_IN_TEST_SPLINE_INTERPOLATION write_output_float_register(1, splineTimerTraveled)
       jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor, is_slowing_down)
 
       qd = get_actual_joint_speeds()
@@ -273,6 +271,7 @@ def jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, 
 
   # Calculate the max needed qdd arg for speedj to distribute the velocity change over the whole timestep no matter the speed slider value
   qdd_max = list_max_norm((spline_qd - last_spline_qd) / timestep)
+  # USED_IN_TEST_SPLINE_INTERPOLATION write_output_float_register(1, splineTimerTraveled)
   speedj(spline_qd, qdd_max, timestep)
 end
 
@@ -312,19 +311,20 @@ def list_max_norm(list):
   # ensure we have something to iterate over
   local length = get_list_length(list)
   if  length < 1:
-      popup("Getting the maximum of an empty list is impossible in list_max().", error = True, blocking = True)
-      textmsg("Getting the maximum of an empty list is impossible in list_max()")
-      halt
+    popup("Getting the maximum of an empty list is impossible in list_max().", error = True, blocking = True)
+    textmsg("Getting the maximum of an empty list is impossible in list_max()")
+    halt
   end
 
   # search for maximum
   local i = 1
   local max = norm(list[0])
   while i < length:
-      if norm(list[i]) > max:
-          max = norm(list[i])
-      end
-      i = i + 1
+    local tmp = norm(list[i])
+    if tmp > max:
+      max = tmp
+    end
+    i = i + 1
   end
 
   return max

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -235,18 +235,17 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
 
   # Make sure that we approach zero velocity slowly, when slowing down
   if is_slowing_down == True:
-    local qd = get_actual_joint_speeds()
-    while norm(qd) > 0.00001:
-      local time_left = splineTotalTravelTime - splineTimerTraveled
+    local time_left = splineTotalTravelTime - splineTimerTraveled
 
+    while time_left >= 1e-5:
+      time_left = splineTotalTravelTime - splineTimerTraveled
       # Compute scaling factor based on time left and total slowing down time
       scaling_factor = time_left / slowing_down_time
       scaled_step_time = get_steptime() * scaling_factor
 
       splineTimerTraveled = splineTimerTraveled + scaled_step_time
+    
       jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor, is_slowing_down)
-
-      qd = get_actual_joint_speeds()
     end
     scaling_factor = 0.0
   end

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -69,6 +69,7 @@ global extrapolate_max_count = 0
 global control_mode = MODE_UNINITIALIZED
 global trajectory_points_left = 0
 global last_spline_qdd = [0, 0, 0, 0, 0, 0]
+global last_spline_qd = [0, 0, 0, 0, 0, 0]
 global tool_contact_running = False
 
 # Global thread variables
@@ -143,14 +144,14 @@ thread speedThread():
   stopj(STOPJ_ACCELERATION)
 end
 
-def cubicSplineRun(end_q, end_qd, time, last_point=False):
+def cubicSplineRun(end_q, end_qd, time, is_last_point=False):
   local str = str_cat(end_q, str_cat(end_qd, time))
   textmsg("Cubic spline arg: ", str)
 
   # Zero time means zero length and therefore no motion to execute
   if time > 0.0:
     local start_q = get_target_joint_positions()
-    local start_qd = get_target_joint_speeds()
+    local start_qd = last_spline_qd
 
     # Coefficients0 is not included, since we do not need to calculate the position
     local coefficients1 = start_qd
@@ -158,18 +159,18 @@ def cubicSplineRun(end_q, end_qd, time, last_point=False):
     local coefficients3 = (2 * start_q - 2 * end_q + start_qd * time + end_qd * time) / pow(time, 3)
     local coefficients4 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     local coefficients5 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, time, last_point)
+    jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, time, is_last_point)
   end
 end
 
-def quinticSplineRun(end_q, end_qd, end_qdd, time, last_point=False):
+def quinticSplineRun(end_q, end_qd, end_qdd, time, is_last_point=False):
   local str = str_cat(end_q, str_cat(end_qd, str_cat(end_qdd, time)))
   textmsg("Quintic spline arg: ", str)
 
   # Zero time means zero length and therefore no motion to execute
   if time > 0.0:
     local start_q = get_target_joint_positions()
-    local start_qd = get_target_joint_speeds()
+    local start_qd = last_spline_qd
     local start_qdd = last_spline_qdd
 
     # Pre-calculate coefficients
@@ -180,16 +181,16 @@ def quinticSplineRun(end_q, end_qd, end_qdd, time, last_point=False):
     local coefficients3 = (-20.0 * start_q + 20.0 * end_q - 3.0 * start_qdd * TIME2 + end_qdd * TIME2 - 12.0 * start_qd * time - 8.0 * end_qd * time) / (2.0 * pow(time, 3))
     local coefficients4 = (30.0 * start_q - 30.0 * end_q + 3.0 * start_qdd * TIME2 - 2.0 * end_qdd * TIME2 + 16.0 * start_qd * time + 14.0 * end_qd * time) / (2.0 * pow(time, 4))
     local coefficients5 = (-12.0 * start_q + 12.0 * end_q - start_qdd * TIME2 + end_qdd * TIME2 - 6.0 * start_qd * time - 6.0 * end_qd * time) / (2.0 * pow(time, 5))
-    jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, time, last_point)
+    jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, time, is_last_point)
   end
 end
 
-def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTotalTravelTime, last_point):
+def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTotalTravelTime, is_last_point):
   # Initialize variables
   local splineTimerTraveled = 0.0
   local scaled_step_time = get_steptime()
   local scaling_factor = 1.0
-  local slowing_down = False
+  local is_slowing_down = False
   local slowing_down_time = 0.0
 
   # Interpolate the spline in whole time steps
@@ -205,23 +206,23 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
 
     # If the velocity is too large close to the end of the trajectory we scale the
     # trajectory, such that we follow the positional part of the trajectory, but end with zero velocity.
-    if (time_left <= deceleration_time) and (last_point == True):
-      if slowing_down == False:
+    if (time_left <= deceleration_time) and (is_last_point == True):
+      if is_slowing_down == False:
 
         # Peek what the joint velocities will be if we take a full time step
         local qd = jointSplinePeek(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled + get_steptime())
         # Compute the time left to decelerate if we take a full time step
         local x = deceleration_time - (time_left - get_steptime())
-        slowing_down = checkSlowDownRequired(x, qd, max_speed, max_deceleration)
+        is_slowing_down = checkSlowDownRequired(x, qd, max_speed, max_deceleration)
 
-        if slowing_down == True:
+        if is_slowing_down == True:
           # This will ensure that we scale the trajectory right away
           slowing_down_time = time_left + get_steptime()
           textmsg("Velocity is too fast towards the end of the trajectory. The robot will be slowing down, while following the positional part of the trajectory.")
         end
       end
 
-      if slowing_down == True:
+      if is_slowing_down == True:
         # Compute scaling factor based on time left and total slowing down time
         scaling_factor = time_left / slowing_down_time
         scaled_step_time = get_steptime() * scaling_factor
@@ -230,11 +231,11 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
 
     splineTimerTraveled = splineTimerTraveled + scaled_step_time
     # USED_IN_TEST_SPLINE_INTERPOLATION write_output_float_register(1, splineTimerTraveled)
-    jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor)
+    jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor, is_slowing_down)
   end
 
   # Make sure that we approach zero velocity slowly, when slowing down
-  if slowing_down == True:
+  if is_slowing_down == True:
     local qd = get_actual_joint_speeds()
     while norm(qd) > 0.00001:
       local time_left = splineTotalTravelTime - splineTimerTraveled
@@ -245,7 +246,7 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
 
       splineTimerTraveled = splineTimerTraveled + scaled_step_time
       # USED_IN_TEST_SPLINE_INTERPOLATION write_output_float_register(1, splineTimerTraveled)
-      jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor)
+      jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, get_steptime(), scaling_factor, is_slowing_down)
 
       qd = get_actual_joint_speeds()
     end
@@ -260,14 +261,20 @@ def jointSplineRun(coefficients1, coefficients2, coefficients3, coefficients4, c
     timeLeftToTravel = get_steptime()
   end
 
-  jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTotalTravelTime, timeLeftToTravel, scaling_factor)
+  jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTotalTravelTime, timeLeftToTravel, scaling_factor, is_slowing_down)
 end
 
-def jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, timestep, scaling_factor):
-  local qd = coefficients1 + 2.0 * splineTimerTraveled * coefficients2 + 3.0 * pow(splineTimerTraveled, 2) * coefficients3 + 4.0 * pow(splineTimerTraveled, 3) * coefficients4 + 5.0 * pow(splineTimerTraveled, 4) * coefficients5
+def jointSplineStep(coefficients1, coefficients2, coefficients3, coefficients4, coefficients5, splineTimerTraveled, timestep, scaling_factor, is_slowing_down=False):
+  last_spline_qd = coefficients1 + 2.0 * splineTimerTraveled * coefficients2 + 3.0 * pow(splineTimerTraveled, 2) * coefficients3 + 4.0 * pow(splineTimerTraveled, 3) * coefficients4 + 5.0 * pow(splineTimerTraveled, 4) * coefficients5
   last_spline_qdd = 2.0 * coefficients2 + 6.0 * splineTimerTraveled * coefficients3 + 12.0 * pow(splineTimerTraveled, 2) * coefficients4 + 20.0 * pow(splineTimerTraveled, 3) * coefficients5
-  qd = qd * scaling_factor
-  speedj(qd, 1000, timestep)
+
+  if is_slowing_down:
+    last_spline_qd = last_spline_qd * scaling_factor
+    speedj(last_spline_qd, 15.0, timestep)
+  else:
+    max_qdd = list_max_norm(last_spline_qdd)
+    speedj(last_spline_qd, max_qdd, timestep)
+  end
 end
 
 # Helper function to see what the velocity will be if we take a full step
@@ -298,6 +305,31 @@ def checkSlowDownRequired(x, qd, max_speed, max_deceleration):
   return False
 end
 
+###
+# @brief Find the maximum value in a list the list must be of non-zero length and contain numbers
+# @param list array list
+###
+def list_max_norm(list):
+  # ensure we have something to iterate over
+  local length = get_list_length(list)
+  if  length == 0:
+      popup("Getting the maximum of an empty list is impossible in list_max().", error = True, blocking = True)
+      halt
+  end
+
+  # search for maximum
+  local i = 0
+  local max = norm(list[0])
+  while i < length:
+      if norm(list[i]) > max:
+          max = norm(list[i])
+      end
+      i = i + 1
+  end
+
+  return max
+end
+
 thread trajectoryThread():
   textmsg("Executing trajectory. Number of points: ", trajectory_points_left)
   local INDEX_TIME = TRAJECTORY_DATA_DIMENSION
@@ -306,6 +338,7 @@ thread trajectoryThread():
   local INDEX_SPLINE_TYPE = INDEX_BLEND
   local INDEX_POINT_TYPE = INDEX_BLEND + 1
   last_spline_qdd = [0, 0, 0, 0, 0, 0]
+  last_spline_qd = [0, 0, 0, 0, 0, 0]
   enter_critical
   while trajectory_points_left > 0:
     #reading trajectory point + blend radius + type of point (cartesian/joint based)
@@ -316,10 +349,10 @@ thread trajectoryThread():
       local q = [ raw_point[1]/ MULT_jointstate, raw_point[2]/ MULT_jointstate, raw_point[3]/ MULT_jointstate, raw_point[4]/ MULT_jointstate, raw_point[5]/ MULT_jointstate, raw_point[6]/ MULT_jointstate]
       local tmptime = raw_point[INDEX_TIME] / MULT_time
       local blend_radius = raw_point[INDEX_BLEND] / MULT_time
-      local last_point = False
+      local is_last_point = False
       if trajectory_points_left == 0:
         blend_radius = 0.0
-        last_point = True
+        is_last_point = True
       end
       # MoveJ point
       if raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_JOINT:
@@ -327,6 +360,7 @@ thread trajectoryThread():
 
         # reset old acceleration
         last_spline_qdd = [0, 0, 0, 0, 0, 0]
+        last_spline_qd = [0, 0, 0, 0, 0, 0]
 
       # Movel point
       elif raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_CARTESIAN:
@@ -334,6 +368,7 @@ thread trajectoryThread():
 
         # reset old acceleration
         last_spline_qdd = [0, 0, 0, 0, 0, 0]
+        last_spline_qd = [0, 0, 0, 0, 0, 0]
 
       # Joint spline point
       elif raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_JOINT_SPLINE:
@@ -341,7 +376,7 @@ thread trajectoryThread():
         # Cubic spline
         if raw_point[INDEX_SPLINE_TYPE] == SPLINE_CUBIC:
           qd = [ raw_point[7] / MULT_jointstate, raw_point[8] / MULT_jointstate, raw_point[9] / MULT_jointstate, raw_point[10] / MULT_jointstate, raw_point[11] / MULT_jointstate, raw_point[12] / MULT_jointstate]
-          cubicSplineRun(q, qd, tmptime, last_point)
+          cubicSplineRun(q, qd, tmptime, is_last_point)
           # reset old acceleration
           last_spline_qdd = [0, 0, 0, 0, 0, 0]
 
@@ -349,7 +384,7 @@ thread trajectoryThread():
         elif raw_point[INDEX_SPLINE_TYPE] == SPLINE_QUINTIC:
           qd = [ raw_point[7] / MULT_jointstate, raw_point[8] / MULT_jointstate, raw_point[9] / MULT_jointstate, raw_point[10] / MULT_jointstate, raw_point[11] / MULT_jointstate, raw_point[12] / MULT_jointstate]
           qdd = [ raw_point[13]/ MULT_jointstate, raw_point[14]/ MULT_jointstate, raw_point[15]/ MULT_jointstate, raw_point[16]/ MULT_jointstate, raw_point[17]/ MULT_jointstate, raw_point[18]/ MULT_jointstate]
-          quinticSplineRun(q, qd, qdd, tmptime, last_point)
+          quinticSplineRun(q, qd, qdd, tmptime, is_last_point)
         else:
           textmsg("Unknown spline type given:", raw_point[INDEX_POINT_TYPE])
           clear_remaining_trajectory_points()
@@ -359,6 +394,7 @@ thread trajectoryThread():
     end
   end
   exit_critical
+  stopj(STOPJ_ACCELERATION)
   socket_send_int(TRAJECTORY_RESULT_SUCCESS, "trajectory_socket")
   textmsg("Trajectory finished")
 end

--- a/tests/resources/rtde_output_recipe_spline.txt
+++ b/tests/resources/rtde_output_recipe_spline.txt
@@ -29,3 +29,4 @@ tcp_offset
 output_double_register_1
 target_q
 target_qd
+target_qdd

--- a/tests/test_spline_interpolation.cpp
+++ b/tests/test_spline_interpolation.cpp
@@ -310,7 +310,7 @@ protected:
                              std::vector<urcl::vector6d_t> expected_positions,
                              std::vector<urcl::vector6d_t> actual_positions,
                              std::vector<urcl::vector6d_t> actual_velocities, std::vector<urcl::vector6d_t> actual_acc,
-                             std::vector<double> speed_scaling)
+                             std::vector<double> speed_scaling, std::vector<double> spline_time)
   {
     std::ofstream outfile(filename);
     // Header
@@ -339,7 +339,8 @@ protected:
             << "error_positions3, "
             << "error_positions4, "
             << "error_positions5, "
-            << "speed_scaling"
+            << "speed_scaling, "
+            << "spline_time"
             << "\n";
 
     // Data
@@ -356,7 +357,8 @@ protected:
               << actual_positions[i][2] - expected_positions[i][2] << ", "
               << actual_positions[i][3] - expected_positions[i][3] << ", "
               << actual_positions[i][4] - expected_positions[i][4] << ", "
-              << actual_positions[i][5] - expected_positions[i][5] << ", " << speed_scaling[i] << "\n";
+              << actual_positions[i][5] - expected_positions[i][5] << ", " << speed_scaling[i] << ", " << spline_time[i]
+              << "\n";
     }
   }
 
@@ -399,7 +401,7 @@ TEST_F(SplineInterpolationTest, cubic_spline_with_end_point_velocity)
 
   // Data for logging
   std::vector<urcl::vector6d_t> actual_positions, actual_velocities, actual_acc, expected_positions;
-  std::vector<double> time_vec;
+  std::vector<double> time_vec, spline_time;
 
   // Send the trajectory to the robot
   sendTrajectory(s_pos, s_vel, std::vector<urcl::vector6d_t>(), s_time);
@@ -459,6 +461,7 @@ TEST_F(SplineInterpolationTest, cubic_spline_with_end_point_velocity)
     actual_acc.push_back(joint_acc);
     speed_scaling_vec.push_back(speed_scaling);
     time_vec.push_back(plot_time);
+    spline_time.push_back(spline_travel_time);
     plot_time += step_time_;
   }
   // Make sure the velocity is zero when the trajectory has finished
@@ -469,8 +472,13 @@ TEST_F(SplineInterpolationTest, cubic_spline_with_end_point_velocity)
     EXPECT_FLOAT_EQ(joint_velocities[i], 0.0);
   }
 
+  // Verify that the full trajectory have been executed
+  double spline_travel_time;
+  data_pkg->getData("output_double_register_1", spline_travel_time);
+  ASSERT_NEAR(spline_travel_time, s_time.back(), 1e-5);
+
   writeTrajectoryToFile("../test_artifacts/cubic_spline_with_end_point_velocity.csv", time_vec, expected_positions,
-                        actual_positions, actual_velocities, actual_acc, speed_scaling_vec);
+                        actual_positions, actual_velocities, actual_acc, speed_scaling_vec, spline_time);
 }
 
 TEST_F(SplineInterpolationTest, quintic_spline_with_end_point_velocity_with_speedscaling)
@@ -512,7 +520,7 @@ TEST_F(SplineInterpolationTest, quintic_spline_with_end_point_velocity_with_spee
 
   // Data for logging
   std::vector<urcl::vector6d_t> actual_positions, actual_velocities, actual_acc, expected_positions;
-  std::vector<double> time_vec;
+  std::vector<double> time_vec, spline_time;
 
   // Send trajectory to the robot
   sendTrajectory(s_pos, s_vel, s_acc, s_time);
@@ -614,6 +622,7 @@ TEST_F(SplineInterpolationTest, quintic_spline_with_end_point_velocity_with_spee
     actual_acc.push_back(joint_acc);
     speed_scaling_vec.push_back(speed_scaling);
     time_vec.push_back(plot_time);
+    spline_time.push_back(spline_travel_time);
     plot_time += step_time_;
     loop_count += 1;
   }
@@ -626,8 +635,14 @@ TEST_F(SplineInterpolationTest, quintic_spline_with_end_point_velocity_with_spee
     EXPECT_FLOAT_EQ(joint_velocities[i], 0.0);
   }
 
+  // Verify that the full trajectory have been executed
+  double spline_travel_time;
+  data_pkg->getData("output_double_register_1", spline_travel_time);
+  ASSERT_NEAR(spline_travel_time, s_time.back(), 1e-5);
+
   writeTrajectoryToFile("../test_artifacts/quintic_spline_with_end_point_velocity_speedscaling.csv", time_vec,
-                        expected_positions, actual_positions, actual_velocities, actual_acc, speed_scaling_vec);
+                        expected_positions, actual_positions, actual_velocities, actual_acc, speed_scaling_vec,
+                        spline_time);
 }
 
 TEST_F(SplineInterpolationTest, spline_interpolation_cubic)
@@ -672,7 +687,7 @@ TEST_F(SplineInterpolationTest, spline_interpolation_cubic)
 
   // Data for logging
   std::vector<urcl::vector6d_t> actual_positions, actual_velocities, actual_acc, expected_positions;
-  std::vector<double> time_vec;
+  std::vector<double> time_vec, spline_time;
 
   // Send the trajectory to the robot
   sendTrajectory(s_pos, s_vel, std::vector<urcl::vector6d_t>(), s_time);
@@ -724,10 +739,17 @@ TEST_F(SplineInterpolationTest, spline_interpolation_cubic)
     actual_acc.push_back(joint_acc);
     speed_scaling_vec.push_back(speed_scaling);
     time_vec.push_back(plot_time);
+    spline_time.push_back(spline_travel_time);
     plot_time += step_time_;
   }
+
+  // Verify that the full trajectory have been executed
+  double spline_travel_time;
+  data_pkg->getData("output_double_register_1", spline_travel_time);
+  ASSERT_NEAR(spline_travel_time, s_time.back(), 1e-5);
+
   writeTrajectoryToFile("../test_artifacts/spline_interpolation_cubic.csv", time_vec, expected_positions,
-                        actual_positions, actual_velocities, actual_acc, speed_scaling_vec);
+                        actual_positions, actual_velocities, actual_acc, speed_scaling_vec, spline_time);
 }
 
 TEST_F(SplineInterpolationTest, spline_interpolation_quintic)
@@ -774,7 +796,7 @@ TEST_F(SplineInterpolationTest, spline_interpolation_quintic)
 
   // Data for logging
   std::vector<urcl::vector6d_t> actual_positions, actual_velocities, actual_acc, expected_positions;
-  std::vector<double> time_vec;
+  std::vector<double> time_vec, spline_time;
 
   // Send the trajectory to the robot
   sendTrajectory(s_pos, s_vel, s_acc, s_time);
@@ -826,11 +848,17 @@ TEST_F(SplineInterpolationTest, spline_interpolation_quintic)
     actual_acc.push_back(joint_acc);
     speed_scaling_vec.push_back(speed_scaling);
     time_vec.push_back(plot_time);
+    spline_time.push_back(spline_travel_time);
     plot_time += step_time_;
   }
 
+  // Verify that the full trajectory have been executed
+  double spline_travel_time;
+  data_pkg->getData("output_double_register_1", spline_travel_time);
+  ASSERT_NEAR(spline_travel_time, s_time.back(), 1e-5);
+
   writeTrajectoryToFile("../test_artifacts/spline_interpolation_quintic.csv", time_vec, expected_positions,
-                        actual_positions, actual_velocities, actual_acc, speed_scaling_vec);
+                        actual_positions, actual_velocities, actual_acc, speed_scaling_vec, spline_time);
 }
 
 int main(int argc, char* argv[])

--- a/tests/test_spline_interpolation.cpp
+++ b/tests/test_spline_interpolation.cpp
@@ -483,7 +483,7 @@ TEST_F(SplineInterpolationTest, cubic_spline_with_end_point_velocity)
 
 TEST_F(SplineInterpolationTest, quintic_spline_with_end_point_velocity_with_speedscaling)
 {
-  // Set target speed scaling to 100% as one test change this value
+  // Set speed scaling to 25% to test interpolation with speed scaling active
   const unsigned int REDUSE_FACTOR(4);
   g_ur_driver_->getRTDEWriter().sendSpeedSlider(1.0 / REDUSE_FACTOR);
 


### PR DESCRIPTION
… when calculating the next spline in the trajectory

Also limited the acceleration to the maximum joint acceleration of the target accelerations calculated from the spline. But still added a constant acceleration when slowing down is active, as the acceleration in the trajectory no longer can be used.

This will fix the issue with discontinuous motion when speed scaling is active

This will fix issue #194 