### PR TITLE
Configure gcovr to ignore negative hits as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: install gcovr
         run: sudo apt-get install -y gcovr
       - name: gcovr
-        run: cd build && gcovr -r ..
+        run: cd build && gcovr -r .. --gcov-ignore-parse-errors negative_hits.warn_once_per_file
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
This seems to be an error in gcov and this occasionally makes our pipelines fail. As a consequence, we just re-run the job hoping that doesn't show up as it doesn't seem to be completely deterministic.

Instead we could just ignore that particular error.