### PR TITLE
Fix driver branch for Jazzy downstream build

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -19,7 +19,7 @@ jobs:
           - NAME: humble
             DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#humble"
           - NAME: jazzy
-            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#main"
+            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#jazzy"
           - NAME: kilted
             DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#main"
           - NAME: rolling


### PR DESCRIPTION
The driver has branched out for Jazzy, we need to update this.