### PR TITLE
Fix trajectory result in trajectory forward mode when no trajectory is running

### DIFF
--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -698,9 +698,11 @@ while control_mode > MODE_STOPPED:
       # Clear remaining trajectory points
       if control_mode == MODE_FORWARD:
         kill thread_trajectory
-        clear_remaining_trajectory_points()
-        stopj(STOPJ_ACCELERATION)
-        socket_send_int(TRAJECTORY_RESULT_CANCELED, "trajectory_socket")
+        if trajectory_points_left > 0:
+          clear_remaining_trajectory_points()
+          stopj(STOPJ_ACCELERATION)
+          socket_send_int(TRAJECTORY_RESULT_CANCELED, "trajectory_socket")
+        end
         # Stop freedrive
       elif control_mode == MODE_FREEDRIVE:
         textmsg("Leaving freedrive mode")


### PR DESCRIPTION
Currently, when switching the control mode away from FORWARD, there will always a trajectory result CANCELED sent to the trajectory socket. This PR modifies the script code such that this will only be done when there actually is a trajectory running.

It also adds a test for that.