### PR TITLE
Reduce usage of dashboard client in tests and examples

### DIFF
--- a/include/ur_client_library/example_robot_wrapper.h
+++ b/include/ur_client_library/example_robot_wrapper.h
@@ -85,6 +85,8 @@ public:
    */
   bool initializeRobotWithDashboard();
 
+  bool initializeRobotWithPrimaryClient();
+
   /**
    * @brief Starts RTDE communication with the robot.
    *
@@ -167,11 +169,19 @@ public:
 
   bool isHealthy() const;
 
-  std::shared_ptr<urcl::DashboardClient> dashboard_client_; /*!< Dashboard client to interact with the robot */
-  std::shared_ptr<urcl::UrDriver> ur_driver_;               /*!< UR driver to interact with the robot */
+  //! Dashboard client to interact with the robot
+  std::shared_ptr<urcl::DashboardClient> dashboard_client_;
+
+  //! primary client to interact with the robot
+  std::shared_ptr<urcl::primary_interface::PrimaryClient> primary_client_;
+
+  //! UR driver to interact with the robot
+  std::shared_ptr<urcl::UrDriver> ur_driver_;
 
 private:
   void handleRobotProgramState(bool program_running);
+
+  comm::INotifier notifier_;
 
   std::atomic<bool> rtde_communication_started_ = false;
   std::atomic<bool> consume_rtde_packages_ = false;

--- a/include/ur_client_library/primary/primary_client.h
+++ b/include/ur_client_library/primary/primary_client.h
@@ -172,6 +172,23 @@ public:
   }
 
   /*!
+   * \brief Get the robot's software version as Major.Minor.Bugfix
+   *
+   * This function by default blocks until a VersionMessage has been received and returns that
+   * version information. If there is an older version message that has been received, this is
+   * returned directly.
+   *
+   * \param blocking If true, the function will block until there is a valid version information
+   * received by the client or the timeout passed by.
+   * \param timeout The maximum time to wait for a valid version message.
+   *
+   * \throws urcl::TimeoutException if no message was received until the given timeout passed by.
+   *
+   */
+  std::shared_ptr<VersionInformation>
+  getRobotVersion(bool wait_for_message = true, const std::chrono::milliseconds timeout = std::chrono::seconds(2));
+
+  /*!
    * \brief Get the latest robot mode data.
    *
    * The robot's mode data will be updated in the background. This will always show the latest received

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -890,6 +890,11 @@ public:
     return trajectory_interface_->isConnected();
   }
 
+  std::shared_ptr<urcl::primary_interface::PrimaryClient> getPrimaryClient()
+  {
+    return primary_client_;
+  }
+
 private:
   void init(const UrDriverConfiguration& config);
 
@@ -898,7 +903,7 @@ private:
 
   comm::INotifier notifier_;
   std::unique_ptr<rtde_interface::RTDEClient> rtde_client_;
-  std::unique_ptr<urcl::primary_interface::PrimaryClient> primary_client_;
+  std::shared_ptr<urcl::primary_interface::PrimaryClient> primary_client_;
   std::unique_ptr<control::ReverseInterface> reverse_interface_;
   std::unique_ptr<control::TrajectoryPointInterface> trajectory_interface_;
   std::unique_ptr<control::ScriptCommandInterface> script_command_interface_;

--- a/src/example_robot_wrapper.cpp
+++ b/src/example_robot_wrapper.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 #include "ur_client_library/exceptions.h"
 #include "ur_client_library/log.h"
+#include "ur_client_library/ur/version_information.h"
 
 namespace urcl
 {
@@ -40,24 +41,31 @@ ExampleRobotWrapper::ExampleRobotWrapper(const std::string& robot_ip, const std:
                                          const std::string& autostart_program, const std::string& script_file)
   : headless_mode_(headless_mode), autostart_program_(autostart_program)
 {
-  dashboard_client_ = std::make_shared<DashboardClient>(robot_ip);
+  primary_client_ = std::make_shared<urcl::primary_interface::PrimaryClient>(robot_ip, notifier_);
 
-  // Connect the robot Dashboard
-  if (!dashboard_client_->connect())
+  primary_client_->start();
+
+  auto robot_version = primary_client_->getRobotVersion();
+  if (*robot_version < VersionInformation::fromString("10.0.0"))
   {
-    URCL_LOG_ERROR("Could not connect to dashboard");
+    dashboard_client_ = std::make_shared<DashboardClient>(robot_ip);
+    // Connect the robot Dashboard
+    if (!dashboard_client_->connect())
+    {
+      URCL_LOG_ERROR("Could not connect to dashboard");
+    }
+
+    // In CI we the dashboard client times out for no obvious reason. Hence we increase the timeout
+    // here.
+    timeval tv;
+    tv.tv_sec = 10;
+    tv.tv_usec = 0;
+    dashboard_client_->setReceiveTimeout(tv);
   }
 
-  // In CI we the dashboard client times out for no obvious reason. Hence we increase the timeout
-  // here.
-  timeval tv;
-  tv.tv_sec = 10;
-  tv.tv_usec = 0;
-  dashboard_client_->setReceiveTimeout(tv);
-
-  if (!initializeRobotWithDashboard())
+  if (!initializeRobotWithPrimaryClient())
   {
-    throw UrException("Could not initialize robot with dashboard");
+    throw UrException("Could not initialize robot with primary client");
   }
 
   UrDriverConfiguration driver_config;
@@ -75,7 +83,7 @@ ExampleRobotWrapper::ExampleRobotWrapper(const std::string& robot_ip, const std:
     startRobotProgram(autostart_program);
   }
 
-  if (headless_mode | !std::empty(autostart_program))
+  if (headless_mode || !std::empty(autostart_program))
   {
     if (!waitForProgramRunning(500))
     {
@@ -94,20 +102,28 @@ ExampleRobotWrapper::~ExampleRobotWrapper()
 
 bool ExampleRobotWrapper::clearProtectiveStop()
 {
-  std::string safety_status;
-  dashboard_client_->commandSafetyStatus(safety_status);
-  bool is_protective_stopped = safety_status.find("PROTECTIVE_STOP") != std::string::npos;
-  if (is_protective_stopped)
+  if (primary_client_->isRobotProtectiveStopped())
   {
     URCL_LOG_INFO("Robot is in protective stop, trying to release it");
-    dashboard_client_->commandClosePopup();
-    dashboard_client_->commandCloseSafetyPopup();
-    if (!dashboard_client_->commandUnlockProtectiveStop())
+    if (dashboard_client_ != nullptr)
+    {
+      dashboard_client_->commandClosePopup();
+      dashboard_client_->commandCloseSafetyPopup();
+    }
+    try
+    {
+      primary_client_->commandUnlockProtectiveStop();
+    }
+    catch (const TimeoutException&)
     {
       std::this_thread::sleep_for(std::chrono::seconds(5));
-      if (!dashboard_client_->commandUnlockProtectiveStop())
+      try
       {
-        URCL_LOG_ERROR("Could not unlock protective stop");
+        primary_client_->commandUnlockProtectiveStop();
+      }
+      catch (const TimeoutException&)
+      {
+        URCL_LOG_ERROR("Robot did not unlock the protective stop within the given timeout");
         return false;
       }
     }
@@ -148,6 +164,36 @@ bool ExampleRobotWrapper::initializeRobotWithDashboard()
   if (!dashboard_client_->commandBrakeRelease())
   {
     URCL_LOG_ERROR("Could not send BrakeRelease command");
+    return false;
+  }
+
+  // Now the robot is ready to receive a program
+  URCL_LOG_INFO("Robot ready to start a program");
+  robot_initialized_ = true;
+  return true;
+}
+
+bool ExampleRobotWrapper::initializeRobotWithPrimaryClient()
+{
+  try
+  {
+    waitFor([&]() { return primary_client_->getRobotModeData() != nullptr; }, std::chrono::seconds(5));
+    clearProtectiveStop();
+  }
+  catch (const std::exception& exc)
+  {
+    URCL_LOG_ERROR("Could not clear protective stop (%s)", exc.what());
+    return false;
+  }
+
+  try
+  {
+    primary_client_->commandStop();
+    primary_client_->commandBrakeRelease();
+  }
+  catch (const TimeoutException& exc)
+  {
+    URCL_LOG_ERROR(exc.what());
     return false;
   }
 
@@ -254,13 +300,20 @@ bool ExampleRobotWrapper::waitForProgramNotRunning(int milliseconds)
 
 bool ExampleRobotWrapper::startRobotProgram(const std::string& program_file_name)
 {
-  if (!dashboard_client_->commandLoadProgram(program_file_name))
+  if (dashboard_client_ != nullptr)
   {
-    URCL_LOG_ERROR("Could not load program '%s'", program_file_name.c_str());
-    return false;
-  }
+    if (!dashboard_client_->commandLoadProgram(program_file_name))
+    {
+      URCL_LOG_ERROR("Could not load program '%s'", program_file_name.c_str());
+      return false;
+    }
 
-  return dashboard_client_->commandPlay();
+    return dashboard_client_->commandPlay();
+  }
+  URCL_LOG_ERROR("Dashboard client is not initialized. If you are running a PolyScope X robot, the dashboard server is "
+                 "not available. Loading and running polyscope programs isn't possible. Please use the headless mode "
+                 "or the teach pendant instead.");
+  return false;
 }
 bool ExampleRobotWrapper::resendRobotProgram()
 {

--- a/src/example_robot_wrapper.cpp
+++ b/src/example_robot_wrapper.cpp
@@ -123,7 +123,7 @@ bool ExampleRobotWrapper::clearProtectiveStop()
       }
       catch (const TimeoutException&)
       {
-        URCL_LOG_ERROR("Robot did not unlock the protective stop within the given timeout");
+        URCL_LOG_ERROR("Robot could not unlock the protective stop");
         return false;
       }
     }

--- a/src/primary/primary_client.cpp
+++ b/src/primary/primary_client.cpp
@@ -33,6 +33,7 @@
 #include <ur_client_library/primary/robot_state.h>
 #include "ur_client_library/exceptions.h"
 #include <ur_client_library/helpers.h>
+#include <chrono>
 namespace urcl
 {
 namespace primary_interface
@@ -266,6 +267,16 @@ void PrimaryClient::commandStop(const bool validate, const std::chrono::millisec
       throw TimeoutException("Robot did not stop the program within the given timeout", timeout);
     }
   }
+}
+std::shared_ptr<VersionInformation> PrimaryClient::getRobotVersion(bool blocking,
+                                                                   const std::chrono::milliseconds timeout)
+{
+  if (blocking)
+  {
+    waitFor([this]() { return consumer_->getVersionInformation() != nullptr; }, timeout);
+  }
+
+  return consumer_->getVersionInformation();
 }
 
 }  // namespace primary_interface

--- a/tests/test_dashboard_client.cpp
+++ b/tests/test_dashboard_client.cpp
@@ -32,6 +32,8 @@
 #include <ur_client_library/exceptions.h>
 #include <chrono>
 #include <thread>
+#include "gtest/gtest.h"
+#include "test_utils.h"
 #include "ur_client_library/comm/tcp_socket.h"
 #include "ur_client_library/ur/version_information.h"
 #include <ur_client_library/ur/dashboard_client.h>
@@ -61,6 +63,12 @@ class DashboardClientTest : public ::testing::Test
 protected:
   void SetUp()
   {
+    if (!robotVersionLessThan(g_ROBOT_IP, "10.0.0"))
+    {
+      GTEST_SKIP_("Running DashboardClient tests for PolyScope X is not supported as it doesn't have a dashboard "
+                  "server.");
+    }
+
     dashboard_client_.reset(new TestableDashboardClient(g_ROBOT_IP));
     // In CI we the dashboard client times out for no obvious reason. Hence we increase the timeout
     // here.

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -35,6 +35,8 @@
 #include "ur_client_library/ur/instruction_executor.h"
 #include "ur_client_library/control/motion_primitives.h"
 
+#include "test_utils.h"
+
 #include <ur_client_library/example_robot_wrapper.h>
 
 using namespace urcl;
@@ -56,6 +58,10 @@ protected:
 
   static void SetUpTestSuite()
   {
+    if (!(robotVersionLessThan(ROBOT_IP, "10.0.0") || g_HEADLESS))
+    {
+      GTEST_SKIP_("Running URCap tests for PolyScope X is currently not supported.");
+    }
     // Setup driver
     g_my_robot = std::make_unique<ExampleRobotWrapper>(ROBOT_IP, OUTPUT_RECIPE, INPUT_RECIPE, g_HEADLESS,
                                                        "external_control.urp", SCRIPT_FILE);
@@ -185,7 +191,7 @@ TEST_F(InstructionExecutorTest, execute_movel_success)
 
 TEST_F(InstructionExecutorTest, sending_commands_without_reverse_interface_connected_fails)
 {
-  g_my_robot->dashboard_client_->commandStop();
+  g_my_robot->primary_client_->commandStop();
   ASSERT_TRUE(g_my_robot->waitForProgramNotRunning(1000));
 
   ASSERT_FALSE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
@@ -213,7 +219,7 @@ TEST_F(InstructionExecutorTest, sending_commands_without_reverse_interface_conne
   auto motion_thread = std::thread([&]() { ASSERT_FALSE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 })); });
 
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  g_my_robot->dashboard_client_->commandStop();
+  g_my_robot->primary_client_->commandStop();
   ASSERT_TRUE(g_my_robot->waitForProgramNotRunning(1000));
   motion_thread.join();
 }
@@ -243,6 +249,11 @@ TEST_F(InstructionExecutorTest, canceling_without_running_trajectory_returns_fal
 
 TEST(InstructionExecutorTestStandalone, canceling_without_receiving_answer_returns_false)
 {
+  if (!(robotVersionLessThan(ROBOT_IP, "10.0.0") || !g_HEADLESS))
+  {
+    GTEST_SKIP_("Running URCap tests for PolyScope X is currently not supported.");
+  }
+
   std::ifstream in_file(SCRIPT_FILE);
   std::ofstream out_file;
   const std::string test_script_file = "test_script.urscript";
@@ -311,13 +322,12 @@ TEST_F(InstructionExecutorTest, unfeasible_movel_target_results_in_failure)
   std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
   while (!is_protective_stopped || std::chrono::steady_clock::now() > start + std::chrono::seconds(5))
   {
-    g_my_robot->dashboard_client_->commandSafetyStatus(safety_status);
-    is_protective_stopped = safety_status.find("PROTECTIVE_STOP") != std::string::npos;
+    is_protective_stopped = g_my_robot->primary_client_->isRobotProtectiveStopped();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   ASSERT_TRUE(is_protective_stopped);
   ASSERT_TRUE(g_my_robot->clearProtectiveStop());
-  ASSERT_TRUE(g_my_robot->dashboard_client_->commandStop());
+  ASSERT_NO_THROW(g_my_robot->primary_client_->commandStop());
 
   move_thread.join();
 }

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -249,7 +249,7 @@ TEST_F(InstructionExecutorTest, canceling_without_running_trajectory_returns_fal
 
 TEST(InstructionExecutorTestStandalone, canceling_without_receiving_answer_returns_false)
 {
-  if (!(robotVersionLessThan(ROBOT_IP, "10.0.0") || !g_HEADLESS))
+  if (!(robotVersionLessThan(ROBOT_IP, "10.0.0") || g_HEADLESS))
   {
     GTEST_SKIP_("Running URCap tests for PolyScope X is currently not supported.");
   }

--- a/tests/test_ur_driver.cpp
+++ b/tests/test_ur_driver.cpp
@@ -33,6 +33,7 @@
 #include <ur_client_library/ur/dashboard_client.h>
 #include <ur_client_library/ur/ur_driver.h>
 #include <ur_client_library/example_robot_wrapper.h>
+#include "test_utils.h"
 
 using namespace urcl;
 
@@ -50,6 +51,10 @@ class UrDriverTest : public ::testing::Test
 protected:
   static void SetUpTestSuite()
   {
+    if (!(robotVersionLessThan(g_ROBOT_IP, "10.0.0") || g_HEADLESS))
+    {
+      GTEST_SKIP_("Running URCap tests for PolyScope X is currently not supported.");
+    }
     // Setup driver
     g_my_robot = std::make_unique<ExampleRobotWrapper>(g_ROBOT_IP, OUTPUT_RECIPE, INPUT_RECIPE, g_HEADLESS,
                                                        "external_control.urp", SCRIPT_FILE);
@@ -279,8 +284,11 @@ TEST_F(UrDriverTest, read_error_code)
   // Wait for after PSTOP before clearing it
   std::this_thread::sleep_for(std::chrono::seconds(6));
 
-  EXPECT_TRUE(g_my_robot->dashboard_client_->commandCloseSafetyPopup());
-  EXPECT_TRUE(g_my_robot->dashboard_client_->commandUnlockProtectiveStop());
+  if (g_my_robot->dashboard_client_ != nullptr)
+  {
+    EXPECT_TRUE(g_my_robot->dashboard_client_->commandCloseSafetyPopup());
+  }
+  EXPECT_NO_THROW(g_my_robot->primary_client_->commandUnlockProtectiveStop());
 }
 
 TEST(UrDriverInitTest, setting_connection_limits_works_correctly)

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,42 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright © 2025 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#pragma once
+
+#include <ur_client_library/primary/primary_client.h>
+
+bool robotVersionLessThan(const std::string& robot_ip, const std::string& robot_version)
+{
+  urcl::comm::INotifier notifier;
+  urcl::primary_interface::PrimaryClient primary_client(robot_ip, notifier);
+  primary_client.start();
+  auto version_information = primary_client.getRobotVersion();
+  return *version_information < urcl::VersionInformation::fromString(robot_version);
+}


### PR DESCRIPTION
As we now have more capabilities in the primary interface, we don't need to rely on the dashboard client to initialize the robot in the example robot wrapper.