### PR TITLE
Add an API reference page to the docs

### DIFF
--- a/doc/api_reference.rst
+++ b/doc/api_reference.rst
@@ -1,0 +1,10 @@
+C++ API Reference
+=================
+
+There is a generated API documentation as a part of the ROS package documentation:
+
+https://docs.ros.org/en/rolling/p/ur_client_library/generated/index.html
+
+It is generated directly from the source code using Doxygen. Though the documentation is hosted
+inside the ROS documentation structure, it is not a ROS-specific API. The API is the same for all
+platforms.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,3 +20,4 @@ can be found on `GitHub <https://github.com/UniversalRobots/Universal_Robots_Cli
    examples
    real_time
    migration_notes
+   api_reference


### PR DESCRIPTION
There is a doxygen-generated API documentation as part of the ROS package documentation. We should at least link to that.