### PR TITLE
add missing headers

### DIFF
--- a/include/ur_client_library/comm/socket_t.h
+++ b/include/ur_client_library/comm/socket_t.h
@@ -50,6 +50,7 @@ static inline int ur_close(socket_t s)
 #  include <netdb.h>
 #  include <sys/select.h>
 #  include <sys/socket.h>
+#  include <sys/time.h>
 #  include <sys/types.h>
 #  include <unistd.h>
 

--- a/include/ur_client_library/comm/socket_t.h
+++ b/include/ur_client_library/comm/socket_t.h
@@ -46,7 +46,9 @@ static inline int ur_close(socket_t s)
 
 #else  // _WIN32
 
+#  include <arpa/inet.h>
 #  include <netdb.h>
+#  include <sys/select.h>
 #  include <sys/socket.h>
 #  include <sys/types.h>
 #  include <unistd.h>

--- a/include/ur_client_library/comm/tcp_server.h
+++ b/include/ur_client_library/comm/tcp_server.h
@@ -29,10 +29,15 @@
 #ifndef UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 #define UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 #include <atomic>
 #include <chrono>
 #include <functional>
 #include <thread>
+#include <vector>
 
 #include "ur_client_library/comm/socket_t.h"
 

--- a/include/ur_client_library/comm/tcp_server.h
+++ b/include/ur_client_library/comm/tcp_server.h
@@ -29,10 +29,6 @@
 #ifndef UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 #define UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 
-#ifndef _WIN32
-#include <sys/select.h>
-#include <arpa/inet.h>
-#endif
 #include <atomic>
 #include <chrono>
 #include <functional>

--- a/include/ur_client_library/comm/tcp_server.h
+++ b/include/ur_client_library/comm/tcp_server.h
@@ -29,9 +29,7 @@
 #ifndef UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 #define UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 
-#include <netinet/in.h>
 #include <sys/select.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <atomic>
 #include <chrono>

--- a/include/ur_client_library/comm/tcp_server.h
+++ b/include/ur_client_library/comm/tcp_server.h
@@ -29,7 +29,9 @@
 #ifndef UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 #define UR_CLIENT_LIBRARY_TCP_SERVER_H_INCLUDED
 
+#ifndef _WIN32
 #include <sys/select.h>
+#endif
 #include <arpa/inet.h>
 #include <atomic>
 #include <chrono>

--- a/include/ur_client_library/comm/tcp_server.h
+++ b/include/ur_client_library/comm/tcp_server.h
@@ -31,8 +31,8 @@
 
 #ifndef _WIN32
 #include <sys/select.h>
-#endif
 #include <arpa/inet.h>
+#endif
 #include <atomic>
 #include <chrono>
 #include <functional>

--- a/include/ur_client_library/comm/tcp_socket.h
+++ b/include/ur_client_library/comm/tcp_socket.h
@@ -19,9 +19,6 @@
  */
 
 #pragma once
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
 #include <atomic>
 #include <chrono>
 #include <mutex>

--- a/include/ur_client_library/comm/tcp_socket.h
+++ b/include/ur_client_library/comm/tcp_socket.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <sys/time.h>
 #include <atomic>
 #include <chrono>
 #include <mutex>

--- a/include/ur_client_library/comm/tcp_socket.h
+++ b/include/ur_client_library/comm/tcp_socket.h
@@ -19,7 +19,9 @@
  */
 
 #pragma once
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 #include <atomic>
 #include <chrono>
 #include <mutex>

--- a/include/ur_client_library/exceptions.h
+++ b/include/ur_client_library/exceptions.h
@@ -29,7 +29,6 @@
 #ifndef UR_CLIENT_LIBRARY_EXCEPTIONS_H_INCLUDED
 #define UR_CLIENT_LIBRARY_EXCEPTIONS_H_INCLUDED
 
-#include <sys/time.h>
 #include <chrono>
 #include <stdexcept>
 #include <sstream>
@@ -42,6 +41,8 @@
 #  ifdef ERROR
 #    undef ERROR
 #  endif  // ERROR
+#else
+#  include <sys/time.h>
 #endif
 
 namespace urcl

--- a/include/ur_client_library/exceptions.h
+++ b/include/ur_client_library/exceptions.h
@@ -29,6 +29,7 @@
 #ifndef UR_CLIENT_LIBRARY_EXCEPTIONS_H_INCLUDED
 #define UR_CLIENT_LIBRARY_EXCEPTIONS_H_INCLUDED
 
+#include <sys/time.h>
 #include <chrono>
 #include <stdexcept>
 #include <sstream>

--- a/include/ur_client_library/queue/atomicops.h
+++ b/include/ur_client_library/queue/atomicops.h
@@ -408,7 +408,7 @@ __declspec(dllimport) int __stdcall ReleaseSemaphore(void* hSemaphore, long lRel
 }
 #elif defined(__MACH__)
 #  include <mach/mach.h>
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__VXWORKS__)
 #  include <semaphore.h>
 #endif
 
@@ -543,7 +543,7 @@ public:
     }
   }
 };
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__VXWORKS__)
 //---------------------------------------------------------
 // Semaphore (POSIX, Linux)
 //---------------------------------------------------------


### PR DESCRIPTION
There are some headers missing, e.g. 

```bash
$ make
[  1%] Building CXX object CMakeFiles/urcl.dir/src/comm/tcp_socket.cpp.o
In file included from /home/akholodn/github/razr/Universal_Robots_Client_Library/src/comm/tcp_socket.cpp:35:
~/github/razr/Universal_Robots_Client_Library/include/ur_client_library/comm/tcp_socket.h:67:19: error: use of undeclared identifier 'timeval'
   67 |   std::unique_ptr<timeval> recv_timeout_;
```

Let's add them.