### PR TITLE
Enable nightly CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '38 2 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
For now I've only added the standalone builds and tests.

This should give us more insight on flaky tests. Also, this runs the URL check so we find broken links earlier.