### PR TITLE
Allow resetting the RTDE client

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -63,6 +63,11 @@ sure to
 * run it from the package's main folder, as for simplicity reasons it doesn't use any sophisticated
   method to locate the required files.
 
+.. note::
+   The ``URDriver`` class creates a ``RTDEClient`` during initialization using the provided
+   recipes and utilizing the robot model's maximum frequency. If you would like to use a different
+   frequency, please use the ``resetRTDEClient()`` method after the ``UrDriver`` object has been
+   created.
 
 RTDEWriter
 ^^^^^^^^^^

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ catkin_package = catkin_pkg.package.parse_package(
 # -- Project information -----------------------------------------------------
 
 project = "ur_client_library"
-copyright = "2022, Felix Exner"
+copyright = "2022, Universal Robots A/S"
 author = "Felix Exner"
 
 # The short X.Y version

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -195,7 +195,7 @@ public:
 
   uint32_t getControlFrequency() const
   {
-    return rtde_frequency_;
+    return rtde_client_->getTargetFrequency();
   }
 
   /*!
@@ -487,6 +487,36 @@ public:
     script_command_interface_->setToolContactResultCallback(tool_contact_result_cb);
   }
 
+  /**
+   * \brief Reset the RTDE client. As during initialization the driver will start RTDE communication
+   * with the maximum available frequency, this enables users to start RTDE communication with a
+   * custom rate.
+   *
+   * Note: After calling this function startRTDECommunication() has to be called again to actually
+   * start RTDE communication.
+   *
+   * \param output_recipe Vector containing the output recipe
+   * \param input_recipe Vector containing the input recipe
+   * \param target_frequency Frequency to run the RTDE client at. Defaults to 0.0 which means maximum frequency.
+   */
+  void resetRTDEClient(const std::vector<std::string>& output_recipe, const std::vector<std::string>& input_recipe,
+                       double target_frequency = 0.0);
+
+  /**
+   * \brief Reset the RTDE client. As during initialization the driver will start RTDE communication
+   * with the maximum available frequency, this enables users to start RTDE communication with a
+   * custom rate.
+   *
+   * Note: After calling this function startRTDECommunication() has to be called again to actually
+   * start RTDE communication.
+   *
+   * \param output_recipe_filename Filename where the output recipe is stored in.
+   * \param input_recipe_filename Filename where the input recipe is stored in.
+   * \param target_frequency Frequency to run the RTDE client at. Defaults to 0.0 which means maximum frequency.
+   */
+  void resetRTDEClient(const std::string& output_recipe_filename, const std::string& input_recipe_filename,
+                       double target_frequency = 0.0);
+
 private:
   static std::string readScriptFile(const std::string& filename);
   /*!
@@ -498,7 +528,9 @@ private:
    */
   bool reconnectSecondaryStream();
 
-  int rtde_frequency_;
+  void initRTDE();
+  void setupReverseInterface(const uint32_t reverse_port);
+
   comm::INotifier notifier_;
   std::unique_ptr<rtde_interface::RTDEClient> rtde_client_;
   std::unique_ptr<control::ReverseInterface> reverse_interface_;
@@ -510,7 +542,6 @@ private:
 
   uint32_t servoj_gain_;
   double servoj_lookahead_time_;
-  std::chrono::milliseconds step_time_;
 
   std::function<void(bool)> handle_program_state_;
 

--- a/tests/test_ur_driver.cpp
+++ b/tests/test_ur_driver.cpp
@@ -372,6 +372,13 @@ TEST_F(UrDriverTest, send_robot_program_retry_on_failure)
   EXPECT_TRUE(g_ur_driver_->sendRobotProgram());
 }
 
+TEST_F(UrDriverTest, reset_rtde_client)
+{
+  double target_frequency = 50;
+  g_ur_driver_->resetRTDEClient(OUTPUT_RECIPE, INPUT_RECIPE, target_frequency);
+  ASSERT_EQ(g_ur_driver_->getControlFrequency(), target_frequency);
+}
+
 // TODO we should add more tests for the UrDriver class.
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
With some control modes such as the trajectory passthrough controller it is actually possible to run the communication at much lower frequencies.

However, so far we always initialize the `RTDEClient` with the maximum frequency that is possible on the respective model.

This PR adds a function to `UrDriver` to reset the `RTDEClient` with another communication frequency.

## ToDo

- [x] Implementation
- [x] Write tests
- [x] Write documentation