### PR TITLE
Fix the image sizes in architecture section

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -26,5 +26,5 @@ The image below shows a rough architecture overview that should help developers 
 modules present in this library. Note that this is an incomplete view on the classes involved.
 
 .. image:: images/urcl_architecture.svg
-  :width: 100%
+  :width: 1200
   :alt: architecture overview

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -11,7 +11,7 @@ be used in conjunction with the :ref:`reverse_interface` during trajectory forwa
 Communication regarding trajectory point execution would usually look like this:
 
 .. figure:: ../images/trajectory_interface.svg
-   :width: 100%
+   :width: 1200
    :alt: Trajectory interface
 
 Basically, the ``TrajectoryPointInterface`` transfers the trajectory points from the external


### PR DESCRIPTION
When browsing the documentation on a big screen images at 100% scale might look too big to read. The fixed size will be treated as a maximum size, so on smaller screens the image will still scale down.