### PR TITLE
Add functionality to send MoveP and MoveC instructions to the robot

### DIFF
--- a/doc/architecture/instruction_executor.rst
+++ b/doc/architecture/instruction_executor.rst
@@ -6,9 +6,11 @@ Instruction Executor
 The Instruction Executor is a convenience wrapper to make common robot instructions such as point
 to point motions easily accessible. Currently, it supports the following instructions:
 
-* Excecute MoveJ point to point motions
+* Execute MoveJ point to point motions
 * Execute MoveL point to point motions
-* Execute sequences consisting of MoveJ and MoveL instructions
+* Execute MoveP point to point motions
+* Execute MoveC circular motions
+* Execute sequences consisting of the motion primitives above
 
 The Instruction Executor uses the :ref:`trajectory_point_interface` and the
 :ref:`reverse_interface`

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -42,10 +42,10 @@ representations in 21 datafields. The data fields have the following meaning:
    0-5    trajectory point positions (floating point)
    6-11   trajectory point velocities (floating point)
    12-17  trajectory point accelerations (floating point)
-   18     trajectory point type (0: JOINT, 1: CARTESIAN, 2: JOINT_SPLINE)
+   18     trajectory point type (0: MOVEJ, 1: MOVEL, 51: SPLINE)
    19     trajectory point time (in seconds, floating point)
    20     depending on trajectory point type
 
-          - JOINT, CARTESIAN: point blend radius (in meters, floating point)
-          - JOINT_SPLINE: spline type (1: CUBIC, 2: QUINTIC)
+          - MOVEJ, MOVEL: point blend radius (in meters, floating point)
+          - SPLINE: spline type (1: CUBIC, 2: QUINTIC)
    =====  =====

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -47,7 +47,7 @@ representations in 21 datafields. The data fields have the following meaning:
 
           - 12: velocity (Multiplied by ``MULT_JOINTSTATE``)
           - 13: acceleration (Multiplied by ``MULT_JOINTSTATE``)
-          - 14: mode
+          - 14: mode (Multiplied by ``MULT_JOINTSTATE``)
 
    18     trajectory point type
 

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -60,7 +60,7 @@ representations in 21 datafields. The data fields have the following meaning:
    19     trajectory point time (in seconds, multiplied by ``MULT_TIME``)
    20     depending on trajectory point type
 
-          - MOVEJ, MOVEL: point blend radius (in meters, multiplied by ``MULT_TIME``)
+          - MOVEJ, MOVEL, MOVEP and MOVEC: point blend radius (in meters, multiplied by ``MULT_TIME``)
           - SPLINE: spline type (1: CUBIC, 2: QUINTIC)
    =====  =====
 

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -39,13 +39,32 @@ representations in 21 datafields. The data fields have the following meaning:
    =====  =====
    index  meaning
    =====  =====
-   0-5    trajectory point positions (floating point)
-   6-11   trajectory point velocities (floating point)
-   12-17  trajectory point accelerations (floating point)
-   18     trajectory point type (0: MOVEJ, 1: MOVEL, 51: SPLINE)
-   19     trajectory point time (in seconds, floating point)
+   0-5    trajectory point positions (Multiplied by ``MULT_JOINTSTATE``)
+   6-11   trajectory point velocities (Multiplied by ``MULT_JOINTSTATE``). For MOVEC, this contains the "via pose".
+   12-17  trajectory point accelerations (Multiplied by ``MULT_JOINTSTATE``).
+
+          For MOVEC:
+
+          - 12: velocity (Multiplied by ``MULT_JOINTSTATE``)
+          - 13: acceleration (Multiplied by ``MULT_JOINTSTATE``)
+          - 14: mode
+
+   18     trajectory point type
+
+          - 0: MOVEJ
+          - 1: MOVEL
+          - 2: MOVEP
+          - 3: MOVEC
+          - 51: SPLINE)
+
+   19     trajectory point time (in seconds, multiplied by ``MULT_TIME``)
    20     depending on trajectory point type
 
-          - MOVEJ, MOVEL: point blend radius (in meters, floating point)
+          - MOVEJ, MOVEL: point blend radius (in meters, multiplied by ``MULT_TIME``)
           - SPLINE: spline type (1: CUBIC, 2: QUINTIC)
    =====  =====
+
+where
+
+- ``MULT_JOINTSTATE``: 1000000
+- ``MULT_TIME``: 1000

--- a/doc/examples/instruction_executor.rst
+++ b/doc/examples/instruction_executor.rst
@@ -44,10 +44,12 @@ To run a sequence of motions, create an
    :end-at: instruction_executor->executeMotion(motion_sequence);
 
 Each element in the motion sequence can be a different motion type. In the example, there are two
-``MoveJ`` motions and two ``MoveL`` motion. The primitives' parameters are directly forwarded to
+``MoveJ`` motions, a ``MoveL`` motion and a ``MoveP`` motion. The primitives' parameters are directly forwarded to
 the underlying script functions, so the parameter descriptions for them apply, as well.
 Particularly, you may want to choose between either a time-based execution speed or an acceleration
-/ velocity parametrization. The latter will be ignored if a time > 0 is given.
+/ velocity parametrization for some move functions. The latter will be ignored if a time > 0 is given.
+
+Please refer to the script manual for details.
 
 Execute a single motion
 -----------------------

--- a/examples/instruction_executor.cpp
+++ b/examples/instruction_executor.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
   // goal time parametrization -- acceleration and velocity will be ignored
   instruction_executor->moveL({ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1, 0.1, goal_time_sec);
 
-  instruction_executor->moveP({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5);
+  instruction_executor->moveP({ -0.203, 0.463, 0.759, 0.68, -1.083, -2.076 }, 1.5, 1.5);
 
   g_my_robot->ur_driver_->stopControl();
   return 0;

--- a/examples/instruction_executor.cpp
+++ b/examples/instruction_executor.cpp
@@ -89,8 +89,8 @@ int main(int argc, char* argv[])
 
     std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose(-0.203, 0.263, 0.559, 0.68, -1.083, -2.076), 0.1,
                                                     std::chrono::seconds(2)),
-    std::make_shared<urcl::control::MoveLPrimitive>(urcl::Pose{ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1,
-                                                    std::chrono::seconds(2)),
+    std::make_shared<urcl::control::MovePPrimitive>(urcl::Pose{ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1, 0.4,
+                                                    0.4),
   };
   instruction_executor->executeMotion(motion_sequence);
 
@@ -104,6 +104,8 @@ int main(int argc, char* argv[])
   instruction_executor->moveL({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5);
   // goal time parametrization -- acceleration and velocity will be ignored
   instruction_executor->moveL({ -0.203, 0.463, 0.559, 0.68, -1.083, -2.076 }, 0.1, 0.1, goal_time_sec);
+
+  instruction_executor->moveP({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 1.5, 1.5);
 
   g_my_robot->ur_driver_->stopControl();
   return 0;

--- a/include/ur_client_library/control/motion_primitives.h
+++ b/include/ur_client_library/control/motion_primitives.h
@@ -109,7 +109,7 @@ struct MovePPrimitive : public MotionPrimitive
 struct MoveCPrimitive : public MotionPrimitive
 {
   MoveCPrimitive(const urcl::Pose& via_point, const urcl::Pose& target, const double blend_radius = 0,
-                 const double acceleration = 1.4, const double velocity = 1.04)
+                 const double acceleration = 1.4, const double velocity = 1.04, const int32_t mode = 0)
   {
     type = MotionType::MOVEC;
     via_point_pose = via_point;
@@ -117,9 +117,11 @@ struct MoveCPrimitive : public MotionPrimitive
     this->acceleration = acceleration;
     this->velocity = velocity;
     this->blend_radius = blend_radius;
+    this->mode = mode;
   }
   urcl::Pose via_point_pose;
   urcl::Pose target_pose;
+  int32_t mode = 0;
 };
 }  // namespace control
 }  // namespace urcl

--- a/include/ur_client_library/control/motion_primitives.h
+++ b/include/ur_client_library/control/motion_primitives.h
@@ -48,9 +48,10 @@ enum class MotionType : uint8_t
   SPLINE = 51,
   UNKNOWN = 255
 };
+
 struct MotionPrimitive
 {
-  MotionType type;
+  MotionType type = MotionType::UNKNOWN;
   std::chrono::duration<double> duration;
   double acceleration;
   double velocity;
@@ -88,6 +89,36 @@ struct MoveLPrimitive : public MotionPrimitive
     this->blend_radius = blend_radius;
   }
 
+  urcl::Pose target_pose;
+};
+
+struct MovePPrimitive : public MotionPrimitive
+{
+  MovePPrimitive(const urcl::Pose& target, const double blend_radius = 0, const double acceleration = 1.4,
+                 const double velocity = 1.04)
+  {
+    type = MotionType::MOVEP;
+    target_pose = target;
+    this->acceleration = acceleration;
+    this->velocity = velocity;
+    this->blend_radius = blend_radius;
+  }
+  urcl::Pose target_pose;
+};
+
+struct MoveCPrimitive : public MotionPrimitive
+{
+  MoveCPrimitive(const urcl::Pose& via_point, const urcl::Pose& target, const double blend_radius = 0,
+                 const double acceleration = 1.4, const double velocity = 1.04)
+  {
+    type = MotionType::MOVEC;
+    via_point_pose = via_point;
+    target_pose = target;
+    this->acceleration = acceleration;
+    this->velocity = velocity;
+    this->blend_radius = blend_radius;
+  }
+  urcl::Pose via_point_pose;
   urcl::Pose target_pose;
 };
 }  // namespace control

--- a/include/ur_client_library/control/motion_primitives.h
+++ b/include/ur_client_library/control/motion_primitives.h
@@ -32,6 +32,7 @@
 #define UR_CLIENT_LIBRARY_MOTION_PRIMITIVES_H_INCLUDED
 
 #include <chrono>
+#include <optional>
 #include <ur_client_library/types.h>
 
 namespace urcl
@@ -47,6 +48,15 @@ enum class MotionType : uint8_t
   MOVEC = 3,
   SPLINE = 51,
   UNKNOWN = 255
+};
+
+/*!
+ * Spline types
+ */
+enum class TrajectorySplineType : int32_t
+{
+  SPLINE_CUBIC = 1,
+  SPLINE_QUINTIC = 2
 };
 
 struct MotionPrimitive
@@ -122,6 +132,35 @@ struct MoveCPrimitive : public MotionPrimitive
   urcl::Pose via_point_pose;
   urcl::Pose target_pose;
   int32_t mode = 0;
+};
+
+struct SplinePrimitive : public MotionPrimitive
+{
+  SplinePrimitive(const urcl::vector6d_t& target_positions, const vector6d_t& target_velocities,
+                  const std::optional<vector6d_t>& target_accelerations,
+                  const std::chrono::duration<double> duration = std::chrono::milliseconds(0))
+  {
+    type = MotionType::SPLINE;
+    this->target_positions = target_positions;
+    this->target_velocities = target_velocities;
+    this->target_accelerations = target_accelerations;
+    this->duration = duration;
+  }
+
+  control::TrajectorySplineType getSplineType() const
+  {
+    if (target_accelerations.has_value())
+    {
+      return control::TrajectorySplineType::SPLINE_QUINTIC;
+    }
+    else
+    {
+      return control::TrajectorySplineType::SPLINE_CUBIC;
+    }
+  }
+  vector6d_t target_positions;
+  vector6d_t target_velocities;
+  std::optional<vector6d_t> target_accelerations;
 };
 }  // namespace control
 }  // namespace urcl

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -56,15 +56,6 @@ enum class TrajectoryResult : int32_t
 std::string trajectoryResultToString(const TrajectoryResult result);
 
 /*!
- * Spline types
- */
-enum class TrajectorySplineType : int32_t
-{
-  SPLINE_CUBIC = 1,
-  SPLINE_QUINTIC = 2
-};
-
-/*!
  * \brief The TrajectoryPointInterface class handles trajectory forwarding to the robot. Full
  * trajectories are forwarded to the robot controller and are executed there.
  */

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -132,6 +132,14 @@ public:
   bool writeTrajectorySplinePoint(const vector6d_t* positions, const vector6d_t* velocities,
                                   const vector6d_t* accelerations, const float goal_time);
 
+  /*!
+   * \brief Writes a motion primitive to the robot to be read by the URScript program.
+   *
+   * \param primitive A shared pointer to a motion primitive object. This can contain any motion
+   * primitive type that is supported. Currently, that is MoveJ, MoveL, MoveP and MoveC.
+   *
+   * \returns True, if the write was performed successfully, false otherwise.
+   */
   bool writeMotionPrimitive(const std::shared_ptr<control::MotionPrimitive> primitive);
 
   void setTrajectoryEndCallback(std::function<void(TrajectoryResult)> callback)

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -64,16 +64,6 @@ enum class TrajectorySplineType : int32_t
 };
 
 /*!
- * Motion Types
- */
-enum class TrajectoryMotionType : int32_t
-{
-  JOINT_POINT = 0,
-  CARTESIAN_POINT = 1,
-  JOINT_POINT_SPLINE = 2
-};
-
-/*!
  * \brief The TrajectoryPointInterface class handles trajectory forwarding to the robot. Full
  * trajectories are forwarded to the robot controller and are executed there.
  */

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -31,6 +31,7 @@
 
 #include <optional>
 
+#include "ur_client_library/control/motion_primitives.h"
 #include "ur_client_library/control/reverse_interface.h"
 #include "ur_client_library/comm/control_mode.h"
 #include "ur_client_library/types.h"
@@ -130,6 +131,8 @@ public:
    */
   bool writeTrajectorySplinePoint(const vector6d_t* positions, const vector6d_t* velocities,
                                   const vector6d_t* accelerations, const float goal_time);
+
+  bool writeMotionPrimitive(const std::shared_ptr<control::MotionPrimitive> primitive);
 
   void setTrajectoryEndCallback(std::function<void(TrajectoryResult)> callback)
   {

--- a/include/ur_client_library/exceptions.h
+++ b/include/ur_client_library/exceptions.h
@@ -205,5 +205,13 @@ public:
     return text_.c_str();
   }
 };
+
+class UnsupportedMotionType : public UrException
+{
+public:
+  explicit UnsupportedMotionType() : std::runtime_error("Unsupported motion type")
+  {
+  }
+};
 }  // namespace urcl
 #endif  // ifndef UR_CLIENT_LIBRARY_EXCEPTIONS_H_INCLUDED

--- a/include/ur_client_library/types.h
+++ b/include/ur_client_library/types.h
@@ -46,6 +46,11 @@ struct Pose
   double rx;
   double ry;
   double rz;
+
+  bool operator==(const Pose& other) const
+  {
+    return x == other.x && y == other.y && z == other.z && rx == other.rx && ry == other.ry && rz == other.rz;
+  }
 };
 
 template <class T, std::size_t N>

--- a/include/ur_client_library/ur/instruction_executor.h
+++ b/include/ur_client_library/ur/instruction_executor.h
@@ -108,11 +108,27 @@ public:
    * \param acceleration Tool acceleration [m/s^2]
    * \param velocity Tool speed [m/s]
    * \param blend_radius The blend radius to use for the motion.
+   *
    * \return True if the robot has reached the target, false otherwise.
    */
   bool moveP(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
              const double blend_radius = 0.0);
 
+  /**
+   * \brief Move the robot to a pose target using movec
+   *
+   * This function will move the robot to the given pose target in a circular motion going through via. The robot will
+   * move with the given acceleration and velocity. The function will return once the robot has reached the target.
+   *
+   * \param via The circle will be defined by the current pose (the end pose of the previous motion), the target and the
+   * via point.
+   * \param target The pose target to move to.
+   * \param acceleration Tool acceleration [m/s^2]
+   * \param velocity Tool speed [m/s]
+   * \param blend_radius The blend radius to use for the motion.
+   *
+   * \return True if the robot has reached the target, false otherwise.
+   */
   bool moveC(const urcl::Pose& via, const urcl::Pose& target, const double acceleration = 1.4,
              const double velocity = 1.04, const double blend_radius = 0.0, const int32_t mode = 0);
 

--- a/include/ur_client_library/ur/instruction_executor.h
+++ b/include/ur_client_library/ur/instruction_executor.h
@@ -98,6 +98,9 @@ public:
   bool moveL(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
              const double time = 0, const double blend_radius = 0);
 
+  bool moveP(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
+             const double blend_radius = 0.0);
+
   /**
    * \brief Cancel the current motion.
    *

--- a/include/ur_client_library/ur/instruction_executor.h
+++ b/include/ur_client_library/ur/instruction_executor.h
@@ -82,10 +82,10 @@ public:
              const double time = 0, const double blend_radius = 0);
 
   /**
-   * \brief Move the robot to a pose target.
+   * \brief Move the robot to a pose target using movel
    *
    * This function will move the robot to the given pose target. The robot will move with the given acceleration and
-   * velocity. The function will return once the robot has reached the target.
+   * velocity or a motion time. The function will return once the robot has reached the target.
    *
    * \param target The pose target to move to.
    * \param acceleration Tool acceleration [m/s^2]
@@ -98,6 +98,18 @@ public:
   bool moveL(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
              const double time = 0, const double blend_radius = 0);
 
+  /**
+   * \brief Move the robot to a pose target using movep
+   *
+   * This function will move the robot to the given pose target. The robot will move with the given acceleration and
+   * velocity. The function will return once the robot has reached the target.
+   *
+   * \param target The pose target to move to.
+   * \param acceleration Tool acceleration [m/s^2]
+   * \param velocity Tool speed [m/s]
+   * \param blend_radius The blend radius to use for the motion.
+   * \return True if the robot has reached the target, false otherwise.
+   */
   bool moveP(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
              const double blend_radius = 0.0);
 

--- a/include/ur_client_library/ur/instruction_executor.h
+++ b/include/ur_client_library/ur/instruction_executor.h
@@ -113,6 +113,9 @@ public:
   bool moveP(const urcl::Pose& target, const double acceleration = 1.4, const double velocity = 1.04,
              const double blend_radius = 0.0);
 
+  bool moveC(const urcl::Pose& via, const urcl::Pose& target, const double acceleration = 1.4,
+             const double velocity = 1.04, const double blend_radius = 0.0, const int32_t mode = 0);
+
   /**
    * \brief Cancel the current motion.
    *

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
 
 #include "ur_client_library/rtde/rtde_client.h"
 #include "ur_client_library/control/reverse_interface.h"
@@ -530,6 +531,8 @@ public:
    * \returns True on successful write.
    */
   bool writeTrajectorySplinePoint(const vector6d_t& positions, const float goal_time = 0.0);
+
+  bool writeMotionPrimitive(const std::shared_ptr<control::MotionPrimitive> motion_instruction);
 
   /*!
    * \brief Writes a control message in trajectory forward mode.

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -532,6 +532,16 @@ public:
    */
   bool writeTrajectorySplinePoint(const vector6d_t& positions, const float goal_time = 0.0);
 
+  /*!
+   * \brief Writes a motion command to the trajectory point interface
+   *
+   * The motion command corresponds directly to a URScript move function such as `movej` or
+   * `movel`. See the MotionPrimitive's header for all possible motion primitives.
+   *
+   * \param motion_instruction The motion primitive to be sent to the robot.
+   *
+   * \returns True on successful write.
+   */
   bool writeMotionPrimitive(const std::shared_ptr<control::MotionPrimitive> motion_instruction);
 
   /*!

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -526,6 +526,10 @@ thread trajectoryThread():
         mode = raw_point[15]
         movec(via, target, acceleration, velocity, blend_radius, mode)
 
+        # reset old acceleration
+        spline_qdd = [0, 0, 0, 0, 0, 0]
+        spline_qd = [0, 0, 0, 0, 0, 0]
+
       # Joint spline point
       elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_SPLINE:
 

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -33,6 +33,8 @@ TRAJECTORY_MODE_CANCEL = -1
 
 MOTION_TYPE_MOVEJ = 0
 MOTION_TYPE_MOVEL = 1
+MOTION_TYPE_MOVEP = 2
+MOTION_TYPE_MOVEC = 3
 MOTION_TYPE_SPLINE = 51
 TRAJECTORY_DATA_DIMENSION = 3 * 6 + 1
 
@@ -500,6 +502,16 @@ thread trajectoryThread():
         acceleration = raw_point[13] / MULT_jointstate
         velocity = raw_point[7] / MULT_jointstate
         movel(p[q[0], q[1], q[2], q[3], q[4], q[5]], a = acceleration, v = velocity, t = tmptime, r = blend_radius)
+
+        # reset old acceleration
+        spline_qdd = [0, 0, 0, 0, 0, 0]
+        spline_qd = [0, 0, 0, 0, 0, 0]
+        
+      # MoveP point
+      elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_MOVEP:
+        acceleration = raw_point[13] / MULT_jointstate
+        velocity = raw_point[7] / MULT_jointstate
+        movep(p[q[0], q[1], q[2], q[3], q[4], q[5]], a = acceleration, v = velocity, r = blend_radius)
 
         # reset old acceleration
         spline_qdd = [0, 0, 0, 0, 0, 0]

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -517,7 +517,16 @@ thread trajectoryThread():
         spline_qdd = [0, 0, 0, 0, 0, 0]
         spline_qd = [0, 0, 0, 0, 0, 0]
 
-        # Joint spline point
+      elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_MOVEC:
+        local v = [raw_point[7], raw_point[8], raw_point[9], raw_point[10], raw_point[11], raw_point[12]] / MULT_jointstate
+        via = p[v[0], v[1], v[2], v[3], v[4], v[5]]
+        target = p[q[0], q[1], q[2], q[3], q[4], q[5]]
+        acceleration = raw_point[13] / MULT_jointstate
+        velocity = raw_point[14] / MULT_jointstate
+        mode = raw_point[15]
+        movec(via, target, acceleration, velocity, blend_radius, mode)
+
+      # Joint spline point
       elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_SPLINE:
 
         # Cubic spline

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -31,9 +31,9 @@ REVERSE_INTERFACE_DATA_DIMENSION = 8
 TRAJECTORY_MODE_RECEIVE = 1
 TRAJECTORY_MODE_CANCEL = -1
 
-TRAJECTORY_POINT_JOINT = 0
-TRAJECTORY_POINT_CARTESIAN = 1
-TRAJECTORY_POINT_JOINT_SPLINE = 2
+MOTION_TYPE_MOVEJ = 0
+MOTION_TYPE_MOVEL = 1
+MOTION_TYPE_SPLINE = 51
 TRAJECTORY_DATA_DIMENSION = 3 * 6 + 1
 
 TRAJECTORY_RESULT_SUCCESS = 0
@@ -486,7 +486,7 @@ thread trajectoryThread():
         is_last_point = True
       end
       # MoveJ point
-      if raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_JOINT:
+      if raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_MOVEJ:
         acceleration = raw_point[13] / MULT_jointstate
         velocity = raw_point[7] / MULT_jointstate
         movej(q, a = acceleration, v = velocity, t = tmptime, r = blend_radius)
@@ -496,7 +496,7 @@ thread trajectoryThread():
         spline_qd = [0, 0, 0, 0, 0, 0]
 
         # Movel point
-      elif raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_CARTESIAN:
+      elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_MOVEL:
         acceleration = raw_point[13] / MULT_jointstate
         velocity = raw_point[7] / MULT_jointstate
         movel(p[q[0], q[1], q[2], q[3], q[4], q[5]], a = acceleration, v = velocity, t = tmptime, r = blend_radius)
@@ -506,7 +506,7 @@ thread trajectoryThread():
         spline_qd = [0, 0, 0, 0, 0, 0]
 
         # Joint spline point
-      elif raw_point[INDEX_POINT_TYPE] == TRAJECTORY_POINT_JOINT_SPLINE:
+      elif raw_point[INDEX_POINT_TYPE] == MOTION_TYPE_SPLINE:
 
         # Cubic spline
         if raw_point[INDEX_SPLINE_TYPE] == SPLINE_CUBIC:

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -523,7 +523,7 @@ thread trajectoryThread():
         target = p[q[0], q[1], q[2], q[3], q[4], q[5]]
         acceleration = raw_point[13] / MULT_jointstate
         velocity = raw_point[14] / MULT_jointstate
-        mode = raw_point[15]
+        mode = raw_point[15] / MULT_jointstate
         movec(via, target, acceleration, velocity, blend_radius, mode)
 
         # reset old acceleration

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -69,9 +69,9 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   std::array<int32_t, MESSAGE_LENGTH> buffer;
 
   // We write three blocks of 6 doubles and some additional data
-  vector6d_t first_block;
-  vector6d_t second_block;
-  vector6d_t third_block;
+  vector6d_t first_block = { 0, 0, 0, 0, 0, 0 };
+  vector6d_t second_block = { 0, 0, 0, 0, 0, 0 };
+  vector6d_t third_block = { 0, 0, 0, 0, 0, 0 };
 
   switch (primitive->type)
   {

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -31,6 +31,7 @@
 #include <math.h>
 #include <stdexcept>
 #include "ur_client_library/comm/socket_t.h"
+#include "ur_client_library/control/motion_primitives.h"
 
 namespace urcl
 {
@@ -105,11 +106,11 @@ bool TrajectoryPointInterface::writeTrajectoryPoint(const vector6d_t* positions,
 
   if (cartesian)
   {
-    val = static_cast<int32_t>(control::TrajectoryMotionType::CARTESIAN_POINT);
+    val = static_cast<int32_t>(control::MotionType::MOVEL);
   }
   else
   {
-    val = static_cast<int32_t>(control::TrajectoryMotionType::JOINT_POINT);
+    val = static_cast<int32_t>(control::MotionType::MOVEJ);
   }
 
   val = htobe32(val);
@@ -193,7 +194,7 @@ bool TrajectoryPointInterface::writeTrajectorySplinePoint(const vector6d_t* posi
   val = htobe32(val);
   b_pos += append(b_pos, val);
 
-  val = static_cast<int32_t>(control::TrajectoryMotionType::JOINT_POINT_SPLINE);
+  val = static_cast<int32_t>(control::MotionType::SPLINE);
   val = htobe32(val);
   b_pos += append(b_pos, val);
 

--- a/src/ur/instruction_executor.cpp
+++ b/src/ur/instruction_executor.cpp
@@ -66,29 +66,15 @@ bool urcl::InstructionExecutor::executeMotion(
 
   for (const auto& primitive : motion_sequence)
   {
-    switch (primitive->type)
+    try
     {
-      case control::MotionType::MOVEJ:
-      {
-        auto movej_primitive = std::static_pointer_cast<control::MoveJPrimitive>(primitive);
-        driver_->writeTrajectoryPoint(movej_primitive->target_joint_configuration, primitive->acceleration,
-                                      primitive->velocity, false, primitive->duration.count(), primitive->blend_radius);
-        break;
-      }
-      case control::MotionType::MOVEL:
-      {
-        auto movel_primitive = std::static_pointer_cast<control::MoveLPrimitive>(primitive);
-        urcl::vector6d_t pose_vec = { movel_primitive->target_pose.x,  movel_primitive->target_pose.y,
-                                      movel_primitive->target_pose.z,  movel_primitive->target_pose.rx,
-                                      movel_primitive->target_pose.ry, movel_primitive->target_pose.rz };
-        driver_->writeTrajectoryPoint(pose_vec, primitive->acceleration, primitive->velocity, true,
-                                      primitive->duration.count(), primitive->blend_radius);
-        break;
-      }
-      default:
-        URCL_LOG_ERROR("Unsupported motion type");
-        // The hardware will complain about missing trajectory points and return a failure for
-        // trajectory execution. Hence, we need to step into the running loop below.
+      driver_->writeMotionPrimitive(primitive);
+    }
+    catch (const UnsupportedMotionType&)
+    {
+      URCL_LOG_ERROR("Unsupported motion type");
+      // The hardware will complain about missing trajectory points and return a failure for
+      // trajectory execution. Hence, we need to step into the running loop below.
     }
   }
   trajectory_running_ = true;
@@ -118,6 +104,12 @@ bool urcl::InstructionExecutor::moveL(const urcl::Pose& target, const double acc
 {
   return executeMotion({ std::make_shared<control::MoveLPrimitive>(
       target, blend_radius, std::chrono::milliseconds(static_cast<int>(time * 1000)), acceleration, velocity) });
+}
+
+bool urcl::InstructionExecutor::moveP(const urcl::Pose& target, const double acceleration, const double velocity,
+                                      const double blend_radius)
+{
+  return executeMotion({ std::make_shared<control::MovePPrimitive>(target, blend_radius, acceleration, velocity) });
 }
 
 bool urcl::InstructionExecutor::cancelMotion()

--- a/src/ur/instruction_executor.cpp
+++ b/src/ur/instruction_executor.cpp
@@ -112,6 +112,13 @@ bool urcl::InstructionExecutor::moveP(const urcl::Pose& target, const double acc
   return executeMotion({ std::make_shared<control::MovePPrimitive>(target, blend_radius, acceleration, velocity) });
 }
 
+bool urcl::InstructionExecutor::moveC(const urcl::Pose& via, const urcl::Pose& target, const double acceleration,
+                                      const double velocity, const double blend_radius, const int32_t mode)
+{
+  return executeMotion(
+      { std::make_shared<control::MoveCPrimitive>(via, target, blend_radius, acceleration, velocity, mode) });
+}
+
 bool urcl::InstructionExecutor::cancelMotion()
 {
   cancel_requested_ = true;

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -240,6 +240,11 @@ bool UrDriver::writeTrajectoryControlMessage(const control::TrajectoryControlMes
   return reverse_interface_->writeTrajectoryControlMessage(trajectory_action, point_number, robot_receive_timeout);
 }
 
+bool UrDriver::writeMotionPrimitive(const std::shared_ptr<control::MotionPrimitive> motion_instruction)
+{
+  return trajectory_interface_->writeMotionPrimitive(motion_instruction);
+}
+
 bool UrDriver::writeFreedriveControlMessage(const control::FreedriveControlMessage freedrive_action,
                                             const RobotReceiveTimeout& robot_receive_timeout)
 {

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -363,6 +363,14 @@ TEST_F(InstructionExecutorTest, empty_sequence_succeeds)
   ASSERT_TRUE(executor_->executeMotion(motion_sequence));
 }
 
+TEST_F(InstructionExecutorTest, movep_succeeds)
+{
+  // move to a feasible starting pose
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
+
+  ASSERT_TRUE(executor_->moveP({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 2.0, 2.0));
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -368,7 +368,7 @@ TEST_F(InstructionExecutorTest, movep_succeeds)
   // move to a feasible starting pose
   ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
 
-  ASSERT_TRUE(executor_->moveP({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 2.0, 2.0));
+  ASSERT_TRUE(executor_->moveP({ -0.203, 0.363, 0.759, 0.68, -1.083, -2.076 }, 1.0, 1.0));
 }
 
 TEST_F(InstructionExecutorTest, movec_succeeds)

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -371,6 +371,16 @@ TEST_F(InstructionExecutorTest, movep_succeeds)
   ASSERT_TRUE(executor_->moveP({ -0.203, 0.263, 0.559, 0.68, -1.083, -2.076 }, 2.0, 2.0));
 }
 
+TEST_F(InstructionExecutorTest, movec_succeeds)
+{
+  // move to a feasible starting pose
+  ASSERT_TRUE(executor_->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }));
+
+  ASSERT_TRUE(executor_->moveP({ -0.209, 0.492, 0.5522, 0.928, -1.134, -2.168 }, 1.2, 0.25, 0.025));
+  ASSERT_TRUE(executor_->moveC({ -0.209, 0.487, 0.671, 1.026, -0.891, -2.337 },
+                               { -0.209, 0.425, 0.841, 1.16, -0.477, -2.553 }, 0.1, 0.25, 0.025, 0));
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -227,6 +227,25 @@ protected:
             (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
       }
+      else if (spl.motion_type == static_cast<int32_t>(control::MotionType::MOVEC))
+      {
+        return std::make_shared<control::MoveCPrimitive>(
+            urcl::Pose{ ((double)spl.vel[0]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.vel[1]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.vel[2]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.vel[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.vel[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.vel[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
+            urcl::Pose{ ((double)spl.pos[0]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[1]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[2]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
+            (double)spl.acc[1] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE, (double)spl.acc[2]);
+      }
       else
       {
         throw std::runtime_error("Unknown motion type");
@@ -548,6 +567,28 @@ TEST_F(TrajectoryPointInterfaceTest, send_movep)
   EXPECT_EQ(received_primitive->blend_radius, blend_radius);
   EXPECT_EQ(received_primitive->velocity, velocity);
   EXPECT_EQ(received_primitive->acceleration, acceleration);
+}
+
+TEST_F(TrajectoryPointInterfaceTest, send_movec)
+{
+  urcl::Pose send_target = { 1.2, 3.1, 2.2, -3.4, -1.1, -1.2 };
+  urcl::Pose send_via = { 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
+  double blend_radius = 0.5;
+  double acceleration = 0.7;
+  double velocity = 0.7;
+  double mode = 1;
+  auto primitive =
+      std::make_shared<control::MoveCPrimitive>(send_via, send_target, blend_radius, acceleration, velocity, mode);
+
+  traj_point_interface_->writeMotionPrimitive(primitive);
+  auto received_primitive = client_->getMotionPrimitive();
+  EXPECT_EQ(received_primitive->type, control::MotionType::MOVEC);
+  EXPECT_EQ(std::static_pointer_cast<control::MoveCPrimitive>(received_primitive)->target_pose, send_target);
+  EXPECT_EQ(std::static_pointer_cast<control::MoveCPrimitive>(received_primitive)->via_point_pose, send_via);
+  EXPECT_EQ(received_primitive->blend_radius, blend_radius);
+  EXPECT_EQ(received_primitive->acceleration, acceleration);
+  EXPECT_EQ(received_primitive->acceleration, velocity);
+  EXPECT_EQ(std::static_pointer_cast<control::MoveCPrimitive>(received_primitive)->mode, mode);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, unsupported_motion_type_throws)

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -244,7 +244,8 @@ protected:
                         ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
             (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
             (double)spl.acc[1] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
-            (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE, (double)spl.acc[2]);
+            (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            (double)spl.acc[2] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
       }
       else
       {

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -31,6 +31,7 @@
 #include <gtest/gtest.h>
 #include <ur_client_library/control/trajectory_point_interface.h>
 #include <ur_client_library/comm/tcp_socket.h>
+#include <ur_client_library/control/motion_primitives.h>
 
 using namespace urcl;
 
@@ -283,7 +284,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
             received_data.blend_radius_or_spline_type);
 
   // Motion type
-  EXPECT_EQ(static_cast<int32_t>(control::TrajectoryMotionType::JOINT_POINT_SPLINE), received_data.motion_type);
+  EXPECT_EQ(static_cast<int32_t>(control::MotionType::SPLINE), received_data.motion_type);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
@@ -327,7 +328,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
             received_data.blend_radius_or_spline_type);
 
   // Motion type
-  EXPECT_EQ(static_cast<int32_t>(control::TrajectoryMotionType::JOINT_POINT_SPLINE), received_data.motion_type);
+  EXPECT_EQ(static_cast<int32_t>(control::MotionType::SPLINE), received_data.motion_type);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_splines_velocities)

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -32,6 +32,7 @@
 #include <ur_client_library/control/trajectory_point_interface.h>
 #include <ur_client_library/comm/tcp_socket.h>
 #include <ur_client_library/control/motion_primitives.h>
+#include "ur_client_library/exceptions.h"
 
 using namespace urcl;
 
@@ -178,6 +179,58 @@ protected:
       TrajData spl;
       readMessage(spl.pos, spl.vel, spl.acc, spl.goal_time, spl.blend_radius_or_spline_type, spl.motion_type);
       return spl;
+    }
+
+    std::shared_ptr<control::MotionPrimitive> getMotionPrimitive()
+    {
+      TrajData spl = getData();
+      if (spl.motion_type == static_cast<int32_t>(control::MotionType::MOVEJ))
+      {
+        return std::make_shared<control::MoveJPrimitive>(
+            vector6d_t{
+                (double)spl.pos[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                (double)spl.pos[1] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                (double)spl.pos[2] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                (double)spl.pos[3] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                (double)spl.pos[4] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                (double)spl.pos[5] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            },
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
+            std::chrono::milliseconds(spl.goal_time),
+            (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
+      }
+      else if (spl.motion_type == static_cast<int32_t>(control::MotionType::MOVEL))
+      {
+        return std::make_shared<control::MoveLPrimitive>(
+            urcl::Pose{ ((double)spl.pos[0]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[1]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[2]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
+            std::chrono::milliseconds(spl.goal_time),
+            (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
+      }
+      else if (spl.motion_type == static_cast<int32_t>(control::MotionType::MOVEP))
+      {
+        return std::make_shared<control::MovePPrimitive>(
+            urcl::Pose{ ((double)spl.pos[0]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[1]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[2]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+                        ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
+            (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
+      }
+      else
+      {
+        throw std::runtime_error("Unknown motion type");
+      }
     }
   };
 
@@ -437,6 +490,70 @@ TEST_F(TrajectoryPointInterfaceTest, trajectory_result)
 
   client_->send(toUnderlying(control::TrajectoryResult::TRAJECTORY_RESULT_SUCCESS));
   EXPECT_TRUE(waitTrajectoryEnd(1000, control::TrajectoryResult::TRAJECTORY_RESULT_SUCCESS));
+}
+
+TEST_F(TrajectoryPointInterfaceTest, send_movej)
+{
+  urcl::vector6d_t send_positions = { 1.2, 3.1, 2.2, -3.4, -1.1, -1.2 };
+  double blend_radius = 0.5;
+  double velocity = 0.6;
+  double acceleration = 0.7;
+  auto duration = std::chrono::milliseconds(434);
+  auto primitive =
+      std::make_shared<control::MoveJPrimitive>(send_positions, blend_radius, duration, acceleration, velocity);
+
+  traj_point_interface_->writeMotionPrimitive(primitive);
+  auto received_primitive = client_->getMotionPrimitive();
+  EXPECT_EQ(received_primitive->type, control::MotionType::MOVEJ);
+  EXPECT_EQ(std::static_pointer_cast<control::MoveJPrimitive>(received_primitive)->target_joint_configuration,
+            send_positions);
+  EXPECT_EQ(received_primitive->blend_radius, blend_radius);
+  EXPECT_EQ(received_primitive->velocity, velocity);
+  EXPECT_EQ(received_primitive->acceleration, acceleration);
+  EXPECT_EQ(received_primitive->duration, duration);
+}
+
+TEST_F(TrajectoryPointInterfaceTest, send_movel)
+{
+  urcl::Pose send_positions = { 1.2, 3.1, 2.2, -3.4, -1.1, -1.2 };
+  double blend_radius = 0.5;
+  double velocity = 0.6;
+  double acceleration = 0.7;
+  auto duration = std::chrono::milliseconds(434);
+  auto primitive =
+      std::make_shared<control::MoveLPrimitive>(send_positions, blend_radius, duration, acceleration, velocity);
+
+  traj_point_interface_->writeMotionPrimitive(primitive);
+  auto received_primitive = client_->getMotionPrimitive();
+  EXPECT_EQ(received_primitive->type, control::MotionType::MOVEL);
+  EXPECT_EQ(std::static_pointer_cast<control::MoveLPrimitive>(received_primitive)->target_pose, send_positions);
+  EXPECT_EQ(received_primitive->blend_radius, blend_radius);
+  EXPECT_EQ(received_primitive->velocity, velocity);
+  EXPECT_EQ(received_primitive->acceleration, acceleration);
+  EXPECT_EQ(received_primitive->duration, duration);
+}
+
+TEST_F(TrajectoryPointInterfaceTest, send_movep)
+{
+  urcl::Pose send_positions = { 1.2, 3.1, 2.2, -3.4, -1.1, -1.2 };
+  double blend_radius = 0.5;
+  double velocity = 0.6;
+  double acceleration = 0.7;
+  auto primitive = std::make_shared<control::MovePPrimitive>(send_positions, blend_radius, acceleration, velocity);
+
+  traj_point_interface_->writeMotionPrimitive(primitive);
+  auto received_primitive = client_->getMotionPrimitive();
+  EXPECT_EQ(received_primitive->type, control::MotionType::MOVEP);
+  EXPECT_EQ(std::static_pointer_cast<control::MovePPrimitive>(received_primitive)->target_pose, send_positions);
+  EXPECT_EQ(received_primitive->blend_radius, blend_radius);
+  EXPECT_EQ(received_primitive->velocity, velocity);
+  EXPECT_EQ(received_primitive->acceleration, acceleration);
+}
+
+TEST_F(TrajectoryPointInterfaceTest, unsupported_motion_type_throws)
+{
+  auto primitive = std::make_shared<control::MotionPrimitive>();
+  EXPECT_THROW(traj_point_interface_->writeMotionPrimitive(primitive), urcl::UnsupportedMotionType);
 }
 
 int main(int argc, char* argv[])

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -32,6 +32,7 @@
 #include <ur_client_library/control/trajectory_point_interface.h>
 #include <ur_client_library/comm/tcp_socket.h>
 #include <ur_client_library/control/motion_primitives.h>
+#include <cmath>
 #include "ur_client_library/exceptions.h"
 
 using namespace urcl;
@@ -245,7 +246,7 @@ protected:
             (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
             (double)spl.acc[1] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
-            (double)spl.acc[2] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
+            round((double)spl.acc[2] / control::TrajectoryPointInterface::MULT_JOINTSTATE));
       }
       else
       {


### PR DESCRIPTION
This PR aims at supporting to send MoveP and MoveC commands to the robot directly through the TrajectoryPointInterface and the InstructionExecutor.