### PR TITLE
Add an explicit CMake option to turn on/off integration tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ FetchContent_MakeAvailable(googletest)
 
 include(GoogleTest)
 
+option(INTEGRATION_TESTS "Build the integration tests that require a running robot / URSim" OFF)
 # Build Tests
 if (INTEGRATION_TESTS)
   # Integration tests require a robot reachable at 192.168.56.101. Therefore, they have to be


### PR DESCRIPTION
This should make it more obvious how to turn on / off the integration tests.