### PR TITLE
Add release.yml for auto-generated changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+---
+changelog:
+  exclude:
+    labels:
+      - release
+  categories:
+    - title: Bugfixes
+      labels:
+        - bugfix
+        - bug
+    - title: New features
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - documentation
+    - title: CI/ Repo / Packages
+      labels:
+        - CI
+        - package
+        - dependencies
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
That file is parsed by GitHub when creating releases which makes the release process easier. Basically, PRs are grouped by their labels.