### PR TITLE
Add bit for 3PE stoppage to UrRtdeSafetyStatusBits

### DIFF
--- a/include/ur_client_library/rtde/rtde_client.h
+++ b/include/ur_client_library/rtde/rtde_client.h
@@ -75,7 +75,7 @@ enum class UrRtdeSafetyStatusBits
   IS_VIOLATION = 8,
   IS_FAULT = 9,
   IS_STOPPED_DUE_TO_SAFETY = 10,
-  IS_SYSTEM_THREE_POSITION_ENABLING_STOPPED = 11
+  IS_3PE_INPUT_ACTIVE = 11
 };
 
 enum class ClientState


### PR DESCRIPTION
Fixes #394.

I think this is really all that is required, unless you have unit tests that you need, but I didn't find any results in the codebase for other symbols from this enumeration.