### PR TITLE
Add new robot types to URSim startup script

### DIFF
--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -49,7 +49,7 @@ help()
   echo
   echo "Syntax: `basename "$0"` [-m|s|h]"
   echo "options:"
-  echo "    -m <model>     Robot model. One of [ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e, ur20, ur30]. Defaults to ur5e."
+  echo "    -m <model>     Robot model. One of [ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e, ur15, ur20, ur30]. Defaults to ur5e."
   echo "    -v <version>   URSim version that should be used.
                    See https://hub.docker.com/r/universalrobots/ursim_e-series/tags
                    for available versions. Defaults to 'latest'"
@@ -92,7 +92,7 @@ get_series_from_model()
     ur3e|ur5e|ur10e|ur16e)
       ROBOT_SERIES=e-series
       ;;
-    ur20|ur30)
+    ur15|ur20|ur30)
       ROBOT_SERIES=e-series
       ;;
     *)
@@ -131,7 +131,7 @@ strip_robot_model()
     ROBOT_MODEL=${robot_model^^}
   else
     ROBOT_MODEL=${robot_model^^}
-    # UR20 and UR30 need no further adjustment
+    # UR15, UR20 and UR30 need no further adjustment
     if [[ "$robot_model" = @(ur3e|ur5e|ur10e|ur16e) ]]; then
       ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
     fi
@@ -155,6 +155,8 @@ validate_parameters()
   [ "$IMAGE_URSIM_VERSION" == "latest" ] && return 0
   local MIN_CB3="3.14.3"
   local MIN_E_SERIES="5.9.4"
+  local MIN_UR15="5.22.0"
+  local MIN_UR15_X="10.8.0"
   local MIN_UR20="5.14.0"
   local MIN_UR30="5.15.0"
 
@@ -170,10 +172,12 @@ validate_parameters()
       verlte "$MIN_CB3" "$IMAGE_URSIM_VERSION" && return 0
       ;;
     e-series)
-      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur10e|ur16e|ur20|ur30) ]]; then
+      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur10e|ur16e|ur15|ur20|ur30) ]]; then
         echo "$ROBOT_MODEL is no valid e-series model!" && exit 1
       fi
-      if [[ $ROBOT_MODEL == "ur20" ]]; then
+      if [[ $ROBOT_MODEL == "ur15" ]]; then
+          MIN_VERSION=$MIN_UR15
+      elif [[ $ROBOT_MODEL == "ur20" ]]; then
           MIN_VERSION=$MIN_UR20
       elif [[ $ROBOT_MODEL == "ur30" ]]; then
           MIN_VERSION=$MIN_UR30
@@ -186,10 +190,11 @@ validate_parameters()
         echo "URSim version $URSIM_VERSION is unfortunately not supported"
         exit 1
       fi
-      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur10e|ur16e|ur20|ur30) ]]; then
+      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur10e|ur16e|ur15|ur20|ur30) ]]; then
         echo "$ROBOT_MODEL is no valid PolyscopeX model!" && exit 1
-      else
-        return 0
+      fi
+      if [[ $ROBOT_MODEL == "ur15" ]]; then
+          MIN_VERSION=$MIN_UR15_X
       fi
       ;;
   esac

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -163,7 +163,7 @@ validate_parameters()
   local MIN_UR20="5.14.0"
   local MIN_UR30="5.15.0"
   local MIN_UR7e="5.22.0" # and UR12e
-  local MIN_UR7e_X="10.8.0" # and UR12e
+  local MIN_UR7e_X="10.9.0" # and UR12e
 
   local MIN_VERSION="0.0"
 
@@ -424,10 +424,14 @@ main() {
     mkdir -p "${PROGRAM_STORAGE}"
     PROGRAM_STORAGE=$(realpath "$PROGRAM_STORAGE")
 
+    ROBOT_MODEL_CONTROLLER_FLAG=""
+    verlte "${POLYSCOPE_X_MAP[10.7.0]}" "$URSIM_VERSION" && verlte "$URSIM_VERSION" "${POLYSCOPE_X_MAP[10.8.0]}" && ROBOT_MODEL_CONTROLLER_FLAG="-e ROBOT_TYPE_CONTROLLER=${ROBOT_MODEL}"
+
     docker_cmd="docker run --rm -d \
       --net ursim_net --ip $IP_ADDRESS \
       -v ${PROGRAM_STORAGE}:/ur/bin/backend/applications \
       -e ROBOT_TYPE=${ROBOT_MODEL} \
+      $ROBOT_MODEL_CONTROLLER_FLAG \
       $PORT_FORWARDING \
       $DOCKER_ARGS \
       --name $CONTAINER_NAME \

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -40,7 +40,8 @@ TEST_RUN=false
 # The PolyScopeX URSim containers follow the SDK versioning scheme. This maps those to marketing
 # versions
 declare -Ag POLYSCOPE_X_MAP=( ["10.7.0"]="0.12.159"
-                              ["10.8.0"]="0.13.124")
+                              ["10.8.0"]="0.13.124"
+                              ["10.9.0"]="0.14.47")
 
 help()
 {
@@ -135,7 +136,11 @@ strip_robot_model()
     if [[ "$robot_model" = @(ur3e|ur5e|ur10e|ur16e) ]]; then
       ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
     elif [[ "$robot_model" = @(ur7e|ur12e) ]]; then
-      ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}e")
+      if [[ "$robot_series" == "polyscopex" ]]; then
+        ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
+      else
+        ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}e")
+      fi
     fi
   fi
 }

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -49,7 +49,7 @@ help()
   echo
   echo "Syntax: `basename "$0"` [-m|s|h]"
   echo "options:"
-  echo "    -m <model>     Robot model. One of [ur3, ur3e, ur5, ur5e, ur10, ur10e, ur16e, ur15, ur20, ur30]. Defaults to ur5e."
+  echo "    -m <model>     Robot model. One of [ur3, ur3e, ur5, ur5e, ur7e, ur10e, ur12e, ur16e, ur15, ur20, ur30]. Defaults to ur5e."
   echo "    -v <version>   URSim version that should be used.
                    See https://hub.docker.com/r/universalrobots/ursim_e-series/tags
                    for available versions. Defaults to 'latest'"
@@ -89,7 +89,7 @@ get_series_from_model()
     ur3|ur5|ur10)
       ROBOT_SERIES=cb3
       ;;
-    ur3e|ur5e|ur10e|ur16e)
+    ur3e|ur5e|ur7e|ur10e|ur12e|ur16e)
       ROBOT_SERIES=e-series
       ;;
     ur15|ur20|ur30)
@@ -134,6 +134,8 @@ strip_robot_model()
     # UR15, UR20 and UR30 need no further adjustment
     if [[ "$robot_model" = @(ur3e|ur5e|ur10e|ur16e) ]]; then
       ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
+    elif [[ "$robot_model" = @(ur7e|ur12e) ]]; then
+      ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}e")
     fi
   fi
 }
@@ -157,8 +159,11 @@ validate_parameters()
   local MIN_E_SERIES="5.9.4"
   local MIN_UR15="5.22.0"
   local MIN_UR15_X="10.8.0"
+  local MIN_POLYSCOPE_X="10.7.0"
   local MIN_UR20="5.14.0"
   local MIN_UR30="5.15.0"
+  local MIN_UR7e="5.22.0" # and UR12e
+  local MIN_UR7e_X="10.8.0" # and UR12e
 
   local MIN_VERSION="0.0"
 
@@ -172,7 +177,7 @@ validate_parameters()
       verlte "$MIN_CB3" "$IMAGE_URSIM_VERSION" && return 0
       ;;
     e-series)
-      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur10e|ur16e|ur15|ur20|ur30) ]]; then
+      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur7e|ur10e|ur12e|ur16e|ur15|ur20|ur30) ]]; then
         echo "$ROBOT_MODEL is no valid e-series model!" && exit 1
       fi
       if [[ $ROBOT_MODEL == "ur15" ]]; then
@@ -181,6 +186,8 @@ validate_parameters()
           MIN_VERSION=$MIN_UR20
       elif [[ $ROBOT_MODEL == "ur30" ]]; then
           MIN_VERSION=$MIN_UR30
+      elif [[ $ROBOT_MODEL == "ur7e" || $ROBOT_MODEL == "ur12e" ]]; then
+          MIN_VERSION=$MIN_UR7e
       else
           MIN_VERSION=$MIN_E_SERIES
       fi
@@ -190,11 +197,14 @@ validate_parameters()
         echo "URSim version $URSIM_VERSION is unfortunately not supported"
         exit 1
       fi
-      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur10e|ur16e|ur15|ur20|ur30) ]]; then
+      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur7e|ur10e|ur12e|ur16e|ur15|ur20|ur30) ]]; then
         echo "$ROBOT_MODEL is no valid PolyscopeX model!" && exit 1
-      fi
-      if [[ $ROBOT_MODEL == "ur15" ]]; then
+      elif [[ $ROBOT_MODEL == "ur7e" || $ROBOT_MODEL == "ur12e" ]]; then
+          MIN_VERSION=$MIN_UR7e_X
+      elif [[ $ROBOT_MODEL == "ur15" ]]; then
           MIN_VERSION=$MIN_UR15_X
+      else
+        MIN_VERSION=$MIN_POLYSCOPE_X
       fi
       ;;
   esac

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -171,9 +171,10 @@ setup() {
   run test_input_handling -m ur7e -v 5.22.0
   echo "$output"
   [ $status -eq 0 ]
-  #run test_input_handling -m ur7e -v 10.9.0
-  #echo "$output"
-  #[ $status -eq 0 ]
+
+  run test_input_handling -m ur7e -v 10.9.0
+  echo "$output"
+  [ $status -eq 0 ]
 }
 
 @test "test ur12e min version" {
@@ -190,9 +191,10 @@ setup() {
   run test_input_handling -m ur12e -v 5.22.0
   echo "$output"
   [ $status -eq 0 ]
-  #run test_input_handling -m ur12e -v 10.9.0
-  #echo "$output"
-  #[ $status -eq 0 ]
+
+  run test_input_handling -m ur12e -v 10.9.0
+  echo "$output"
+  [ $status -eq 0 ]
 }
 
 @test "test ur15 min version" {

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -38,6 +38,10 @@ setup() {
   echo "ROBOT_SERIES: $ROBOT_SERIES"
   [ "$ROBOT_SERIES" = "cb3" ]
 
+  get_series_from_model "ur15"
+  echo "ROBOT_SERIES: $ROBOT_SERIES"
+  [ "$ROBOT_SERIES" = "e-series" ]
+
   get_series_from_model "ur20"
   echo "ROBOT_SERIES: $ROBOT_SERIES"
   [ "$ROBOT_SERIES" = "e-series" ]
@@ -146,6 +150,25 @@ setup() {
   [ "$ROBOT_MODEL" = "ur5e" ]
   [ "$ROBOT_SERIES" = "e-series" ]
   [ "$URSIM_VERSION" = "latest" ]  
+}
+
+@test "test ur15 min version" {
+  run test_input_handling -m ur15 -v 3.14.3
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur15 -v 5.21.0
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur15 -v 10.7.0
+  echo "$output"
+  [ $status -eq 1 ]
+
+  run test_input_handling -m ur15 -v 5.22.0
+  echo "$output"
+  [ $status -eq 0 ]
+  run test_input_handling -m ur15 -v 10.8.0
+  echo "$output"
+  [ $status -eq 0 ]
 }
 
 @test "test ur20 min version" {

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -1,3 +1,8 @@
+setup_file() {
+  docker pull universalrobots/ursim_cb3:latest
+  docker pull universalrobots/ursim_e-series:latest
+}
+
 setup() {
     # get the containing directory of this file
     # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -149,7 +149,45 @@ setup() {
   test_input_handling
   [ "$ROBOT_MODEL" = "ur5e" ]
   [ "$ROBOT_SERIES" = "e-series" ]
-  [ "$URSIM_VERSION" = "latest" ]  
+  [ "$URSIM_VERSION" = "latest" ]
+}
+
+@test "test ur7e min version" {
+  run test_input_handling -m ur7e -v 3.14.3
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur7e -v 5.21.0
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur7e -v 10.8.0
+  echo "$output"
+  [ $status -eq 1 ]
+
+  run test_input_handling -m ur7e -v 5.22.0
+  echo "$output"
+  [ $status -eq 0 ]
+  #run test_input_handling -m ur7e -v 10.9.0
+  #echo "$output"
+  #[ $status -eq 0 ]
+}
+
+@test "test ur12e min version" {
+  run test_input_handling -m ur12e -v 3.14.3
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur12e -v 5.21.0
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur12e -v 10.8.0
+  echo "$output"
+  [ $status -eq 1 ]
+
+  run test_input_handling -m ur12e -v 5.22.0
+  echo "$output"
+  [ $status -eq 0 ]
+  #run test_input_handling -m ur12e -v 10.9.0
+  #echo "$output"
+  #[ $status -eq 0 ]
 }
 
 @test "test ur15 min version" {
@@ -229,7 +267,7 @@ setup() {
   echo "$output"
   image=$(echo "$output" | tail -n1 | awk '{ print $NF }')
   [ $status -eq 0 ]
-  [ "$image" == "universalrobots/ursim_cb3:latest" ]
+  [[ "$image" =~ universalrobots/ursim_cb3:[0-9]+\.[0-9]+\.[0-9]+ ]]
 }
 
 @test "docker image e-series latest" {
@@ -237,7 +275,7 @@ setup() {
   echo "$output"
   image=$(echo "$output" | tail -n1 | awk '{ print $NF }')
   [ $status -eq 0 ]
-  [ "$image" == "universalrobots/ursim_e-series:latest" ]
+  [[ "$image" =~ universalrobots/ursim_e-series:[0-9]+\.[0-9]+\.[0-9]+ ]]
 }
 
 @test "docker image cb3 specific" {
@@ -488,5 +526,66 @@ setup() {
 @test "setting_detached_argument" {
   test_input_handling -d
   [ "$DETACHED" = "true" ]
+}
+
+@test "successful_validate_parameters" {
+  URSIM_VERSION="5.21.0"
+  ROBOT_MODEL="ur10e"
+  ROBOT_SERIES="e-series"
+
+  validate_parameters
+}
+
+@test "successful_validate_parameters_latest_e" {
+  URSIM_VERSION="latest"
+  ROBOT_MODEL="ur10e"
+  ROBOT_SERIES="e-series"
+
+  validate_parameters
+}
+
+@test "validate_parameters_on_invalid_model_fails_e" {
+  URSIM_VERSION="latest"
+  ROBOT_MODEL="ur10"
+  ROBOT_SERIES="e-series"
+
+  run validate_parameters
+  [ $status -eq 1 ]
+}
+
+@test "successful_validate_parameters_latest_cb3" {
+  URSIM_VERSION="latest"
+  ROBOT_MODEL="ur10"
+  ROBOT_SERIES="cb3"
+
+  validate_parameters
+}
+
+@test "validate_parameters_on_invalid_model_fails_cb3" {
+  URSIM_VERSION="latest"
+  ROBOT_MODEL="ur103"
+  ROBOT_SERIES="cb3"
+
+  run validate_parameters
+  [ $status -eq 1 ]
+}
+
+@test "validate_parameters_on_invalid_version_fails" {
+  URSIM_VERSION="foobar"
+  ROBOT_MODEL="ur10e"
+  ROBOT_SERIES="e-series"
+
+  run validate_parameters
+  [ $status -eq 1 ]
+}
+
+@test "validate_parameters_on_invalid_model_fails" {
+
+  URSIM_VERSION="5.21.0"
+  ROBOT_MODEL="ur10"
+  ROBOT_SERIES="e-series"
+  run validate_parameters
+  [ $status -eq 1 ]
+
 }
 

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -338,6 +338,14 @@ setup() {
   strip_robot_model ur30 polyscopex
   echo "Robot model is: $ROBOT_MODEL"
   [ "$ROBOT_MODEL" = "UR30" ]
+
+  strip_robot_model ur7e e-series
+  echo "Robot model is: $ROBOT_MODEL"
+  [ "$ROBOT_MODEL" = "UR7e" ]
+
+  strip_robot_model ur12e e-series
+  echo "Robot model is: $ROBOT_MODEL"
+  [ "$ROBOT_MODEL" = "UR12e" ]
 }
 
 @test "help_prints_fine" {


### PR DESCRIPTION
This adds support for starting robot models

- UR7e
- UR12e
- UR15

This also adds support for URSim 5.22 (which is the requirement for the above robot models)