### PR TITLE
Fix branch name for integration tests run on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
They were setup to run on "main" while we have "master"