### PR TITLE
Update ignore regex for 3rdparty

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,6 +4,6 @@ codecov:
   strict_yaml_branch: default  # only use the latest YAML on stated branch
 
 ignore:
-  - "3rdparty/*"  # ignore examples
+  - "3rdparty/**/*"  # ignore examples
   - "examples/*"  # ignore examples
   - "tests/*"  # ignore unit tests


### PR DESCRIPTION
Codecov seems not to ignore the 3rdparty folder as it should. This PR attempts to fix that.