### PR TITLE
readme: load ROSin imgs from press_kit repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,14 @@ Developed in collaboration between:
 -->
 
 <a href="http://rosin-project.eu">
-  <img src="http://rosin-project.eu/wp-content/uploads/rosin_ack_logo_wide.png"
+  <img src="https://raw.githubusercontent.com/rosin-project/press_kit/master/img/rosin_ack_logo_wide.png"
        alt="rosin_logo" height="60" >
 </a>
 
 Supported by ROSIN - ROS-Industrial Quality-Assured Robot Software Components.
 More information: <a href="http://rosin-project.eu">rosin-project.eu</a>
 
-<img src="http://rosin-project.eu/wp-content/uploads/rosin_eu_flag.jpg"
+<img src="https://raw.githubusercontent.com/rosin-project/press_kit/master/img/rosin_eu_flag.jpg"
      alt="eu_flag" height="45" align="left" >
 
 This project has received funding from the European Union’s Horizon 2020


### PR DESCRIPTION
As per title.

I pushed the logo + EU flag to [rosin-project/press_kit](https://github.com/rosin-project/press_kit).
