### PR TITLE
REVERT_ME: Switch version checks to 5.22.0 as that't the beta version

### DIFF
--- a/examples/pd_controller_example.cpp
+++ b/examples/pd_controller_example.cpp
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
 
   {
     auto robot_version = g_my_robot->getUrDriver()->getVersion();
-    if (robot_version < urcl::VersionInformation::fromString("5.23.0") ||
+    if (robot_version < urcl::VersionInformation::fromString("5.22.0") ||  // ToDo: Increase to 5.23.0 once released
         (robot_version.major > 5 && robot_version < urcl::VersionInformation::fromString("10.10.0")))
     {
       URCL_LOG_ERROR("This example requires a robot with at least version 5.23.0 / 10.10.0. Your robot has version %s.",

--- a/examples/torque_control.cpp
+++ b/examples/torque_control.cpp
@@ -67,7 +67,8 @@ int main(int argc, char* argv[])
   // software versions.
   {
     auto robot_version = g_my_robot->getUrDriver()->getVersion();
-    if (robot_version < urcl::VersionInformation::fromString("5.23.0") ||
+    // ToDo: Increase to 5.23.0 once released
+    if (robot_version < urcl::VersionInformation::fromString("5.22.0") ||
         (robot_version.major > 5 && robot_version < urcl::VersionInformation::fromString("10.10.0")))
     {
       URCL_LOG_ERROR("This example requires a robot with at least version 5.23.0 / 10.10.0. Your robot has version %s.",

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -270,7 +270,7 @@ thread torqueThread():
   textmsg("ExternalControl: Starting torque thread")
   while control_mode == MODE_TORQUE:
     torque = cmd_torque
-    {% if ROBOT_SOFTWARE_VERSION >= v5.23.0 %}
+    {% if ROBOT_SOFTWARE_VERSION >= v5.22.0 %} # ToDo: Increase to 5.23.0 once released
       {% if ROBOT_SOFTWARE_VERSION < v6.0.0 %}
     torque_command(torque, friction_comp=friction_compensation_enabled)
       {% elif ROBOT_SOFTWARE_VERSION >= v10.10.0 %}
@@ -688,7 +688,7 @@ end
 thread PDControlThread():
   while control_mode == MODE_PD_CONTROLLER_JOINT or control_mode == MODE_PD_CONTROLLER_TASK: 
     local q_err = cmd_servo_q - get_actual_joint_positions()
-    {% if ROBOT_SOFTWARE_VERSION >= v5.23.0 %}
+    {% if ROBOT_SOFTWARE_VERSION >= v5.22.0 %} # ToDo: Increase to 5.23.0 once released
       {% if ROBOT_SOFTWARE_VERSION < v6.0.0 %}
     local tau = pd_controller_gains.kp * q_err - pd_controller_gains.kd  * get_actual_joint_speeds()
     tau = clamp_array(tau, max_joint_torques)

--- a/src/control/script_command_interface.cpp
+++ b/src/control/script_command_interface.cpp
@@ -228,7 +228,8 @@ bool ScriptCommandInterface::endToolContact()
 
 bool ScriptCommandInterface::setFrictionCompensation(const bool friction_compensation_enabled)
 {
-  robotVersionSupportsCommandOrWarn(urcl::VersionInformation::fromString("5.23.0"),
+  // ToDo: Increase to 5.23.0 once released
+  robotVersionSupportsCommandOrWarn(urcl::VersionInformation::fromString("5.22.0"),
                                     urcl::VersionInformation::fromString("10.10.0"), __func__);
   const int message_length = 2;
   uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];
@@ -253,7 +254,8 @@ bool ScriptCommandInterface::setFrictionCompensation(const bool friction_compens
 
 bool ScriptCommandInterface::setPDControllerGains(const urcl::vector6d_t* kp, const urcl::vector6d_t* kd)
 {
-  robotVersionSupportsCommandOrWarn(urcl::VersionInformation::fromString("5.23.0"),
+  // ToDo: Increase to 5.23.0 once released
+  robotVersionSupportsCommandOrWarn(urcl::VersionInformation::fromString("5.22.0"),
                                     urcl::VersionInformation::fromString("10.10.0"), __func__);
   const int message_length = 13;
   uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];
@@ -287,7 +289,8 @@ bool ScriptCommandInterface::setPDControllerGains(const urcl::vector6d_t* kp, co
 
 bool ScriptCommandInterface::setMaxJointTorques(const urcl::vector6d_t* max_joint_torques)
 {
-  robotVersionSupportsCommandOrWarn(urcl::VersionInformation::fromString("5.23.0"),
+  // ToDo: Increase to 5.23.0 once released
+  robotVersionSupportsCommandOrWarn(urcl::VersionInformation::fromString("5.22.0"),
                                     urcl::VersionInformation::fromString("10.10.0"), __func__);
   const int message_length = 7;
   uint8_t buffer[sizeof(int32_t) * MAX_MESSAGE_LENGTH];


### PR DESCRIPTION
Temporarily relax the version check for torque control features.

The torque control features will be available from 5.23.0 on. However, as we are currently running a public beta program, where the reported software version is 5.22.0 we should relax the version check until 5.23.0 is actually released.