### PR TITLE
Set increased timeout in dashboard client test

### DIFF
--- a/tests/test_dashboard_client.cpp
+++ b/tests/test_dashboard_client.cpp
@@ -62,6 +62,12 @@ protected:
   void SetUp()
   {
     dashboard_client_.reset(new TestableDashboardClient(g_ROBOT_IP));
+    // In CI we the dashboard client times out for no obvious reason. Hence we increase the timeout
+    // here.
+    timeval tv;
+    tv.tv_sec = 10;
+    tv.tv_usec = 0;
+    dashboard_client_->setReceiveTimeout(tv);
   }
 
   void TearDown()


### PR DESCRIPTION
The test seems to be flaky with 1s timeout. As we use 10 seconds at other places, as well I guess it wouldn't hurt to use this in the tests.