### PR TITLE
Fix DashboardClient load program from subdir

### DIFF
--- a/src/ur/dashboard_client.cpp
+++ b/src/ur/dashboard_client.cpp
@@ -246,8 +246,7 @@ bool DashboardClient::commandBrakeRelease()
 bool DashboardClient::commandLoadProgram(const std::string& program_file_name)
 {
   assertVersion("5.0.0", "1.4", "load <program>");
-  return sendRequest("load " + program_file_name + "", "(?:Loading program: ).*(?:" + program_file_name + ").*") &&
-         waitForReply("programState", "STOPPED " + program_file_name);
+  return sendRequest("load " + program_file_name + "", "(?:Loading program: ).*(?:" + program_file_name + ").*");
 }
 
 bool DashboardClient::commandLoadInstallation(const std::string& installation_file_name)

--- a/src/ur/dashboard_client.cpp
+++ b/src/ur/dashboard_client.cpp
@@ -26,6 +26,7 @@
  */
 //----------------------------------------------------------------------
 
+#include <filesystem>
 #include <iostream>
 #include <regex>
 #include <thread>
@@ -246,7 +247,12 @@ bool DashboardClient::commandBrakeRelease()
 bool DashboardClient::commandLoadProgram(const std::string& program_file_name)
 {
   assertVersion("5.0.0", "1.4", "load <program>");
-  return sendRequest("load " + program_file_name + "", "(?:Loading program: ).*(?:" + program_file_name + ").*");
+  // We load the program, which will fail if the program is not found or the requested file does
+  // not contain a valid program. Afterwards, we wait until the program state is stopped with a
+  // program named the same as the requested program. We cannot check the full file path here, but
+  // the important thing is that the program state is stopped.
+  return sendRequest("load " + program_file_name + "", "(?:Loading program: ).*(?:" + program_file_name + ").*") &&
+         waitForReply("programState", "STOPPED " + std::filesystem::path{ program_file_name }.filename().string());
 }
 
 bool DashboardClient::commandLoadInstallation(const std::string& installation_file_name)

--- a/tests/test_dashboard_client.cpp
+++ b/tests/test_dashboard_client.cpp
@@ -242,6 +242,13 @@ TEST_F(DashboardClientTest, connecting_twice_returns_false)
   EXPECT_FALSE(dashboard_client_->connect());
 }
 
+TEST_F(DashboardClientTest, load_program_in_subdir_works)
+{
+  ASSERT_TRUE(dashboard_client_->connect());
+
+  ASSERT_TRUE(dashboard_client_->commandLoadProgram("/ursim/programs/wait_program.urp"));
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Fixes #268 

Drop checking programState when loading a program
    
When loading a program from an absolute path or a subdirectory instead
of a file being directly in /programs (or /ursim/programs in the case of
URSim) the check "programState" will only return the filename without
the path while we compare it against the path that was requested to
load.
    
However, that second check should not be necessary, as the "load" call
will already make sure that the program is loading correctly.

