### PR TITLE
Add support for UR8 LONG

### DIFF
--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -95,6 +95,7 @@ enum class RobotType : int8_t
   UR10 = 2,
   UR3 = 3,
   UR16 = 4,
+  UR8LONG = 6,
   UR20 = 7,
   UR30 = 8,
   UR15 = 9

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -43,7 +43,7 @@ help()
   echo
   echo "Syntax: `basename "$0"` [-m|s|h]"
   echo "options:"
-  echo "    -m <model>     Robot model. One of [ur3, ur3e, ur5, ur5e, ur7e, ur10e, ur12e, ur16e, ur15, ur20, ur30]. Defaults to ur5e."
+  echo "    -m <model>     Robot model. One of [ur3, ur3e, ur5, ur5e, ur7e, ur8long, ur10e, ur12e, ur16e, ur15, ur20, ur30]. Defaults to ur5e."
   echo "    -v <version>   URSim version that should be used.
                    See https://hub.docker.com/r/universalrobots/ursim_e-series/tags
                    for available versions. Defaults to 'latest'"
@@ -86,7 +86,7 @@ get_series_from_model()
     ur3e|ur5e|ur7e|ur10e|ur12e|ur16e)
       ROBOT_SERIES=e-series
       ;;
-    ur15|ur20|ur30)
+    ur8long|ur15|ur20|ur30)
       ROBOT_SERIES=e-series
       ;;
     *)
@@ -125,7 +125,7 @@ strip_robot_model()
     ROBOT_MODEL=${robot_model^^}
   else
     ROBOT_MODEL=${robot_model^^}
-    # UR15, UR20 and UR30 need no further adjustment
+    # UR8LONG, UR15, UR20 and UR30 need no further adjustment
     if [[ "$robot_model" = @(ur3e|ur5e|ur10e|ur16e) ]]; then
       ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
     elif [[ "$robot_model" = @(ur7e|ur12e) ]]; then
@@ -153,6 +153,8 @@ validate_parameters()
   local MIN_UR30="5.15.0"
   local MIN_UR7e="5.22.0" # and UR12e
   local MIN_UR7e_X="10.9.0" # and UR12e
+  local MIN_UR8LONG="5.23.0"
+  local MIN_UR8LONG_X="10.11.0"
 
   local URSIM_VERSION_CHECK="$URSIM_VERSION"
   if [[ "$URSIM_VERSION" == "latest" ]]; then
@@ -182,7 +184,7 @@ validate_parameters()
       verlte "$MIN_CB3" "$URSIM_VERSION_CHECK" && return 0
       ;;
     e-series)
-      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur7e|ur10e|ur12e|ur16e|ur15|ur20|ur30) ]]; then
+      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur7e|ur8long|ur10e|ur12e|ur16e|ur15|ur20|ur30) ]]; then
         echo "$ROBOT_MODEL is no valid e-series model!" && exit 1
       fi
       if [[ $ROBOT_MODEL == "ur15" ]]; then
@@ -193,6 +195,8 @@ validate_parameters()
           MIN_VERSION=$MIN_UR30
       elif [[ $ROBOT_MODEL == "ur7e" || $ROBOT_MODEL == "ur12e" ]]; then
           MIN_VERSION=$MIN_UR7e
+      elif [[ $ROBOT_MODEL == "ur8long" ]]; then
+          MIN_VERSION=$MIN_UR8LONG
       else
           MIN_VERSION=$MIN_E_SERIES
       fi
@@ -202,10 +206,12 @@ validate_parameters()
         echo "PolyscopeX is only supported from version $MIN_POLYSCOPE_X onwards"
         exit 1
       fi
-      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur7e|ur10e|ur12e|ur16e|ur15|ur20|ur30) ]]; then
+      if [[ $ROBOT_MODEL != @(ur3e|ur5e|ur7e|ur8long|ur10e|ur12e|ur16e|ur15|ur20|ur30) ]]; then
         echo "$ROBOT_MODEL is no valid PolyscopeX model!" && exit 1
       elif [[ $ROBOT_MODEL == "ur7e" || $ROBOT_MODEL == "ur12e" ]]; then
           MIN_VERSION=$MIN_UR7e_X
+      elif [[ $ROBOT_MODEL == "ur8long" ]]; then
+          MIN_VERSION=$MIN_UR8LONG_X
       elif [[ $ROBOT_MODEL == "ur15" ]]; then
           MIN_VERSION=$MIN_UR15_X
       else

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -247,6 +247,24 @@ setup() {
   [ $status -eq 0 ]
 }
 
+@test "test ur8long min version" {
+  run test_input_handling -m ur8long -v 3.14.3
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur8long -v 5.22.3
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur8long -v 5.23.0
+  echo "$output"
+  [ $status -eq 0 ]
+  run test_input_handling -m ur8long -v 10.10.0
+  echo "$output"
+  [ $status -eq 1 ]
+  run test_input_handling -m ur8long -v 10.11.0
+  echo "$output"
+  [ $status -eq 0 ]
+}
+
 @test "unsupported versions raise error" {
   run main -v 1.2.3 -t
   echo "$output"


### PR DESCRIPTION
Add support for the [recently released UR8 Long](https://www.universal-robots.com/news-and-media/news-center/universal-robots-unveils-ur8-long/).

- Add it as a model to start_ursim.sh
- Add it to `URCL::RobotType