### PR TITLE
Minimal support for building on macOS

### DIFF
--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -55,7 +55,11 @@ void TCPSocket::setupOptions()
 {
   int flag = 1;
   ur_setsockopt(socket_fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
+
+  // macOS does not have TCP_QUICKACK
+#ifdef TCP_QUICKACK
   ur_setsockopt(socket_fd_, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(int));
+#endif
 
   if (recv_timeout_ != nullptr)
   {


### PR DESCRIPTION
I'd like to be able to do iterative development against the UR client library on macOS since that's my local platform. I don't need to actually run anything there, necessarily, though it would, ultimately, be nice to have the simulator working there too. This is enough to get the client library to build from source on macOS. Note though that it is incomplete due to #340 - the installed library cannot yet be consumed since the `endian.h` header doesn't get installed. 