### PR TITLE
Change ubuntu manpage link from bionic to noble

### DIFF
--- a/doc/real_time.rst
+++ b/doc/real_time.rst
@@ -225,7 +225,7 @@ Setup user privileges to use real-time scheduling
 -------------------------------------------------
 
 To be able to schedule threads with user privileges (what the driver will do) you'll have to change
-the user's limits by changing ``/etc/security/limits.conf`` (See `the manpage <https://manpages.ubuntu.com/manpages/bionic/man5/limits.conf.5.html>`_ for details)
+the user's limits by changing ``/etc/security/limits.conf`` (See `the manpage <https://manpages.ubuntu.com/manpages/noble/en/man5/limits.conf.5.html>`_ for details)
 
 We recommend to setup a group for real-time users instead of writing a fixed username into the config
 file:


### PR DESCRIPTION
While there is a redirection in place, the target URL technically doesn't exist anymore.

This should fix the check_links workflow.