### PR TITLE
Analog domain

### DIFF
--- a/include/ur_client_library/rtde/rtde_writer.h
+++ b/include/ur_client_library/rtde/rtde_writer.h
@@ -34,6 +34,7 @@
 #include "ur_client_library/rtde/data_package.h"
 #include "ur_client_library/comm/stream.h"
 #include "ur_client_library/queue/readerwriterqueue.h"
+#include "ur_client_library/ur/datatypes.h"
 #include <thread>
 #include <mutex>
 
@@ -118,10 +119,12 @@ public:
    *
    * \param output_pin The pin to change
    * \param value The new value, it should be between 0 and 1, where 0 is 4mA and 1 is 20mA.
+   * \param type The domain for the output can be eitherAnalogOutputType::CURRENT or  AnalogOutputType::VOLTAGE
    *
    * \returns Success of the package creation
    */
-  bool sendStandardAnalogOutput(uint8_t output_pin, double value);
+  bool sendStandardAnalogOutput(uint8_t output_pin, double value,
+                                const AnalogOutputType type = AnalogOutputType::CURRENT);
 
   /*!
    * \brief Creates a package to request setting a new value for an input_bit_register

--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -79,6 +79,12 @@ enum class SafetyStatus : int8_t  // Only available on 3.10/5.4
   SYSTEM_THREE_POSITION_ENABLING_STOP = 13
 };
 
+enum class AnalogOutputType : uint8_t
+{
+  CURRENT = 0,
+  VOLTAGE = 1
+};
+
 inline std::string robotModeString(const RobotMode& mode)
 {
   switch (mode)

--- a/src/rtde/rtde_writer.cpp
+++ b/src/rtde/rtde_writer.cpp
@@ -204,7 +204,7 @@ bool RTDEWriter::sendToolDigitalOutput(uint8_t output_pin, bool value)
   return success;
 }
 
-bool RTDEWriter::sendStandardAnalogOutput(uint8_t output_pin, double value)
+bool RTDEWriter::sendStandardAnalogOutput(uint8_t output_pin, double value, const AnalogOutputType type)
 {
   if (output_pin > 1)
   {
@@ -224,7 +224,7 @@ bool RTDEWriter::sendStandardAnalogOutput(uint8_t output_pin, double value)
   std::lock_guard<std::mutex> guard(package_mutex_);
   uint8_t mask = pinToMask(output_pin);
   // default to current for now, as no functionality to choose included in set io service
-  uint8_t output_type = 0;
+  uint8_t output_type = toUnderlying(type);
   bool success = true;
   success = package_.setData("standard_analog_output_mask", mask);
   success = success && package_.setData("standard_analog_output_type", output_type);

--- a/src/rtde/rtde_writer.cpp
+++ b/src/rtde/rtde_writer.cpp
@@ -221,10 +221,12 @@ bool RTDEWriter::sendStandardAnalogOutput(uint8_t output_pin, double value, cons
     return false;
   }
 
+
   std::lock_guard<std::mutex> guard(package_mutex_);
   uint8_t mask = pinToMask(output_pin);
-  // default to current for now, as no functionality to choose included in set io service
-  uint8_t output_type = toUnderlying(type);
+
+  auto output_type_bits = [](const uint8_t pin, const uint8_t type){return type << pin;};
+  uint8_t output_type = output_type_bits(output_pin, toUnderlying(type));
   bool success = true;
   success = package_.setData("standard_analog_output_mask", mask);
   success = success && package_.setData("standard_analog_output_type", output_type);


### PR DESCRIPTION
This adds the possibility to specify the output domain when setting an analog output.

Tests are still missing, hence the draft status.