### PR TITLE
Docs: Remove beta statement for External Control URCapX

### DIFF
--- a/doc/setup/robot_setup.rst
+++ b/doc/setup/robot_setup.rst
@@ -264,8 +264,3 @@ application.
       If you select the External Control program node, you'll see a button "Update program"
       appearing next to it. With the external application started, press it to receive the script
       code.
-
-      .. warning::
-
-         Support for PolyScope X isn't fully developed, yet. Please consider using External Control
-         with PolyScope X as an open beta.


### PR DESCRIPTION
I think, it is safe to remove the beta notice from the PolyScope X External Control URCapX. We have released that in version 1.0.0 already and we have no outstanding work regarding feature parity with that URCapX.