### PR TITLE
Do not throw exception in DashboardClient::sendRequest

### DIFF
--- a/src/ur/dashboard_client.cpp
+++ b/src/ur/dashboard_client.cpp
@@ -160,7 +160,7 @@ bool DashboardClient::sendRequest(const std::string& command, const std::string&
   bool ret = std::regex_match(response, std::regex(expected));
   if (!ret)
   {
-    throw UrException("Expected: " + expected + ", but received: " + response);
+    URCL_LOG_WARN("Expected: \"%s\", but received: \"%s\"", expected.c_str(), response.c_str());
   }
   return ret;
 }

--- a/tests/test_dashboard_client.cpp
+++ b/tests/test_dashboard_client.cpp
@@ -221,29 +221,25 @@ TEST_F(DashboardClientTest, connect_non_running_robot)
 
 TEST_F(DashboardClientTest, non_expected_result_returns_correctly)
 {
-  std::unique_ptr<DashboardClient> dashboard_client;
-  dashboard_client.reset(new DashboardClient("192.168.56.101"));
-  ASSERT_TRUE(dashboard_client->connect());
-  EXPECT_TRUE(dashboard_client->commandPowerOff());
+  ASSERT_TRUE(dashboard_client_->connect());
+  EXPECT_TRUE(dashboard_client_->commandPowerOff());
 
   // We will not get this answer
-  EXPECT_FALSE(dashboard_client->sendRequest("brake release", "non-existing-response"));
+  EXPECT_FALSE(dashboard_client_->sendRequest("brake release", "non-existing-response"));
 
   // A non-matching answer should throw an exception for this call
-  EXPECT_THROW(dashboard_client->sendRequestString("brake release", "non-existing-response"), UrException);
+  EXPECT_THROW(dashboard_client_->sendRequestString("brake release", "non-existing-response"), UrException);
 
   // Waiting for a non-matching answer should return false
   // Internally we wait 100ms between each attempt, hence the 300ms wait time
   EXPECT_FALSE(
-      dashboard_client->waitForReply("brake_release", "non-existing-response", std::chrono::milliseconds(300)));
+      dashboard_client_->waitForReply("brake_release", "non-existing-response", std::chrono::milliseconds(300)));
 }
 
-TEST_F(DashboardClientTest, connecting_twoice_returns_false)
+TEST_F(DashboardClientTest, connecting_twice_returns_false)
 {
-  std::unique_ptr<DashboardClient> dashboard_client;
-  dashboard_client.reset(new DashboardClient("192.168.56.101"));
-  ASSERT_TRUE(dashboard_client->connect());
-  EXPECT_FALSE(dashboard_client->connect());
+  ASSERT_TRUE(dashboard_client_->connect());
+  EXPECT_FALSE(dashboard_client_->connect());
 }
 
 int main(int argc, char* argv[])

--- a/tests/test_dashboard_client.cpp
+++ b/tests/test_dashboard_client.cpp
@@ -219,6 +219,33 @@ TEST_F(DashboardClientTest, connect_non_running_robot)
   EXPECT_LT(elapsed, 2 * comm::TCPSocket::DEFAULT_RECONNECTION_TIME);
 }
 
+TEST_F(DashboardClientTest, non_expected_result_returns_correctly)
+{
+  std::unique_ptr<DashboardClient> dashboard_client;
+  dashboard_client.reset(new DashboardClient("192.168.56.101"));
+  ASSERT_TRUE(dashboard_client->connect());
+  EXPECT_TRUE(dashboard_client->commandPowerOff());
+
+  // We will not get this answer
+  EXPECT_FALSE(dashboard_client->sendRequest("brake release", "non-existing-response"));
+
+  // A non-matching answer should throw an exception for this call
+  EXPECT_THROW(dashboard_client->sendRequestString("brake release", "non-existing-response"), UrException);
+
+  // Waiting for a non-matching answer should return false
+  // Internally we wait 100ms between each attempt, hence the 300ms wait time
+  EXPECT_FALSE(
+      dashboard_client->waitForReply("brake_release", "non-existing-response", std::chrono::milliseconds(300)));
+}
+
+TEST_F(DashboardClientTest, connecting_twoice_returns_false)
+{
+  std::unique_ptr<DashboardClient> dashboard_client;
+  dashboard_client.reset(new DashboardClient("192.168.56.101"));
+  ASSERT_TRUE(dashboard_client->connect());
+  EXPECT_FALSE(dashboard_client->connect());
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
I don't know why we changed it to throwing an exception. It doesn't make sense for this function.