### PR TITLE
Disable checking links for two broken ones

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -32,6 +32,8 @@ jobs:
             --exclude '^http://192\.168\.56\.101'
             --exclude 'kernel\.org\/pub\/linux\/kernel'
             --exclude 'releases/download/v\$%7BURCAP_VERSION%7D/externalcontrol-\$%7BURCAP_VERSION%7D\.jar'
+            --exclude '^http://rosin-project\.eu'
+            --exclude '2013181\/gdb-causes-sem-wait-to-fail-with-eintr-error'
             --max-concurrency 1
             './**/*.md' './**/*.html' './**/*.rst' './**/*.cpp' './**/*.h' './**/*.py'
       - name: Save lychee cache


### PR DESCRIPTION
- rosin-project.eu seems to be down. We want to keep attribution to the project, nevertheless.
- We get a 403 on that stackoverflow question. I don't know why, but let's ignore that in the report.