### PR TITLE
Do not disconnect dashboard_client on read timeout

### DIFF
--- a/src/ur/dashboard_client_implementation_g5.cpp
+++ b/src/ur/dashboard_client_implementation_g5.cpp
@@ -167,10 +167,7 @@ std::string DashboardClientImplG5::read()
   {
     if (!TCPSocket::read((uint8_t*)&character, 1, read_chars))
     {
-      disconnect();
-      throw TimeoutException("Did not receive answer from dashboard server in time. Disconnecting from dashboard "
-                             "server.",
-                             *recv_timeout_);
+      throw TimeoutException("Did not receive answer from dashboard server in time.", *recv_timeout_);
     }
     result << character;
     if (character == '\n')


### PR DESCRIPTION
Currently, we disconnect from the dashboard server whenever we don't receive an answer inside the configured timeout and we throw an exception. The idea behind that was, that if we don't get an answer in time there's probably something wrong with the connection, anyway. However, it could just be that the command in question takes longer to process. There are a couple of commands where we manually add higher timeouts, such as generating the flight report, but also powering on the robot after an update can take longer if the firmware has to be updated.

With the change in this commit, we still throw the exception leaving it up to the application layer to handle this. However, keeping the connection alive allows running other dashboard commands to inspect what's going on or simply retry with another timeout setting.