### PR TITLE
Do not print a warning when querying the dashboard server for a running program

### DIFF
--- a/src/ur/dashboard_client.cpp
+++ b/src/ur/dashboard_client.cpp
@@ -322,7 +322,8 @@ bool DashboardClient::commandQuit()
 bool DashboardClient::commandRunning()
 {
   assertVersion("5.0.0", "1.6", "running");
-  return sendRequest("running", "Program running: true");
+  std::string const response = sendAndReceive("running");
+  return std::regex_match(response, std::regex("Program running: true"));
 }
 
 bool DashboardClient::commandIsProgramSaved()

--- a/tests/test_dashboard_client.cpp
+++ b/tests/test_dashboard_client.cpp
@@ -89,7 +89,9 @@ TEST_F(DashboardClientTest, run_program)
   EXPECT_TRUE(dashboard_client_->commandPlay());
   EXPECT_TRUE(dashboard_client_->commandPause());
   EXPECT_TRUE(dashboard_client_->commandPlay());
+  EXPECT_TRUE(dashboard_client_->commandRunning());
   EXPECT_TRUE(dashboard_client_->commandStop());
+  EXPECT_FALSE(dashboard_client_->commandRunning());
   EXPECT_TRUE(dashboard_client_->commandPowerOff());
   dashboard_client_->commandClosePopup();  // Necessary for CB3 test
 }


### PR DESCRIPTION
Before, the dashboard client was printing a warning when no program was running and the `commandRunning` call was made. However, not having a program running is an absolutely valid result of that command, so it should not produce a warning about an unexpected answer.

Fixes #286 