### PR TITLE
Add two new RTDE fields

### DIFF
--- a/src/rtde/data_package.cpp
+++ b/src/rtde/data_package.cpp
@@ -452,6 +452,8 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "payload_inertia", vector6d_t() },
   { "script_control_line", uint32_t() },
   { "time_scale_source", int32_t() },
+  { "target_gravity", vector3d_t() },
+  { "target_base_acceleration", vector6d_t() },
 
   // NOT IN OFFICIAL DOCS
   { "tool_digital_output_mask", uint8_t() },

--- a/tests/resources/exhaustive_rtde_output_recipe.txt
+++ b/tests/resources/exhaustive_rtde_output_recipe.txt
@@ -400,3 +400,5 @@ payload_cog
 payload_inertia
 script_control_line
 time_scale_source
+target_gravity
+target_base_acceleration


### PR DESCRIPTION
Add fields

- target_gravity
- target_base_acceleration

which will be abailable from 5.26.0 / 10.12.0