### PR TITLE
Remove the not regarding MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ licensed under different licenses:
   and is released under the BSD-2-Clause license.
 * The semaphore implementation used inside the queue implementation is written by Jeff Preshing and
   licensed under the zlib license
-* The Dockerfile used for the integration tests of this repository is originally written by Arran
-  Hobson Sayers and released under the MIT license
 
 While the main `LICENSE` file in this repository contains the Apache-2.0 license used for the
 majority of the work, the respective libraries of third-party components reside together with the


### PR DESCRIPTION
We no longer have the docker of ursim inside the client library, which originally gave us this dependency to the MIT license