### PR TITLE
Add const qualifier to get functions and changed map value retrieval to at() function

### DIFF
--- a/include/ur_client_library/rtde/data_package.h
+++ b/include/ur_client_library/rtde/data_package.h
@@ -125,11 +125,11 @@ public:
    * \returns True on success, false if the field cannot be found inside the package.
    */
   template <typename T>
-  bool getData(const std::string& name, T& val)
+  bool getData(const std::string& name, T& val) const
   {
     if (data_.find(name) != data_.end())
     {
-      val = std::get<T>(data_[name]);
+      val = std::get<T>(data_.at(name));
     }
     else
     {
@@ -149,13 +149,13 @@ public:
    * \returns True on success, false if the field cannot be found inside the package.
    */
   template <typename T, size_t N>
-  bool getData(const std::string& name, std::bitset<N>& val)
+  bool getData(const std::string& name, std::bitset<N>& val) const
   {
     static_assert(sizeof(T) * 8 >= N, "Bitset is too large for underlying variable");
 
     if (data_.find(name) != data_.end())
     {
-      val = std::bitset<N>(std::get<T>(data_[name]));
+      val = std::bitset<N>(std::get<T>(data_.at(name)));
     }
     else
     {
@@ -179,7 +179,7 @@ public:
   {
     if (data_.find(name) != data_.end())
     {
-      data_[name] = val;
+      data_.at(name) = val;
     }
     else
     {


### PR DESCRIPTION
Currently getData functions are not const, although they shouldn't modify the data since they are retrieval functions.

It is a minor change I though about while using the library.