### PR TITLE
UrDriver: Send program in headless mode after creating trajectory and script_command servers

### DIFF
--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -148,6 +148,9 @@ void UrDriver::init(const UrDriverConfiguration& config)
   }
   prog.replace(prog.find(BEGIN_REPLACE), BEGIN_REPLACE.length(), begin_replace.str());
 
+  trajectory_interface_.reset(new control::TrajectoryPointInterface(config.trajectory_port));
+  script_command_interface_.reset(new control::ScriptCommandInterface(config.script_command_port));
+
   if (in_headless_mode_)
   {
     full_robot_program_ = "stop program\n";
@@ -166,9 +169,6 @@ void UrDriver::init(const UrDriverConfiguration& config)
     script_sender_.reset(new control::ScriptSender(config.script_sender_port, prog));
     URCL_LOG_DEBUG("Created script sender");
   }
-
-  trajectory_interface_.reset(new control::TrajectoryPointInterface(config.trajectory_port));
-  script_command_interface_.reset(new control::ScriptCommandInterface(config.script_command_port));
 
   if (!std::empty(config.calibration_checksum))
   {


### PR DESCRIPTION
Before, we were sending the script code for execution to the robot and then opening the sockets that the script would connect to.

This has been working fine in most cases, but that fails when too much time passes between the two steps. E.g. I experienced that when having debug output switched on, the robot script was not able to connect to the sockets.

From my understanding this has been overlooked and there is no specific reason why the order was like that. Opening the sockets first and then sending the script seems to make more sense.