### PR TITLE
Update link to sphinx-doc.org using https

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,7 +4,7 @@
 #
 # This file does only contain a selection of the most common options. For a
 # full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 


### PR DESCRIPTION
The http version seems to have been deactivated.

Same as https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1240