### PR TITLE
Add instruction executor for high-level robot control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(urcl SHARED
     src/ur/ur_driver.cpp
     src/ur/calibration_checker.cpp
     src/ur/dashboard_client.cpp
+    src/ur/instruction_executor.cpp
     src/ur/tool_communication.cpp
     src/ur/robot_receive_timeout.cpp
     src/ur/version_information.cpp

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -14,6 +14,7 @@ well as a couple of standalone modules to directly use subsets of the library's 
    architecture/script_sender
    architecture/trajectory_point_interface
    architecture/ur_driver
+   architecture/instruction_executor
 
 
 Dataflow overview with UrDriver

--- a/doc/architecture/instruction_executor.rst
+++ b/doc/architecture/instruction_executor.rst
@@ -1,0 +1,23 @@
+Instruction Executor
+====================
+
+The Instruction Executor is a convenience wrapper to make common robot instructions such as point
+to point motions easily accessible. Currently, it supports the following instructions:
+
+* Excecute MoveJ point to point motions
+* Execute MoveL point to point motions
+* Execute sequences consisting of MoveJ and MoveL instructions
+
+The Instruction Executor uses the :ref:`trajectory_point_interface` and the
+:ref:`reverse_interface`
+for sending motion instructions to the robot. Hence, it requires a :ref:`ur_driver` object.
+
+As a minimal working example, please see ``examples/instruction_executor.cpp`` example:
+
+.. literalinclude:: ../../examples/instruction_executor.cpp
+   :language: c++
+   :caption: examples/instruction_executor.cpp
+   :linenos:
+   :lineno-match:
+   :start-at: g_my_driver.reset
+   :end-at: g_my_driver->stopControl();

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,9 +7,8 @@ project(ur_driver_examples)
 # # Check C++11 support / enable global pedantic and Wall
 # #
 include(DefineCXX17CompilerFlag)
-#DEFINE_CXX_17_COMPILER_FLAG(CXX17_FLAG)
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
+DEFINE_CXX_17_COMPILER_FLAG(CXX17_FLAG)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
 
 add_executable(driver_example
   full_driver.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,8 +7,9 @@ project(ur_driver_examples)
 # # Check C++11 support / enable global pedantic and Wall
 # #
 include(DefineCXX17CompilerFlag)
-DEFINE_CXX_17_COMPILER_FLAG(CXX17_FLAG)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+#DEFINE_CXX_17_COMPILER_FLAG(CXX17_FLAG)
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 
 add_executable(driver_example
   full_driver.cpp)
@@ -64,3 +65,7 @@ add_executable(trajectory_point_interface_example
 trajectory_point_interface.cpp)
 target_compile_options(trajectory_point_interface_example PUBLIC ${CXX17_FLAG})
 target_link_libraries(trajectory_point_interface_example ur_client_library::urcl)
+
+add_executable(instruction_executor
+instruction_executor.cpp)
+target_link_libraries(instruction_executor ur_client_library::urcl)

--- a/examples/instruction_executor.cpp
+++ b/examples/instruction_executor.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
     std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1,
                                                     std::chrono::seconds(2)),
   };
-  instruction_executor->executeMotion(motion_sequence);  // That could also receive velocity parametrization
+  instruction_executor->executeMotion(motion_sequence);
 
   instruction_executor->moveJ({ -1.57, -1.57, 0, 0, 0, 0 });
   instruction_executor->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 });

--- a/examples/instruction_executor.cpp
+++ b/examples/instruction_executor.cpp
@@ -1,0 +1,135 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2024 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+#include "ur_client_library/types.h"
+#include "ur_client_library/ur/ur_driver.h"
+#include "ur_client_library/log.h"
+#include "ur_client_library/control/trajectory_point_interface.h"
+#include "ur_client_library/ur/dashboard_client.h"
+#include "ur_client_library/ur/instruction_executor.h"
+
+const std::string DEFAULT_ROBOT_IP = "192.168.56.101";
+const std::string SCRIPT_FILE = "resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "examples/resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "examples/resources/rtde_input_recipe.txt";
+const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
+
+std::unique_ptr<urcl::DashboardClient> g_my_dashboard;
+std::shared_ptr<urcl::UrDriver> g_my_driver;
+
+// We need a callback function to register. See UrDriver's parameters for details.
+void handleRobotProgramState(bool program_running)
+{
+  // Print the text in green so we see it better
+  std::cout << "\033[1;32mProgram running: " << std::boolalpha << program_running << "\033[0m\n" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+  urcl::setLogLevel(urcl::LogLevel::INFO);
+  // Parse the ip arguments if given
+  std::string robot_ip = DEFAULT_ROBOT_IP;
+  if (argc > 1)
+  {
+    robot_ip = std::string(argv[1]);
+  }
+
+  // --------------- INITIALIZATION BEGIN -------------------
+  // Making the robot ready for the program by:
+  // Connect the robot Dashboard
+  g_my_dashboard.reset(new urcl::DashboardClient(robot_ip));
+  //  if (!g_my_dashboard->connect())
+  //  {
+  //    URCL_LOG_ERROR("Could not connect to dashboard");
+  //    return 1;
+  //  }
+  //
+  //  // // Stop program, if there is one running
+  //  if (!g_my_dashboard->commandStop())
+  //  {
+  //    URCL_LOG_ERROR("Could not send stop program command");
+  //    return 1;
+  //  }
+  //
+  //  // Power it off
+  //  if (!g_my_dashboard->commandPowerOff())
+  //  {
+  //    URCL_LOG_ERROR("Could not send Power off command");
+  //    return 1;
+  //  }
+  //
+  //  // Power it on
+  //  if (!g_my_dashboard->commandPowerOn())
+  //  {
+  //    URCL_LOG_ERROR("Could not send Power on command");
+  //    return 1;
+  //  }
+  //
+  //  // Release the brakes
+  //  if (!g_my_dashboard->commandBrakeRelease())
+  //  {
+  //    URCL_LOG_ERROR("Could not send BrakeRelease command");
+  //    return 1;
+  //  }
+
+  std::unique_ptr<urcl::ToolCommSetup> tool_comm_setup;
+  const bool headless = true;
+  g_my_driver.reset(new urcl::UrDriver(robot_ip, SCRIPT_FILE, OUTPUT_RECIPE, INPUT_RECIPE, &handleRobotProgramState,
+                                       headless, std::move(tool_comm_setup), CALIBRATION_CHECKSUM));
+  auto instruction_executor = std::make_shared<urcl::InstructionExecutor>(g_my_driver);
+  // --------------- INITIALIZATION END -------------------
+
+  URCL_LOG_INFO("Running motion");
+  // Trajectory definition
+  std::vector<std::shared_ptr<urcl::control::MotionPrimitive>> motion_sequence{
+    std::make_shared<urcl::control::MoveJPrimitive>(urcl::vector6d_t{ -1.57, -1.57, 0, 0, 0, 0 }, 0.1,
+                                                    std::chrono::seconds(5)),
+    std::make_shared<urcl::control::MoveJPrimitive>(urcl::vector6d_t{ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }, 0.1,
+                                                    std::chrono::seconds(5)),
+
+    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose(-0.203, 0.263, 0.559, 0.68, -1.083, -2.076), 0.1,
+                                                    std::chrono::seconds(2)),
+    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1,
+                                                    std::chrono::seconds(2)),
+  };
+  instruction_executor->executeMotion(motion_sequence);  // That could also receive velocity parametrization
+
+  instruction_executor->moveJ({ -1.57, -1.57, 0, 0, 0, 0 });
+  instruction_executor->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 });
+  instruction_executor->moveL({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 });
+  instruction_executor->moveL({ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 });
+
+  g_my_driver->stopControl();
+  return 0;
+}

--- a/include/ur_client_library/control/motion_primitives.h
+++ b/include/ur_client_library/control/motion_primitives.h
@@ -1,0 +1,94 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2025 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_MOTION_PRIMITIVES_H_INCLUDED
+#define UR_CLIENT_LIBRARY_MOTION_PRIMITIVES_H_INCLUDED
+
+#include <chrono>
+#include <ur_client_library/types.h>
+
+namespace urcl
+{
+namespace control
+{
+
+enum class MotionType : uint8_t
+{
+  MOVEJ = 0,
+  MOVEL = 1,
+  MOVEP = 2,
+  MOVEC = 3,
+  SPLINE = 51,
+};
+struct MotionPrimitive
+{
+  MotionType type;
+  std::chrono::duration<double> duration;
+  double acceleration;
+  double velocity;
+  double blend_radius;
+};
+
+struct MoveJPrimitive : public MotionPrimitive
+{
+  MoveJPrimitive(const urcl::vector6d_t& target, const double blend_radius = 0,
+                 const std::chrono::duration<double> duration = std::chrono::milliseconds(0),
+                 const double acceleration = 1.4, const double velocity = 1.04)
+  {
+    type = MotionType::MOVEJ;
+    target_joint_configuration = target;
+    this->duration = duration;
+    this->acceleration = acceleration;
+    this->velocity = velocity;
+    this->blend_radius = blend_radius;
+  }
+
+  urcl::vector6d_t target_joint_configuration;
+};
+
+struct MoveLPrimitive : public MotionPrimitive
+{
+  MoveLPrimitive(const urcl::Pose& target, const double blend_radius = 0,
+                 const std::chrono::duration<double> duration = std::chrono::milliseconds(0),
+                 const double acceleration = 1.4, const double velocity = 1.04)
+  {
+    type = MotionType::MOVEL;
+    target_pose = target;
+    this->duration = duration;
+    this->acceleration = acceleration;
+    this->velocity = velocity;
+    this->blend_radius = blend_radius;
+  }
+
+  urcl::Pose target_pose;
+};
+}  // namespace control
+}  // namespace urcl
+#endif  // UR_CLIENT_LIBRARY_MOTION_PRIMITIVES_H_INCLUDED

--- a/include/ur_client_library/control/motion_primitives.h
+++ b/include/ur_client_library/control/motion_primitives.h
@@ -46,6 +46,7 @@ enum class MotionType : uint8_t
   MOVEP = 2,
   MOVEC = 3,
   SPLINE = 51,
+  UNKNOWN = 255
 };
 struct MotionPrimitive
 {

--- a/include/ur_client_library/control/reverse_interface.h
+++ b/include/ur_client_library/control/reverse_interface.h
@@ -141,12 +141,19 @@ public:
                "commands.")]] virtual void
   setKeepaliveCount(const uint32_t count);
 
+  void registerDisconnectionCallback(std::function<void(const int)> disconnection_fun)
+  {
+    disconnection_callback_ = disconnection_fun;
+  }
+
 protected:
   virtual void connectionCallback(const int filedescriptor);
 
   virtual void disconnectionCallback(const int filedescriptor);
 
   virtual void messageCallback(const int filedescriptor, char* buffer, int nbytesrecv);
+
+  std::function<void(const int)> disconnection_callback_ = nullptr;
 
   int client_fd_;
   comm::TCPServer server_;

--- a/include/ur_client_library/types.h
+++ b/include/ur_client_library/types.h
@@ -31,6 +31,23 @@ using vector6d_t = std::array<double, 6>;
 using vector6int32_t = std::array<int32_t, 6>;
 using vector6uint32_t = std::array<uint32_t, 6>;
 
+struct Pose
+{
+  Pose() : x(0.0), y(0.0), z(0.0), rx(0.0), ry(0.0), rz(0.0)
+  {
+  }
+  Pose(const double x, const double y, const double z, const double rx, const double ry, const double rz)
+    : x(x), y(y), z(z), rx(rx), ry(ry), rz(rz)
+  {
+  }
+  double x;
+  double y;
+  double z;
+  double rx;
+  double ry;
+  double rz;
+};
+
 template <class T, std::size_t N>
 std::ostream& operator<<(std::ostream& out, const std::array<T, N>& item)
 {

--- a/include/ur_client_library/ur/instruction_executor.h
+++ b/include/ur_client_library/ur/instruction_executor.h
@@ -1,0 +1,104 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2025 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_INSTRUCTION_EXECUTOR_H_INCLUDED
+#define UR_CLIENT_LIBRARY_INSTRUCTION_EXECUTOR_H_INCLUDED
+
+#include "ur_client_library/ur/ur_driver.h"
+#include "ur_client_library/control/motion_primitives.h"
+
+namespace urcl
+{
+class InstructionExecutor
+{
+public:
+  InstructionExecutor() = delete;
+  InstructionExecutor(std::shared_ptr<urcl::UrDriver> driver) : driver_(driver)
+  {
+    driver_->registerTrajectoryDoneCallback(
+        std::bind(&InstructionExecutor::trajDoneCallback, this, std::placeholders::_1));
+    driver_->registerTrajectoryInterfaceDisconnectedCallback(
+        std::bind(&InstructionExecutor::trajDisconnectCallback, this, std::placeholders::_1));
+  }
+
+  /**
+   * \brief Execute a sequence of motion primitives.
+   *
+   * This function will execute a sequence of motion primitives. The robot will move according to the given motion
+   * primitives. The function will return once the robot has reached the final target.
+   *
+   * \param motion_sequence The sequence of motion primitives to execute
+   */
+  void executeMotion(const std::vector<std::shared_ptr<control::MotionPrimitive>>& motion_sequence);
+
+  /**
+   * \brief Move the robot to a joint target.
+   *
+   * This function will move the robot to the given joint target. The robot will move with the given acceleration and
+   * velocity. The function will return once the robot has reached the target.
+   *
+   * \param target The joint target to move to.
+   * \param acceleration Joint acceleration of leading axis [rad/s^2]
+   * \param velocity Joint speed of leading axis [rad/s]
+   * \param time The time to reach the target. If set to 0, the robot will move with the given acceleration and
+   * velocity.
+   * \param blend_radius The blend radius to use for the motion.
+   * \return True if the robot has reached the target, false otherwise.
+   */
+  bool moveJ(const urcl::vector6d_t& target, const double acceleration = 1.4, const double velocity = 1.04,
+             const double time = 0, const double blend_radius = 0);
+
+  /**
+   * \brief Move the robot to a pose target.
+   *
+   * This function will move the robot to the given pose target. The robot will move with the given acceleration and
+   * velocity. The function will return once the robot has reached the target.
+   *
+   * \param target The pose target to move to.
+   * \param acceleration Tool acceleration [m/s^2]
+   * \param velocity Tool speed [m/s]
+   * \param time The time to reach the target. If set to 0, the robot will move with the given acceleration and
+   * velocity.
+   * \param blend_radius The blend radius to use for the motion.
+   * \return True if the robot has reached the target, false otherwise.
+   */
+  bool moveL(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
+             const double time = 0, const double blend_radius = 0);
+
+private:
+  void trajDoneCallback(const urcl::control::TrajectoryResult& result);
+  void trajDisconnectCallback(const int filedescriptor);
+  std::shared_ptr<urcl::UrDriver> driver_;
+  bool trajectory_done_ = false;
+  urcl::control::TrajectoryResult result_;
+};
+}  // namespace urcl
+
+#endif  // UR_CLIENT_LIBRARY_INSTRUCTION_EXECUTOR_H_INCLUDED

--- a/include/ur_client_library/ur/instruction_executor.h
+++ b/include/ur_client_library/ur/instruction_executor.h
@@ -56,7 +56,7 @@ public:
    *
    * \param motion_sequence The sequence of motion primitives to execute
    */
-  void executeMotion(const std::vector<std::shared_ptr<control::MotionPrimitive>>& motion_sequence);
+  bool executeMotion(const std::vector<std::shared_ptr<control::MotionPrimitive>>& motion_sequence);
 
   /**
    * \brief Move the robot to a joint target.
@@ -96,8 +96,9 @@ private:
   void trajDoneCallback(const urcl::control::TrajectoryResult& result);
   void trajDisconnectCallback(const int filedescriptor);
   std::shared_ptr<urcl::UrDriver> driver_;
-  bool trajectory_done_ = false;
-  urcl::control::TrajectoryResult result_;
+  std::atomic<bool> trajectory_running_ = false;
+  std::mutex trajectory_result_mutex_;
+  urcl::control::TrajectoryResult trajectory_result_;
 };
 }  // namespace urcl
 

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -647,6 +647,11 @@ public:
   void resetRTDEClient(const std::string& output_recipe_filename, const std::string& input_recipe_filename,
                        double target_frequency = 0.0, bool ignore_unavailable_outputs = false);
 
+  void registerTrajectoryInterfaceDisconnectedCallback(std::function<void(const int)> fun)
+  {
+    trajectory_interface_->registerDisconnectionCallback(fun);
+  }
+
 private:
   static std::string readScriptFile(const std::string& filename);
   /*!

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -197,8 +197,12 @@ void TrajectoryPointInterface::connectionCallback(const int filedescriptor)
 
 void TrajectoryPointInterface::disconnectionCallback(const int filedescriptor)
 {
-  URCL_LOG_DEBUG("Connection to trajectory interface dropped.", filedescriptor);
+  URCL_LOG_INFO("Connection to trajectory interface dropped.");
   client_fd_ = -1;
+  if (disconnection_callback_ != nullptr)
+  {
+    disconnection_callback_(filedescriptor);
+  }
 }
 
 void TrajectoryPointInterface::messageCallback(const int filedescriptor, char* buffer, int nbytesrecv)

--- a/src/ur/instruction_executor.cpp
+++ b/src/ur/instruction_executor.cpp
@@ -1,0 +1,111 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2025 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#include "ur_client_library/ur/instruction_executor.h"
+void urcl::InstructionExecutor::trajDoneCallback(const urcl::control::TrajectoryResult& result)
+{
+  result_ = result;
+  trajectory_done_ = true;
+}
+void urcl::InstructionExecutor::trajDisconnectCallback(const int filedescriptor)
+{
+  URCL_LOG_INFO("Trajectory disconnect");
+  result_ = urcl::control::TrajectoryResult::TRAJECTORY_RESULT_FAILURE;
+  trajectory_done_ = true;
+}
+void urcl::InstructionExecutor::executeMotion(
+    const std::vector<std::shared_ptr<control::MotionPrimitive>>& motion_sequence)
+{
+  trajectory_done_ = false;
+  if (!driver_->writeTrajectoryControlMessage(urcl::control::TrajectoryControlMessage::TRAJECTORY_START,
+                                              motion_sequence.size()))
+  {
+    URCL_LOG_ERROR("Cannot send trajectory control command. No client connected?");
+    return;
+    ;
+  }
+
+  for (const auto& primitive : motion_sequence)
+  {
+    switch (primitive->type)
+    {
+      case control::MotionType::MOVEJ:
+      {
+        auto movej_primitive = std::static_pointer_cast<control::MoveJPrimitive>(primitive);
+        driver_->writeTrajectoryPoint(movej_primitive->target_joint_configuration, primitive->acceleration,
+                                      primitive->velocity, false, primitive->duration.count(), primitive->blend_radius);
+        break;
+      }
+      case control::MotionType::MOVEL:
+      {
+        auto movel_primitive = std::static_pointer_cast<control::MoveLPrimitive>(primitive);
+        urcl::vector6d_t pose_vec = { movel_primitive->target_pose.x,  movel_primitive->target_pose.y,
+                                      movel_primitive->target_pose.z,  movel_primitive->target_pose.rx,
+                                      movel_primitive->target_pose.ry, movel_primitive->target_pose.rz };
+        if (!driver_->writeTrajectoryPoint(pose_vec, primitive->acceleration, primitive->velocity, true,
+                                           primitive->duration.count(), primitive->blend_radius))
+        {
+          URCL_LOG_ERROR("Cannot send trajectory control command. No client connected?");
+          return;
+        }
+        break;
+      }
+      default:
+        URCL_LOG_ERROR("Unsupported motion type");
+        return;
+    }
+  }
+
+  while (!trajectory_done_)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (!driver_->writeTrajectoryControlMessage(urcl::control::TrajectoryControlMessage::TRAJECTORY_NOOP))
+    {
+      URCL_LOG_ERROR("Cannot send trajectory control command. No client connected?");
+      return;
+      ;
+    }
+  }
+  URCL_LOG_INFO("Trajectory done with result %d", result_);
+}
+bool urcl::InstructionExecutor::moveJ(const urcl::vector6d_t& target, const double acceleration, const double velocity,
+                                      const double time, const double blend_radius)
+{
+  executeMotion({ std::make_shared<control::MoveJPrimitive>(
+      target, blend_radius, std::chrono::milliseconds(static_cast<int>(time * 1000)), acceleration, velocity) });
+  return result_ == urcl::control::TrajectoryResult::TRAJECTORY_RESULT_SUCCESS;
+}
+bool urcl::InstructionExecutor::moveL(const urcl::Pose& target, const double acceleration, const double velocity,
+                                      const double time, const double blend_radius)
+{
+  executeMotion({ std::make_shared<control::MoveLPrimitive>(
+      target, blend_radius, std::chrono::milliseconds(static_cast<int>(time * 1000)), acceleration, velocity) });
+  return result_ == urcl::control::TrajectoryResult::TRAJECTORY_RESULT_SUCCESS;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,13 @@ if (INTEGRATION_TESTS)
   gtest_add_tests(TARGET      ur_driver_tests
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
+
+  add_executable(instruction_executor_test test_instruction_executor.cpp)
+  target_include_directories(instruction_executor_test PRIVATE ${GTEST_INCLUDE_DIRS})
+  target_link_libraries(instruction_executor_test PRIVATE ur_client_library::urcl ${GTEST_LIBRARIES})
+  gtest_add_tests(TARGET instruction_executor_test
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 else()
   message(STATUS "Skipping integration tests.")
 endif()

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -1,0 +1,285 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2025 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#include <gtest/gtest.h>
+#include "ur_client_library/ur/dashboard_client.h"
+#include "ur_client_library/ur/instruction_executor.h"
+#include "ur_client_library/control/motion_primitives.h"
+
+using namespace urcl;
+using namespace urcl::control;
+
+const std::string SCRIPT_FILE = "../resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "resources/rtde_input_recipe.txt";
+const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
+std::string ROBOT_IP = "192.168.56.101";
+
+bool g_program_running;
+std::condition_variable g_program_not_running_cv;
+std::mutex g_program_not_running_mutex;
+std::condition_variable g_program_running_cv;
+std::mutex g_program_running_mutex;
+
+std::unique_ptr<DashboardClient> g_dashboard_client;
+std::shared_ptr<UrDriver> g_ur_driver;
+
+// Helper functions for the driver
+void handleRobotProgramState(bool program_running)
+{
+  // Print the text in green so we see it better
+  std::cout << "\033[1;32mProgram running: " << std::boolalpha << program_running << "\033[0m\n" << std::endl;
+  if (program_running)
+  {
+    std::lock_guard<std::mutex> lk(g_program_running_mutex);
+    g_program_running = program_running;
+    g_program_running_cv.notify_one();
+  }
+  else
+  {
+    std::lock_guard<std::mutex> lk(g_program_not_running_mutex);
+    g_program_running = program_running;
+    g_program_not_running_cv.notify_one();
+  }
+}
+
+bool waitForProgramNotRunning(int milliseconds = 100)
+{
+  std::unique_lock<std::mutex> lk(g_program_not_running_mutex);
+  if (g_program_not_running_cv.wait_for(lk, std::chrono::milliseconds(milliseconds)) == std::cv_status::no_timeout ||
+      g_program_running == false)
+  {
+    return true;
+  }
+  return false;
+}
+
+bool waitForProgramRunning(int milliseconds = 100)
+{
+  std::unique_lock<std::mutex> lk(g_program_running_mutex);
+  if (g_program_running_cv.wait_for(lk, std::chrono::milliseconds(milliseconds)) == std::cv_status::no_timeout ||
+      g_program_running == true)
+  {
+    return true;
+  }
+  return false;
+}
+
+class InstructionExecutorTest : public ::testing::Test
+{
+protected:
+  std::unique_ptr<InstructionExecutor> executor_;
+
+  static void SetUpTestSuite()
+  {
+    g_dashboard_client.reset(new DashboardClient(ROBOT_IP));
+    ASSERT_TRUE(g_dashboard_client->connect());
+
+    // Make robot ready for test
+    timeval tv;
+    tv.tv_sec = 10;
+    tv.tv_usec = 0;
+    g_dashboard_client->setReceiveTimeout(tv);
+
+    // Stop running program if there is one
+    ASSERT_TRUE(g_dashboard_client->commandStop());
+
+    // if the robot is not powered on and ready
+    ASSERT_TRUE(g_dashboard_client->commandBrakeRelease());
+
+    // Setup driver
+    std::unique_ptr<ToolCommSetup> tool_comm_setup;
+    const bool headless = true;
+    try
+    {
+      g_ur_driver.reset(new UrDriver(ROBOT_IP, SCRIPT_FILE, OUTPUT_RECIPE, INPUT_RECIPE, &handleRobotProgramState,
+                                     headless, std::move(tool_comm_setup), CALIBRATION_CHECKSUM));
+    }
+    catch (UrException& exp)
+    {
+      std::cout << "caught exception " << exp.what() << " while launch driver, retrying once in 10 seconds"
+                << std::endl;
+      std::this_thread::sleep_for(std::chrono::seconds(10));
+      g_ur_driver.reset(new UrDriver(ROBOT_IP, SCRIPT_FILE, OUTPUT_RECIPE, INPUT_RECIPE, &handleRobotProgramState,
+                                     headless, std::move(tool_comm_setup), CALIBRATION_CHECKSUM));
+    }
+  }
+  void SetUp() override
+  {
+    executor_ = std::make_unique<InstructionExecutor>(g_ur_driver);
+    // Make sure script is running on the robot
+    if (g_program_running == false)
+    {
+      g_ur_driver->sendRobotProgram();
+      ASSERT_TRUE(waitForProgramRunning(1000));
+    }
+  }
+};
+
+TEST_F(InstructionExecutorTest, execute_motion_sequence_success)
+{
+  std::vector<std::shared_ptr<urcl::control::MotionPrimitive>> motion_sequence{
+    std::make_shared<urcl::control::MoveJPrimitive>(urcl::vector6d_t{ -1.57, -1.57, 0, 0, 0, 0 }, 0.1,
+                                                    std::chrono::seconds(5)),
+    std::make_shared<urcl::control::MoveJPrimitive>(urcl::vector6d_t{ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }, 0.1,
+                                                    std::chrono::seconds(5)),
+
+    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 0.1,
+                                                    std::chrono::seconds(2)),
+    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1,
+                                                    std::chrono::seconds(2)),
+  };
+  ASSERT_TRUE(executor_->executeMotion(motion_sequence));
+}
+
+TEST_F(InstructionExecutorTest, execute_movej_success)
+{
+  // default parametrization
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.57, 0, 0, 0, 0 }));
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
+
+  // acceleration & velocity parametrization
+  auto start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.57, 0, 0, 0, 0 }, 3.4, 3.1, 0));
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 1550, 100);
+
+  start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }, 3.4, 3.1, 0));
+  end = std::chrono::steady_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 1550, 100);
+
+  // time parametrization
+  start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.57, 0, 0, 0, 0 }, 1.4, 1.04, 3));
+  end = std::chrono::steady_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 3100, 200);
+
+  start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }, 1.4, 1.04, 2.5));
+  end = std::chrono::steady_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 2600, 150);
+}
+
+TEST_F(InstructionExecutorTest, execute_movel_success)
+{
+  // move to a feasible starting pose
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
+  ASSERT_TRUE(executor_->moveL({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }));
+  ASSERT_TRUE(executor_->moveL({ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }));
+
+  // acceleration & velocity parametrization
+  auto start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveL({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5));
+  auto end = std::chrono::steady_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 750, 100);
+
+  start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveL({ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5));
+  end = std::chrono::steady_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 750, 100);
+
+  // time parametrization
+  start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveL({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5, 0.3));
+  end = std::chrono::steady_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 400, 50);
+
+  start = std::chrono::steady_clock::now();
+  ASSERT_TRUE(executor_->moveL({ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5, 0.3));
+  end = std::chrono::steady_clock::now();
+  duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  ASSERT_NEAR(duration.count(), 400, 50);
+}
+
+TEST_F(InstructionExecutorTest, sending_commands_without_reverse_interface_connected_fails)
+{
+  g_dashboard_client->commandStop();
+  ASSERT_TRUE(waitForProgramNotRunning(1000));
+
+  ASSERT_FALSE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
+  ASSERT_FALSE(executor_->moveL({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }));
+  std::vector<std::shared_ptr<urcl::control::MotionPrimitive>> motion_sequence{
+    std::make_shared<urcl::control::MoveJPrimitive>(urcl::vector6d_t{ -1.57, -1.57, 0, 0, 0, 0 }, 0.1,
+                                                    std::chrono::seconds(5)),
+    std::make_shared<urcl::control::MoveJPrimitive>(urcl::vector6d_t{ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }, 0.1,
+                                                    std::chrono::seconds(5)),
+
+    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 0.1,
+                                                    std::chrono::seconds(2)),
+    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1,
+                                                    std::chrono::seconds(2)),
+  };
+  ASSERT_FALSE(executor_->executeMotion(motion_sequence));
+
+  // Disconnect mid-motion
+  g_ur_driver->sendRobotProgram();
+  ASSERT_TRUE(waitForProgramRunning(1000));
+
+  // move to first pose
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.57, 0, 0, 0, 0 }));
+  // move to second pose asynchronoysly
+  auto motion_thread = std::thread([&]() { ASSERT_FALSE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 })); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  g_dashboard_client->commandStop();
+  ASSERT_TRUE(waitForProgramNotRunning(1000));
+  motion_thread.join();
+}
+
+TEST_F(InstructionExecutorTest, sending_illegal_motion_type_fails)
+{
+  auto primitive = std::make_shared<urcl::control::MotionPrimitive>();
+  primitive->type = urcl::control::MotionType::UNKNOWN;
+  std::vector<std::shared_ptr<urcl::control::MotionPrimitive>> motion_sequence{ primitive };
+  ASSERT_FALSE(executor_->executeMotion(motion_sequence));
+}
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  for (int i = 0; i < argc; i++)
+  {
+    if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
+    {
+      ROBOT_IP = argv[i + 1];
+      break;
+    }
+  }
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
With the trajectory point interface there is a method of executing motions with only the urcl present as shown in https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/examples/trajectory_point_interface.cpp

However, usage is a bit cumbersome, we might want to support a one-liner for executing ptp motions, instead.

This PR adds the `InstructionExecutor`, a high-level module that uses existing functionality to provide simple-to-use interfaces, currently to execute MoveJ, MoveL and sequences of the two. In future, we might extend that to other instructions such as other motion types, but possibly also other functionality, hence the more general name.