### PR TITLE
Join thread_move instead of killing it

### DIFF
--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -806,7 +806,7 @@ while control_mode > MODE_STOPPED:
 end
 
 textmsg("ExternalControl: Stopping communication and control")
-kill thread_move
+join thread_move
 kill thread_trajectory
 kill thread_script_commands
 stopj(STOPJ_ACCELERATION)


### PR DESCRIPTION
Once we change the operational mode to STOPPED in the main thread, the move thread should stop by itself, so we can wait for it to join.