### PR TITLE
Tcp socket improvements

### DIFF
--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -489,6 +489,14 @@ public:
 
 private:
   static std::string readScriptFile(const std::string& filename);
+  /*!
+   * \brief Reconnects the secondary stream used to send program to the robot.
+   *
+   * Only for use in headless mode, as it replaces the use of the URCaps program.
+   *
+   * \returns true of on successful reconnection, false otherwise
+   */
+  bool reconnectSecondaryStream();
 
   int rtde_frequency_;
   comm::INotifier notifier_;

--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -296,12 +296,13 @@ void TCPServer::readData(const int fd)
   }
   else
   {
-    if (0 < nbytesrecv)
+    if (nbytesrecv < 0)
     {
       if (errno == ECONNRESET)  // if connection gets reset by client, we want to suppress this output
       {
-        URCL_LOG_DEBUG("client from FD %s sent a connection reset package.", fd);
+        URCL_LOG_DEBUG("client from FD %d sent a connection reset package.", fd);
       }
+      else
       {
         URCL_LOG_ERROR("recv() on FD %d failed.", fd);
       }

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -188,7 +188,7 @@ bool TCPSocket::read(uint8_t* buf, const size_t buf_len, size_t& read)
   }
   else if (res < 0)
   {
-    if (errno != EAGAIN && errno != EWOULDBLOCK)
+    if (!(errno == EAGAIN || errno == EWOULDBLOCK))
     {
       // any permanent error should be detected early
       state_ = SocketState::Disconnected;

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -187,7 +187,14 @@ bool TCPSocket::read(uint8_t* buf, const size_t buf_len, size_t& read)
     return false;
   }
   else if (res < 0)
+  {
+    if (errno != EAGAIN && errno != EWOULDBLOCK)
+    {
+      // any permanent error should be detected early
+      state_ = SocketState::Disconnected;
+    }
     return false;
+  }
 
   read = static_cast<size_t>(res);
   return true;

--- a/tests/test_ur_driver.cpp
+++ b/tests/test_ur_driver.cpp
@@ -359,6 +359,19 @@ TEST_F(UrDriverTest, target_outside_limits_pose)
   waitForProgramNotRunning(1000);
 }
 
+TEST_F(UrDriverTest, send_robot_program_retry_on_failure)
+{
+  // Start robot program
+  g_ur_driver_->sendRobotProgram();
+  EXPECT_TRUE(waitForProgramRunning(1000));
+
+  // Check that sendRobotProgram is robust to the secondary stream being disconnected. This is what happens when
+  // switching from Remote to Local and back to Remote mode for example.
+  g_ur_driver_->secondary_stream_->close();
+
+  EXPECT_TRUE(g_ur_driver_->sendRobotProgram());
+}
+
 // TODO we should add more tests for the UrDriver class.
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Couple of improvements related to TCP communication:

1. the error handling in `tcp_server::readData` seems wrong since the error case should be when the number of bytes received is strictly negative and not equal to 0
1. added early disconnection in `tcp_socket::read` in case of permanent failure in order to ease failure detection
1. added robustness to `UrDriver::sendScript`: the program sending is now retried once after closing and reconnecting the secondary stream. This is the workaround described in https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/459. It helps mitigate program sending issues when working with the UR ROS2 driver in headless mode.  

New tests added for 2 and 3. For 1 the debug output of `TCPServerTest::client_connections` seems to confirm the behaviour makes sense. We now see `client from FD <xx> sent a connection reset package`  which is what I'd expect given the client willingly terminates connection.

Before the fix:
```
DEBUG <xxx>/src/comm/tcp_server.cpp 252: Activity on FD 8 
DEBUG <xxx>/src/comm/tcp_server.cpp 268: 8 disconnected. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 8 failed. 
DEBUG <xxx>/src/comm/tcp_server.cpp 228: Activity on self-pipe 
DEBUG <xxx>/src/comm/tcp_server.cpp 252: Activity on FD 10 
DEBUG <xxx>/src/comm/tcp_server.cpp 268: 10 disconnected. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 8 failed. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 10 failed. 
DEBUG <xxx>/src/comm/tcp_server.cpp 228: Activity on self-pipe 
DEBUG <xxx>/src/comm/tcp_server.cpp 252: Activity on FD 12 
DEBUG <xxx>/src/comm/tcp_server.cpp 268: 12 disconnected. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 8 failed. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 10 failed. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 12 failed. 
```
After the fix:
```
DEBUG <xxx>/src/comm/tcp_server.cpp 252: Activity on FD 8 
DEBUG <xxx>/src/comm/tcp_server.cpp 268: 8 disconnected. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 8 failed. 
DEBUG <xxx>/src/comm/tcp_server.cpp 228: Activity on self-pipe 
DEBUG <xxx>/src/comm/tcp_server.cpp 252: Activity on FD 10 
DEBUG <xxx>/src/comm/tcp_server.cpp 303: client from FD 10 sent a connection reset package. 
DEBUG <xxx>/src/comm/tcp_server.cpp 268: 10 disconnected. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 8 failed. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 10 failed. 
DEBUG <xxx>/src/comm/tcp_server.cpp 228: Activity on self-pipe 
DEBUG <xxx>/src/comm/tcp_server.cpp 252: Activity on FD 12 
DEBUG <xxx>/src/comm/tcp_server.cpp 303: client from FD 12 sent a connection reset package. 
DEBUG <xxx>/src/comm/tcp_server.cpp 268: 12 disconnected. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 8 failed. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 10 failed. 
ERROR <xxx>/src/comm/tcp_server.cpp 347: Sending data through socket 12 failed. 
```