### PR TITLE
Use coverage flags to distinguish between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.env.ROBOT_MODEL }}-${{ matrix.env.URSIM_VERSION }}
       - name: Generate URSim log files
         if: always()
         run: |


### PR DESCRIPTION
Currently, we run separate coverage jobs for the different software versions. We run unit and integration tests for

- The lowest supported CB3 version with a UR5 (Currently 3.14.3)
- The lowest suppoted PolyScope 5 version with a UR5e (Currently 5.9.4)
- The latest PolyScope 5 version with a UR20

All of these gather coverage data, but take different branches in the code due to version-dependent execution. As we generate and upload coverage data for all of them, coverage data varies slightly. This approach uses individual flags for each matrix entry. I am not 100% sure whether this does what we want, but I want to give it a try.