### PR TITLE
Initialize ReverseInterface with a config struct

### DIFF
--- a/include/ur_client_library/control/reverse_interface.h
+++ b/include/ur_client_library/control/reverse_interface.h
@@ -91,6 +91,7 @@ public:
    * \param handle_program_state Function handle to a callback on program state changes.
    * \param step_time The robots step time
    */
+  [[deprecated("Use ReverseInterfaceConfig instead of port, handle_program_state and step_time parameters")]]
   ReverseInterface(uint32_t port, std::function<void(bool)> handle_program_state,
                    std::chrono::milliseconds step_time = std::chrono::milliseconds(8));
 

--- a/include/ur_client_library/control/reverse_interface.h
+++ b/include/ur_client_library/control/reverse_interface.h
@@ -34,6 +34,7 @@
 #include "ur_client_library/types.h"
 #include "ur_client_library/log.h"
 #include "ur_client_library/ur/robot_receive_timeout.h"
+#include "ur_client_library/ur/version_information.h"
 #include <cstring>
 #include <endian.h>
 #include <condition_variable>
@@ -62,6 +63,17 @@ enum class FreedriveControlMessage : int32_t
   FREEDRIVE_START = 1,  ///< Represents command to start freedrive mode.
 };
 
+struct ReverseInterfaceConfig
+{
+  uint32_t port = 50001;  //!< Port the server is started on
+  std::function<void(bool)> handle_program_state = [](bool) {
+    return;
+  };  //!< Function handle to a callback on program state changes.
+  std::chrono::milliseconds step_time = std::chrono::milliseconds(8);  //!< The robots step time
+  uint32_t keepalive_count = 0;                                      //!< Number of allowed timeout reads on the robot.
+  VersionInformation robot_software_version = VersionInformation();  //!< The robot software version.
+};
+
 /*!
  * \brief The ReverseInterface class handles communication to the robot. It starts a server and
  * waits for the robot to connect via its URCaps program.
@@ -81,6 +93,8 @@ public:
    */
   ReverseInterface(uint32_t port, std::function<void(bool)> handle_program_state,
                    std::chrono::milliseconds step_time = std::chrono::milliseconds(8));
+
+  ReverseInterface(const ReverseInterfaceConfig& config);
 
   /*!
    * \brief Disconnects possible clients so the reverse interface object can be safely destroyed.
@@ -166,6 +180,8 @@ protected:
   std::function<void(const int)> disconnection_callback_ = nullptr;
   socket_t client_fd_;
   comm::TCPServer server_;
+
+  VersionInformation robot_software_version_;
 
   template <typename T>
   size_t append(uint8_t* buffer, T& val)

--- a/include/ur_client_library/control/script_command_interface.h
+++ b/include/ur_client_library/control/script_command_interface.h
@@ -61,6 +61,7 @@ public:
    *
    * \param port Port to start the server on
    */
+  [[deprecated("Use ReverseInterfaceConfig instead of port, handle_program_state and step_time parameters")]]
   ScriptCommandInterface(uint32_t port);
 
   /*!

--- a/include/ur_client_library/control/script_command_interface.h
+++ b/include/ur_client_library/control/script_command_interface.h
@@ -64,6 +64,14 @@ public:
   ScriptCommandInterface(uint32_t port);
 
   /*!
+   * \brief Creates a ScriptCommandInterface object, including a new TCPServer
+   *
+   * \param config Configuration for the ReverseInterface, including the port to start the server
+   * on.
+   */
+  ScriptCommandInterface(const ReverseInterfaceConfig& config);
+
+  /*!
    * \brief Zero the force torque sensor
    *
    * \returns True, if the write was performed successfully, false otherwise.

--- a/src/control/reverse_interface.cpp
+++ b/src/control/reverse_interface.cpp
@@ -35,10 +35,16 @@ namespace control
 {
 ReverseInterface::ReverseInterface(uint32_t port, std::function<void(bool)> handle_program_state,
                                    std::chrono::milliseconds step_time)
+  : ReverseInterface(ReverseInterfaceConfig{ port, handle_program_state, step_time })
+{
+}
+
+ReverseInterface::ReverseInterface(const ReverseInterfaceConfig& config)
   : client_fd_(INVALID_SOCKET)
-  , server_(port)
-  , handle_program_state_(handle_program_state)
-  , step_time_(step_time)
+  , server_(config.port)
+  , robot_software_version_(config.robot_software_version)
+  , handle_program_state_(config.handle_program_state)
+  , step_time_(config.step_time)
   , keep_alive_count_modified_deprecated_(false)
 {
   handle_program_state_(false);

--- a/src/control/script_command_interface.cpp
+++ b/src/control/script_command_interface.cpp
@@ -33,9 +33,8 @@ namespace urcl
 {
 namespace control
 {
-ScriptCommandInterface::ScriptCommandInterface(uint32_t port) : ReverseInterface(port, [](bool foo) { return foo; })
+ScriptCommandInterface::ScriptCommandInterface(uint32_t port) : ScriptCommandInterface(ReverseInterfaceConfig{ port })
 {
-  client_connected_ = false;
 }
 
 ScriptCommandInterface::ScriptCommandInterface(const ReverseInterfaceConfig& config) : ReverseInterface(config)

--- a/src/control/script_command_interface.cpp
+++ b/src/control/script_command_interface.cpp
@@ -38,6 +38,11 @@ ScriptCommandInterface::ScriptCommandInterface(uint32_t port) : ReverseInterface
   client_connected_ = false;
 }
 
+ScriptCommandInterface::ScriptCommandInterface(const ReverseInterfaceConfig& config) : ReverseInterface(config)
+{
+  client_connected_ = false;
+}
+
 bool ScriptCommandInterface::zeroFTSensor()
 {
   const int message_length = 1;

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -56,7 +56,7 @@ std::string trajectoryResultToString(const TrajectoryResult result)
   }
 }
 
-TrajectoryPointInterface::TrajectoryPointInterface(uint32_t port) : ReverseInterface(port, [](bool foo) { return foo; })
+TrajectoryPointInterface::TrajectoryPointInterface(uint32_t port) : ReverseInterface(ReverseInterfaceConfig{ port })
 {
 }
 

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -89,7 +89,10 @@ void UrDriver::init(const UrDriverConfiguration& config)
   std::string local_ip = config.reverse_ip.empty() ? rtde_client_->getIP() : config.reverse_ip;
 
   trajectory_interface_.reset(new control::TrajectoryPointInterface(config.trajectory_port));
-  script_command_interface_.reset(new control::ScriptCommandInterface(config.script_command_port));
+  control::ReverseInterfaceConfig script_command_config;
+  script_command_config.port = config.script_command_port;
+  script_command_config.robot_software_version = rtde_client_->getVersion();
+  script_command_interface_.reset(new control::ScriptCommandInterface(script_command_config));
 
   startPrimaryClientCommunication();
 
@@ -622,7 +625,12 @@ void UrDriver::setupReverseInterface(const uint32_t reverse_port)
 {
   auto rtde_frequency = rtde_client_->getTargetFrequency();
   auto step_time = std::chrono::milliseconds(static_cast<int>(1000 / rtde_frequency));
-  reverse_interface_.reset(new control::ReverseInterface(reverse_port, handle_program_state_, step_time));
+  control::ReverseInterfaceConfig config;
+  config.step_time = step_time;
+  config.port = reverse_port;
+  config.handle_program_state = handle_program_state_;
+  config.robot_software_version = robot_version_;
+  reverse_interface_.reset(new control::ReverseInterface(config));
 }
 
 void UrDriver::startPrimaryClientCommunication()

--- a/tests/test_reverse_interface.cpp
+++ b/tests/test_reverse_interface.cpp
@@ -150,8 +150,10 @@ protected:
 
   void SetUp()
   {
-    reverse_interface_.reset(new control::ReverseInterface(
-        50001, std::bind(&ReverseIntefaceTest::handleProgramState, this, std::placeholders::_1)));
+    control::ReverseInterfaceConfig config;
+    config.port = 50001;
+    config.handle_program_state = std::bind(&ReverseIntefaceTest::handleProgramState, this, std::placeholders::_1);
+    reverse_interface_.reset(new control::ReverseInterface(config));
     client_.reset(new Client(50001));
   }
 

--- a/tests/test_script_command_interface.cpp
+++ b/tests/test_script_command_interface.cpp
@@ -102,7 +102,7 @@ protected:
 
   void SetUp()
   {
-    script_command_interface_.reset(new control::ScriptCommandInterface(50004));
+    script_command_interface_.reset(new control::ScriptCommandInterface(control::ReverseInterfaceConfig{ 50004 }));
     client_.reset(new Client(50004));
   }
 


### PR DESCRIPTION
This way, we will be able to supply additional information such as the robot's software version to the ReverseInterface without breaking the API.

This is e.g. used in #348