### PR TITLE
Install endian.h and add that to the target include directories...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,18 @@ add_library(ur_client_library::urcl ALIAS urcl)
 target_compile_features(urcl PUBLIC cxx_std_17)
 
 if(MSVC)
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/endian)
   target_link_libraries(urcl ws2_32)
+  target_include_directories(urcl PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/endian>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}/3rdparty>
+  )
 else()
+  if(APPLE)
+    target_include_directories(urcl PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/endian>
+      $<INSTALL_INTERFACE:include/${PROJECT_NAME}/3rdparty>
+    )
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
   target_compile_options(urcl PRIVATE -Wall -Wextra -Wno-unused-parameter)
 
@@ -70,7 +79,7 @@ else()
   endif()
 endif()
 
-target_include_directories( urcl PUBLIC
+target_include_directories(urcl PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
@@ -102,6 +111,9 @@ install(TARGETS urcl EXPORT urcl_targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY 3rdparty/endian/ DESTINATION include/${PROJECT_NAME}/3rdparty
+  FILES_MATCHING PATTERN "*.h"
+)
 
 install(EXPORT urcl_targets
   DESTINATION lib/cmake/ur_client_library


### PR DESCRIPTION
... on Windows and MacOS

When installing this library the source directory might not be available, thus we need to install the header. However, we need to make sure it is doesn't spill into the global include directories to shadow and os-specific installations e.g. on Linux.

Installing it to a 3rdparty folder and adding that to the target_include_directories on Windows should do the trick from my understanding.

This should fix #340 and is related to #341.

@acmorrow As I don't have a lot of experience with MacOS or Windows development - could I ask you for a review regarding MacOS?