### PR TITLE
Fix GH edit URL for trajectory_point_interface example

### DIFF
--- a/doc/examples/trajectory_point_interface.rst
+++ b/doc/examples/trajectory_point_interface.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/doc/examples/trajecotry_point_interface.rst
+:github_url: https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/doc/examples/trajectory_point_interface.rst
 
 .. _trajecotry_joint_interface_example:
 

--- a/doc/examples/trajectory_point_interface.rst
+++ b/doc/examples/trajectory_point_interface.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/doc/examples/trajecotry_joint_interface_example.rst
+:github_url: https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/doc/examples/trajecotry_point_interface.rst
 
 .. _trajecotry_joint_interface_example:
 


### PR DESCRIPTION
That was wrong when introduced earlier