### PR TITLE
Try catch RTDE setup

### DIFF
--- a/src/rtde/rtde_client.cpp
+++ b/src/rtde/rtde_client.cpp
@@ -92,10 +92,12 @@ bool RTDEClient::init(const size_t max_connection_attempts, const std::chrono::m
   unsigned int attempts = 0;
   while (attempts < max_initialization_attempts)
   {
-    setupCommunication(max_connection_attempts, reconnection_timeout);
-    if (client_state_ == ClientState::INITIALIZED)
+    try {
+      setupCommunication(max_connection_attempts, reconnection_timeout);
+    } catch (const UrException&) {}
+    if (client_state_ == ClientState::INITIALIZED) {
       return true;
-
+    }
     if (++attempts < max_initialization_attempts)
     {
       URCL_LOG_ERROR("Failed to initialize RTDE client, retrying in %d seconds", initialization_timeout.count() / 1000);

--- a/src/rtde/rtde_client.cpp
+++ b/src/rtde/rtde_client.cpp
@@ -90,12 +90,19 @@ bool RTDEClient::init(const size_t max_connection_attempts, const std::chrono::m
   }
 
   unsigned int attempts = 0;
+  std::stringstream ss;
   while (attempts < max_initialization_attempts)
   {
-    try {
+    try
+    {
       setupCommunication(max_connection_attempts, reconnection_timeout);
-    } catch (const UrException&) {}
-    if (client_state_ == ClientState::INITIALIZED) {
+    }
+    catch (const UrException& exc)
+    {
+      ss << exc.what() << std::endl;
+    }
+    if (client_state_ == ClientState::INITIALIZED)
+    {
       return true;
     }
     if (++attempts < max_initialization_attempts)
@@ -104,7 +111,6 @@ bool RTDEClient::init(const size_t max_connection_attempts, const std::chrono::m
       std::this_thread::sleep_for(initialization_timeout);
     }
   }
-  std::stringstream ss;
   ss << "Failed to initialize RTDE client after " << max_initialization_attempts << " attempts";
   throw UrException(ss.str());
 }

--- a/tests/test_rtde_client.cpp
+++ b/tests/test_rtde_client.cpp
@@ -363,13 +363,14 @@ TEST_F(RTDEClientTest, connect_non_running_robot)
   client_.reset(
       new rtde_interface::RTDEClient("192.168.56.123", notifier_, resources_output_recipe_, resources_input_recipe_));
   auto start = std::chrono::system_clock::now();
-  EXPECT_THROW(client_->init(2, std::chrono::milliseconds(500)), UrException);
+  EXPECT_THROW(client_->init(2, std::chrono::milliseconds(500), 1), UrException);
   auto end = std::chrono::system_clock::now();
   auto elapsed = end - start;
   // This is only a rough estimate, obviously.
   // Since this isn't done on the loopback device, trying to open a socket on a non-existing address
   // takes considerably longer.
-  EXPECT_LT(elapsed, 2 * comm::TCPSocket::DEFAULT_RECONNECTION_TIME);
+  EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(),
+            2 * comm::TCPSocket::DEFAULT_RECONNECTION_TIME.count());
 }
 
 TEST_F(RTDEClientTest, check_all_rtde_output_variables_exist)


### PR DESCRIPTION
In #266, we improved the behavior of the urcl regarding reconnection attempts and timeouts for sockets. However, there are still a few problems (more to come later). I propose to fix one of them here to keep the scope of the PRs small.

`RTDEClient::setupCommunication` is called in a while loop, and inside `RTDEClient::setupCommunication` there is a call to `pipeline_->init(...)` which in turn calls `producer_.setupProducer(...)`. `setupProducer` (see [here](https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/62d34dff101bc460a4d36692405fd076974b8791/include/ur_client_library/comm/producer.h#L67)) throws if the connection of the `stream_` (which is just a tcp socket in my understanding) fails. Hence, if the RTDE sockets are not available, this causes the initialization sequence to terminate immediately and not retry for the desired `max_initialization_attempts`.

Now that I have a deeper understanding of the URCL after digging deeper a bit (sorry that I didn't bring that up earlier), I don't fully agree with the `rtde_initialization_attempts` and `rtde_initialization_timeout` anymore since the RTDE sockets are just usual tcp sockets that are already subject to `socket_reconnect_attempts` and `socket_reconnection_timeout`. This means that currently it's just a while loop of connecting tcp sockets in a while loop for the RTDE connection setup which is maybe not really necessary and just creates a lot of delays. But it's also possible that I miss an important detail about RTDE comm so maybe my feeling is wrong here.

This has been tested on my side.
@urfeex @bpapaspyros