### PR TITLE
[CI Doc builds] Pin sphinx version to <9

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<9
 sphinx-copybutton
 sphinx-tabs
 sphinx_rtd_theme


### PR DESCRIPTION
Using sphinx >=9 leads to issues with the sphinx-tabs extension (see executablebooks/sphinx-tabs#206)

Until this is fixed upstream, sphinx will be pinned to version <9.

This should fix our doc builds.