### PR TITLE
Add parsing of safety mode messages to the primary interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(urcl
     src/primary/robot_message/runtime_exception_message.cpp
     src/primary/robot_message/text_message.cpp
     src/primary/robot_message/version_message.cpp
+    src/primary/robot_message/safety_mode_message.cpp
     src/primary/robot_state.cpp
     src/primary/robot_state/kinematics_info.cpp
     src/primary/robot_state/robot_mode_data.cpp

--- a/include/ur_client_library/comm/bin_parser.h
+++ b/include/ur_client_library/comm/bin_parser.h
@@ -32,6 +32,7 @@
 #include "ur_client_library/log.h"
 #include "ur_client_library/types.h"
 #include "ur_client_library/exceptions.h"
+#include <variant>
 
 namespace urcl
 {
@@ -140,6 +141,20 @@ public:
   {
     val = peek<T>();
     buf_pos_ += sizeof(T);
+  }
+
+  /*!
+   * \brief Parses the next bytes as the given type, the given type must match one of the types in the variant
+   *
+   * @tparam T Type to parse as
+   * \param val Reference to variant to write the parsed value to
+   */
+  template <typename T>
+  void parse(std::variant<uint32_t, int32_t, float>& val)
+  {
+    T return_val;
+    parse<T>(return_val);
+    val = return_val;
   }
 
   /*!

--- a/include/ur_client_library/primary/abstract_primary_consumer.h
+++ b/include/ur_client_library/primary/abstract_primary_consumer.h
@@ -36,6 +36,7 @@
 #include "ur_client_library/primary/robot_state/kinematics_info.h"
 #include "ur_client_library/primary/robot_state/robot_mode_data.h"
 #include "ur_client_library/primary/robot_state/configuration_data.h"
+#include "ur_client_library/primary/robot_message/safety_mode_message.h"
 
 namespace urcl
 {
@@ -79,6 +80,7 @@ public:
   virtual bool consume(ErrorCodeMessage& pkg) = 0;
   virtual bool consume(RobotModeData& pkg) = 0;
   virtual bool consume(ConfigurationData& pkg) = 0;
+  virtual bool consume(SafetyModeMessage& pkg) = 0;
 
 private:
   /* data */

--- a/include/ur_client_library/primary/primary_client.h
+++ b/include/ur_client_library/primary/primary_client.h
@@ -201,6 +201,34 @@ public:
   }
 
   /*!
+   * \brief Get the latest safety mode message.
+   *
+   * The safety mode will be updated in the background. This will always show the latest received
+   * state independent of the time that has passed since receiving it. The return value of this
+   * will be a nullptr if no data has been received yet.
+   */
+  std::shared_ptr<SafetyModeMessage> getSafetyModeMessage()
+  {
+    return consumer_->getSafetyModeMessage();
+  }
+
+  /*!
+   * \brief Get the latest safety mode.
+   *
+   * The safety mode will be updated in the background. This will always show the latest received
+   * robot mode independent of the time that has passed since receiving it.
+   */
+  SafetyMode getSafetyMode()
+  {
+    auto safety_mode = consumer_->getSafetyModeMessage();
+    if (safety_mode == nullptr)
+    {
+      return SafetyMode::UNDEFINED_SAFETY_MODE;
+    }
+    return safety_mode->safety_mode_type_;
+  }
+
+  /*!
    * \brief Query if the robot is protective stopped.
    *
    * The robot's protective_stop state will be updated in the background. This will always show the latest received

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -172,8 +172,7 @@ public:
 
   virtual bool consume(SafetyModeMessage& pkg) override
   {
-    URCL_LOG_DEBUG("Robot safety mode is now %s",
-                   safetyModeString(static_cast<SafetyMode>(pkg.safety_mode_type_)).c_str());
+    URCL_LOG_DEBUG("Robot safety mode is now %s", safetyModeString(pkg.safety_mode_type_).c_str());
     std::scoped_lock lock(safety_mode_mutex_);
     safety_mode_ = std::make_shared<SafetyModeMessage>(pkg);
     return true;

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -170,6 +170,14 @@ public:
     return true;
   }
 
+  virtual bool consume(SafetyModeMessage& pkg) override
+  {
+    URCL_LOG_DEBUG("Robot safety mode is now %s", safetyModeString(static_cast<SafetyMode>(pkg.safety_mode_type_)));
+    std::scoped_lock lock(safety_mode_mutex_);
+    safety_mode_ = std::make_shared<SafetyModeMessage>(pkg);
+    return true;
+  }
+
   virtual bool consume(ConfigurationData& pkg) override
   {
     std::scoped_lock lock(configuration_data_mutex_);
@@ -211,6 +219,18 @@ public:
   }
 
   /*!
+   * \brief Get the latest safety mode message.
+   *
+   * The safety mode will be updated in the background. This will always show the latest received
+   * safety mode independent of the time that has passed since receiving it.
+   */
+  std::shared_ptr<SafetyModeMessage> getSafetyModeMessage()
+  {
+    std::scoped_lock lock(safety_mode_mutex_);
+    return safety_mode_;
+  }
+
+  /*!
    * \brief Get the latest version information.
    *
    * The version information will be updated in the background. This will always show the latest
@@ -245,6 +265,8 @@ private:
   std::shared_ptr<VersionInformation> version_information_;
   std::shared_ptr<ConfigurationData> configuration_data_;
   std::mutex configuration_data_mutex_;
+  std::mutex safety_mode_mutex_;
+  std::shared_ptr<SafetyModeMessage> safety_mode_;
 };
 
 }  // namespace primary_interface

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -172,7 +172,8 @@ public:
 
   virtual bool consume(SafetyModeMessage& pkg) override
   {
-    URCL_LOG_DEBUG("Robot safety mode is now %s", safetyModeString(static_cast<SafetyMode>(pkg.safety_mode_type_)));
+    URCL_LOG_DEBUG("Robot safety mode is now %s",
+                   safetyModeString(static_cast<SafetyMode>(pkg.safety_mode_type_)).c_str());
     std::scoped_lock lock(safety_mode_mutex_);
     safety_mode_ = std::make_shared<SafetyModeMessage>(pkg);
     return true;

--- a/include/ur_client_library/primary/primary_parser.h
+++ b/include/ur_client_library/primary/primary_parser.h
@@ -34,6 +34,7 @@
 #include "ur_client_library/primary/robot_message/error_code_message.h"
 #include "ur_client_library/primary/robot_state/robot_mode_data.h"
 #include "ur_client_library/primary/robot_state/configuration_data.h"
+#include "ur_client_library/primary/robot_message/safety_mode_message.h"
 
 namespace urcl
 {
@@ -241,6 +242,8 @@ private:
         return new KeyMessage(timestamp, source);
       case RobotMessagePackageType::ROBOT_MESSAGE_RUNTIME_EXCEPTION:
         return new RuntimeExceptionMessage(timestamp, source);
+      case RobotMessagePackageType::ROBOT_MESSAGE_SAFETY_MODE:
+        return new SafetyModeMessage(timestamp, source);
       default:
         return new RobotMessage(timestamp, source, type);
     }

--- a/include/ur_client_library/primary/robot_message/safety_mode_message.h
+++ b/include/ur_client_library/primary/robot_message/safety_mode_message.h
@@ -1,0 +1,116 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2026 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author      Jacob Larsen jala@universal-robots.com
+ * \maintainer  Felix Exner feex@universal-robots.com
+ * \date        2026-03-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_CLIENT_LIBRARY_PRIMARY_SAFETY_MODE_MESSAGE_H_INCLUDED
+#define UR_CLIENT_LIBRARY_PRIMARY_SAFETY_MODE_MESSAGE_H_INCLUDED
+
+#include "ur_client_library/primary/robot_message.h"
+#include "ur_client_library/ur/datatypes.h"
+#include <variant>
+
+namespace urcl
+{
+namespace primary_interface
+{
+/*!
+ *  \brief Representation of the primary interface's safety mode message
+ */
+class SafetyModeMessage : public RobotMessage
+{
+public:
+  SafetyModeMessage() = delete;
+
+  /*!
+   * \brief Creates a new SafetyModeMessage object to be filled from a package.
+   *
+   * \param timestamp Timestamp of the package
+   * \param source The package's source
+   */
+  SafetyModeMessage(uint64_t timestamp, int8_t source)
+    : RobotMessage(timestamp, source, RobotMessagePackageType::ROBOT_MESSAGE_SAFETY_MODE)
+  {
+  }
+  SafetyModeMessage(const SafetyModeMessage& pkg);
+
+  virtual ~SafetyModeMessage() = default;
+
+  /*!
+   * \brief Sets the attributes of the package by parsing a serialized representation of the
+   * package.
+   *
+   * \param bp A parser containing a serialized text of the package
+   *
+   * \returns True, if the package was parsed successfully, false otherwise
+   */
+  virtual bool parseWith(comm::BinParser& bp);
+
+  /*!
+   * \brief Consume this package with a specific consumer.
+   *
+   * \param consumer Placeholder for the consumer calling this
+   *
+   * \returns true on success
+   */
+  virtual bool consumeWith(AbstractPrimaryConsumer& consumer);
+
+  /*!
+   * \brief Produces a human readable representation of the package object.
+   *
+   * \returns A string representing the object
+   */
+  virtual std::string toString() const;
+
+  int32_t message_code_;
+  int32_t message_argument_;
+  SafetyMode safety_mode_type_;
+  uint32_t report_data_type_;
+
+  /* Content data type varies depending on report_data_type_
+  Type 0 and 1: uint32_t
+  Type 2: int32_t
+  Type 3: float
+  Type 4 : uint32_t (but should be displayed as hex, when printed) */
+  std::variant<uint32_t, int32_t, float> report_data_;
+};
+}  // namespace primary_interface
+
+}  // namespace urcl
+
+#endif  // ifndef UR_CLIENT_LIBRARY_PRIMARY_SAFETY_MODE_MESSAGE_H_INCLUDED

--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -49,7 +49,7 @@ enum class RobotMode : int8_t
   UPDATING_FIRMWARE = 8
 };
 
-enum class SafetyMode : int8_t
+enum class SafetyMode : uint8_t
 {
   NORMAL = 1,
   REDUCED = 2,
@@ -61,7 +61,17 @@ enum class SafetyMode : int8_t
   VIOLATION = 8,
   FAULT = 9,
   VALIDATE_JOINT_ID = 10,
-  UNDEFINED_SAFETY_MODE = 11
+  UNDEFINED_SAFETY_MODE = 11,
+  AUTOMATIC_MODE_SAFEGUARD_STOP = 12,
+  SYSTEM_THREE_POSITION_ENABLING_STOP = 13,
+  TP_THREE_POSITION_ENABLING_STOP = 14,
+  IMMI_EMERGENCY_STOP = 15,
+  IMMI_SAFEGUARD_STOP = 16,
+  PROFISAFE_WAITING_FOR_PARAMETERS = 17,
+  PROFISAFE_AUTOMATIC_MODE_SAFEGUARD_STOP = 18,
+  PROFISAFE_SAFEGUARD_STOP = 19,
+  PROFISAFE_EMERGENCY_STOP = 20,
+  SAFETY_API_SAFEGUARD_STOP = 22
 };
 
 enum class SafetyStatus : int8_t  // Only available on 3.10/5.4
@@ -159,6 +169,26 @@ inline std::string safetyModeString(const SafetyMode& mode)
       return "VALIDATE_JOINT_ID";
     case SafetyMode::UNDEFINED_SAFETY_MODE:
       return "UNDEFINED_SAFETY_MODE";
+    case SafetyMode::AUTOMATIC_MODE_SAFEGUARD_STOP:
+      return "AUTOMATIC_MODE_SAFEGUARD_STOP";
+    case SafetyMode::SYSTEM_THREE_POSITION_ENABLING_STOP:
+      return "SYSTEM_THREE_POSITION_ENABLING_STOP";
+    case SafetyMode::TP_THREE_POSITION_ENABLING_STOP:
+      return "TP_THREE_POSITION_ENABLING_STOP";
+    case SafetyMode::IMMI_EMERGENCY_STOP:
+      return "IMMI_EMERGENCY_STOP";
+    case SafetyMode::IMMI_SAFEGUARD_STOP:
+      return "IMMI_SAFEGUARD_STOP";
+    case SafetyMode::PROFISAFE_WAITING_FOR_PARAMETERS:
+      return "PROFISAFE_WAITING_FOR_PARAMETERS";
+    case SafetyMode::PROFISAFE_AUTOMATIC_MODE_SAFEGUARD_STOP:
+      return "PROFISAFE_AUTOMATIC_MODE_SAFEGUARD_STOP";
+    case SafetyMode::PROFISAFE_SAFEGUARD_STOP:
+      return "PROFISAFE_SAFEGUARD_STOP";
+    case SafetyMode::PROFISAFE_EMERGENCY_STOP:
+      return "PROFISAFE_EMERGENCY_STOP";
+    case SafetyMode::SAFETY_API_SAFEGUARD_STOP:
+      return "SAFETY_API_SAFEGUARD_STOP";
     default:
       std::stringstream ss;
       ss << "Unknown safety mode: " << static_cast<int>(mode);

--- a/src/primary/robot_message/safety_mode_message.cpp
+++ b/src/primary/robot_message/safety_mode_message.cpp
@@ -84,7 +84,7 @@ bool SafetyModeMessage::consumeWith(AbstractPrimaryConsumer& consumer)
 std::string SafetyModeMessage::toString() const
 {
   std::stringstream ss;
-  ss << "SafetyModeMessage \n";
+  ss << "SafetyModeMessage\n";
   ss << "Message code: " << message_code_ << "\n";
   ss << "Message argument: " << message_argument_ << "\n";
   ss << "Safety mode type: " << unsigned(safety_mode_type_) << "\n";
@@ -99,7 +99,7 @@ std::string SafetyModeMessage::toString() const
       ss << std::get<float>(report_data_);
       break;
     case 4:
-      ss << std::hex << std::get<uint32_t>(report_data_);
+      ss << "0x" << std::hex << std::get<uint32_t>(report_data_);
       break;
     default:
       ss << std::get<uint32_t>(report_data_);

--- a/src/primary/robot_message/safety_mode_message.cpp
+++ b/src/primary/robot_message/safety_mode_message.cpp
@@ -1,0 +1,112 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2026 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author      Jacob Larsen jala@universal-robots.com
+ * \maintainer  Felix Exner feex@universal-robots.com
+ * \date        2026-03-30
+ *
+ */
+//----------------------------------------------------------------------
+
+#include "ur_client_library/primary/robot_message/safety_mode_message.h"
+#include "ur_client_library/primary/abstract_primary_consumer.h"
+
+namespace urcl
+{
+namespace primary_interface
+{
+SafetyModeMessage::SafetyModeMessage(const SafetyModeMessage& pkg)
+  : RobotMessage(pkg.timestamp_, pkg.source_, RobotMessagePackageType::ROBOT_MESSAGE_SAFETY_MODE)
+{
+  message_code_ = pkg.message_code_;
+  message_argument_ = pkg.message_argument_;
+  safety_mode_type_ = pkg.safety_mode_type_;
+  report_data_type_ = pkg.report_data_type_;
+  report_data_ = pkg.report_data_;
+}
+
+bool SafetyModeMessage::parseWith(comm::BinParser& bp)
+{
+  bp.parse(message_code_);
+  bp.parse(message_argument_);
+  bp.parse(safety_mode_type_);
+  bp.parse(report_data_type_);
+  switch (report_data_type_)
+  {
+    case 2:
+      bp.parse<int32_t>(report_data_);
+      break;
+    case 3:
+      bp.parse<float>(report_data_);
+      break;
+    default:
+      bp.parse<uint32_t>(report_data_);
+      break;
+  }
+  return true;
+}
+
+bool SafetyModeMessage::consumeWith(AbstractPrimaryConsumer& consumer)
+{
+  return consumer.consume(*this);
+}
+
+std::string SafetyModeMessage::toString() const
+{
+  std::stringstream ss;
+  ss << "SafetyModeMessage \n";
+  ss << "Message code: " << message_code_ << "\n";
+  ss << "Message argument: " << message_argument_ << "\n";
+  ss << "Safety mode type: " << unsigned(safety_mode_type_) << "\n";
+  ss << "Report data type: " << report_data_type_ << "\n";
+  ss << "Report data: ";
+  switch (report_data_type_)
+  {
+    case 2:
+      ss << std::get<int32_t>(report_data_);
+      break;
+    case 3:
+      ss << std::get<float>(report_data_);
+      break;
+    case 4:
+      ss << std::hex << std::get<uint32_t>(report_data_);
+      break;
+    default:
+      ss << std::get<uint32_t>(report_data_);
+      break;
+  }
+  return ss.str();
+}
+}  // namespace primary_interface
+
+}  // namespace urcl

--- a/tests/test_bin_parser.cpp
+++ b/tests/test_bin_parser.cpp
@@ -469,6 +469,21 @@ TEST(bin_parser, peek_throws_when_past_end)
   EXPECT_THROW(bp.peek<uint16_t>(), UrException);
 }
 
+TEST(bin_parser, parse_into_variant)
+{
+  std::variant<uint32_t, int32_t, float> variant;
+  uint8_t buffer[] = { 0x81, 0x92, 0x29, 0x18 };
+  comm::BinParser bp1(buffer, sizeof(buffer));
+  bp1.parse<uint32_t>(variant);
+  EXPECT_EQ(std::get<uint32_t>(variant), unsigned(0x81922918));
+  comm::BinParser bp2(buffer, sizeof(buffer));
+  bp2.parse<int32_t>(variant);
+  EXPECT_EQ(std::get<int32_t>(variant), signed(0x81922918));
+  comm::BinParser bp3(buffer, sizeof(buffer));
+  bp3.parse<float>(variant);
+  EXPECT_EQ(std::get<float>(variant), float(2.19167036e-24));
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_primary_client.cpp
+++ b/tests/test_primary_client.cpp
@@ -362,6 +362,23 @@ TEST_F(PrimaryClientTest, test_program_execution_reports_exception)
   }
 }
 
+TEST_F(PrimaryClientTest, test_read_safety_mode)
+{
+  EXPECT_NO_THROW(client_->start());
+  EXPECT_EQ(client_->getSafetyMode(), urcl::SafetyMode::UNDEFINED_SAFETY_MODE);
+  EXPECT_NO_THROW(client_->commandBrakeRelease(true, std::chrono::milliseconds(20000)));
+  client_->sendScript("protective_stop()");
+  EXPECT_NO_THROW(waitFor([this]() { return client_->getSafetyMode() == urcl::SafetyMode::PROTECTIVE_STOP; },
+                          std::chrono::milliseconds(1000)));
+  // This will not happen immediately
+  EXPECT_THROW(client_->commandUnlockProtectiveStop(true, std::chrono::milliseconds(1)), TimeoutException);
+
+  // It is not allowed to unlock the protective stop immediately
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+  EXPECT_NO_THROW(client_->commandUnlockProtectiveStop());
+  EXPECT_EQ(client_->getSafetyMode(), urcl::SafetyMode::NORMAL);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/test_primary_parser.cpp
+++ b/tests/test_primary_parser.cpp
@@ -454,7 +454,7 @@ TEST_F(PrimaryParserTest, parse_safetymode_msg)
     comm::BinParser bp_loop(raw_data, sizeof(raw_data));
     std::vector<std::unique_ptr<primary_interface::PrimaryPackage>> products_loop;
     ASSERT_TRUE(parser_.parse(bp_loop, products_loop));
-    ASSERT_EQ(products.size(), 1);
+    ASSERT_EQ(products_loop.size(), 1);
 
     if (primary_interface::SafetyModeMessage* data_loop =
             dynamic_cast<primary_interface::SafetyModeMessage*>(products_loop[0].get()))

--- a/tests/test_primary_parser.cpp
+++ b/tests/test_primary_parser.cpp
@@ -182,6 +182,29 @@ const unsigned char RUNTIME_EXCEPTION_MESSAGE[] = {
   0x6e, 0x6f, 0x74, 0x5f, 0x66, 0x6f, 0x75, 0x6e, 0x64, 0x3a, 0x74, 0x78, 0x74, 0x6d, 0x73, 0x67, 0x3a
 };
 
+const unsigned char SAFETY_MODE_MESSAGE[] = {
+  // message size
+  0x00, 0x00, 0x00, 0x20,
+  // message type robot message
+  0x14,
+  // timestamp
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  // source
+  0xfd,
+  // robot_message_type SAFETY_MODE
+  0x05,
+  // Robot message code
+  0x00, 0x00, 0x00, 0x00,
+  // Robot message argument
+  0x00, 0x00, 0x00, 0x00,
+  // Safety mode type
+  0x03,
+  // Report data type
+  0x00, 0x00, 0x00, 0x00,
+  // Report data
+  0x00, 0x00, 0x00, 0x01
+};
+
 class PrimaryParserTest : public ::testing::Test
 {
 protected:
@@ -385,6 +408,71 @@ TEST_F(PrimaryParserTest, parse_robot_state_with_oversized_submessage)
     ASSERT_NE(ki, nullptr);
     EXPECT_EQ(ki->calibration_status_, 0u);
     EXPECT_EQ(ki->dh_theta_, vector6d_t({ 0, 0, 0, 0, 0, 0 }));
+  }
+}
+
+TEST_F(PrimaryParserTest, parse_safetymode_msg)
+{
+  unsigned char raw_data[sizeof(SAFETY_MODE_MESSAGE)];
+  memcpy(raw_data, SAFETY_MODE_MESSAGE, sizeof(SAFETY_MODE_MESSAGE));
+  comm::BinParser bp(raw_data, sizeof(raw_data));
+
+  std::vector<std::unique_ptr<primary_interface::PrimaryPackage>> products;
+  ASSERT_TRUE(parser_.parse(bp, products));
+  ASSERT_EQ(products.size(), 1);
+
+  if (primary_interface::SafetyModeMessage* data =
+          dynamic_cast<primary_interface::SafetyModeMessage*>(products[0].get()))
+  {
+    EXPECT_EQ(data->message_code_, 0);
+    EXPECT_EQ(data->message_argument_, 0);
+    EXPECT_EQ(data->safety_mode_type_, urcl::SafetyMode::PROTECTIVE_STOP);  // 3
+    EXPECT_EQ(data->report_data_type_, 0);
+    EXPECT_EQ(std::get<uint32_t>(data->report_data_), 1);
+
+    primary_interface::SafetyModeMessage clone = *data;
+    EXPECT_EQ(data->message_code_, clone.message_code_);
+    EXPECT_EQ(data->message_argument_, clone.message_argument_);
+    EXPECT_EQ(data->safety_mode_type_, clone.safety_mode_type_);
+    EXPECT_EQ(data->report_data_type_, clone.report_data_type_);
+    EXPECT_EQ(data->report_data_, clone.report_data_);
+  }
+
+  // Test all report data types
+  for (unsigned char i = 1; i < 5; i++)
+  {
+    memcpy(raw_data, SAFETY_MODE_MESSAGE, sizeof(SAFETY_MODE_MESSAGE));
+    raw_data[27] = i;
+    // Make negative number
+    if (i == 2)
+    {
+      raw_data[28] ^= 0xff;
+      raw_data[29] ^= 0xff;
+      raw_data[30] ^= 0xff;
+      raw_data[31] ^= 0xff;
+    }
+    comm::BinParser bp(raw_data, sizeof(raw_data));
+    std::vector<std::unique_ptr<primary_interface::PrimaryPackage>> products;
+    ASSERT_TRUE(parser_.parse(bp, products));
+    ASSERT_EQ(products.size(), 1);
+
+    if (primary_interface::SafetyModeMessage* data =
+            dynamic_cast<primary_interface::SafetyModeMessage*>(products[0].get()))
+    {
+      EXPECT_EQ(data->report_data_type_, static_cast<uint32_t>(i));
+      if (data->report_data_type_ == 2)
+      {
+        EXPECT_EQ(std::get<int32_t>(data->report_data_), -2);
+      }
+      else if (data->report_data_type_ == 3)
+      {
+        EXPECT_EQ(std::get<float>(data->report_data_), float(2.3509887e-38));
+      }
+      else
+      {
+        EXPECT_EQ(std::get<uint32_t>(data->report_data_), 1);
+      }
+    }
   }
 }
 

--- a/tests/test_primary_parser.cpp
+++ b/tests/test_primary_parser.cpp
@@ -26,6 +26,7 @@
  */
 //----------------------------------------------------------------------
 
+#include <iostream>
 #include <gtest/gtest.h>
 #include <string.h>
 
@@ -203,6 +204,29 @@ const unsigned char SAFETY_MODE_MESSAGE[] = {
   0x00, 0x00, 0x00, 0x00,
   // Report data
   0x00, 0x00, 0x00, 0x01
+};
+
+const unsigned char SAFETY_MODE_MESSAGE_STRING[] = {
+  // message size
+  0x00, 0x00, 0x00, 0x20,
+  // message type robot message
+  0x14,
+  // timestamp
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  // source
+  0xfd,
+  // robot_message_type SAFETY_MODE
+  0x05,
+  // Robot message code
+  0x00, 0x00, 0x00, 0x00,
+  // Robot message argument
+  0x00, 0x00, 0x00, 0x00,
+  // Safety mode type
+  0x03,
+  // Report data type
+  0x00, 0x00, 0x00, 0x00,
+  // Report data
+  0x80, 0x07, 0x06, 0x05
 };
 
 class PrimaryParserTest : public ::testing::Test
@@ -471,6 +495,55 @@ TEST_F(PrimaryParserTest, parse_safetymode_msg)
       else
       {
         EXPECT_EQ(std::get<uint32_t>(data_loop->report_data_), 1);
+      }
+    }
+  }
+}
+
+std::string construct_string(int data_type, std::string data)
+{
+  std::stringstream ss;
+  ss << "SafetyModeMessage\n";
+  ss << "Message code: 0\n";
+  ss << "Message argument: 0\n";
+  ss << "Safety mode type: 3\n";
+  ss << "Report data type: " << data_type << "\n";
+  ss << "Report data: " << data;
+  return ss.str();
+}
+
+TEST_F(PrimaryParserTest, parsing_safetymode_results_in_correct_string)
+{
+  unsigned char raw_data[sizeof(SAFETY_MODE_MESSAGE_STRING)];
+  // Test all report data types
+  for (unsigned char i = 0; i < 5; i++)
+  {
+    memcpy(raw_data, SAFETY_MODE_MESSAGE_STRING, sizeof(SAFETY_MODE_MESSAGE_STRING));
+    raw_data[27] = i;
+    comm::BinParser bp(raw_data, sizeof(raw_data));
+    std::vector<std::unique_ptr<primary_interface::PrimaryPackage>> products;
+    ASSERT_TRUE(parser_.parse(bp, products));
+    ASSERT_EQ(products.size(), 1);
+
+    if (primary_interface::SafetyModeMessage* data =
+            dynamic_cast<primary_interface::SafetyModeMessage*>(products[0].get()))
+    {
+      EXPECT_EQ(data->report_data_type_, static_cast<uint32_t>(i));
+      if (data->report_data_type_ == 0 || data->report_data_type_ == 1)
+      {
+        EXPECT_EQ(data->toString(), construct_string(data->report_data_type_, "2147943941"));
+      }
+      else if (data->report_data_type_ == 2)
+      {
+        EXPECT_EQ(data->toString(), construct_string(data->report_data_type_, "-2147023355"));
+      }
+      else if (data->report_data_type_ == 3)
+      {
+        EXPECT_EQ(data->toString(), construct_string(data->report_data_type_, "6.30203e-36"));
+      }
+      else
+      {
+        EXPECT_EQ(data->toString(), construct_string(data->report_data_type_, "0x80070605"));
       }
     }
   }

--- a/tests/test_primary_parser.cpp
+++ b/tests/test_primary_parser.cpp
@@ -451,26 +451,26 @@ TEST_F(PrimaryParserTest, parse_safetymode_msg)
       raw_data[30] ^= 0xff;
       raw_data[31] ^= 0xff;
     }
-    comm::BinParser bp(raw_data, sizeof(raw_data));
-    std::vector<std::unique_ptr<primary_interface::PrimaryPackage>> products;
-    ASSERT_TRUE(parser_.parse(bp, products));
+    comm::BinParser bp_loop(raw_data, sizeof(raw_data));
+    std::vector<std::unique_ptr<primary_interface::PrimaryPackage>> products_loop;
+    ASSERT_TRUE(parser_.parse(bp_loop, products_loop));
     ASSERT_EQ(products.size(), 1);
 
-    if (primary_interface::SafetyModeMessage* data =
-            dynamic_cast<primary_interface::SafetyModeMessage*>(products[0].get()))
+    if (primary_interface::SafetyModeMessage* data_loop =
+            dynamic_cast<primary_interface::SafetyModeMessage*>(products_loop[0].get()))
     {
-      EXPECT_EQ(data->report_data_type_, static_cast<uint32_t>(i));
-      if (data->report_data_type_ == 2)
+      EXPECT_EQ(data_loop->report_data_type_, static_cast<uint32_t>(i));
+      if (data_loop->report_data_type_ == 2)
       {
-        EXPECT_EQ(std::get<int32_t>(data->report_data_), -2);
+        EXPECT_EQ(std::get<int32_t>(data_loop->report_data_), -2);
       }
-      else if (data->report_data_type_ == 3)
+      else if (data_loop->report_data_type_ == 3)
       {
-        EXPECT_EQ(std::get<float>(data->report_data_), float(2.3509887e-38));
+        EXPECT_EQ(std::get<float>(data_loop->report_data_), float(2.3509887e-38));
       }
       else
       {
-        EXPECT_EQ(std::get<uint32_t>(data->report_data_), 1);
+        EXPECT_EQ(std::get<uint32_t>(data_loop->report_data_), 1);
       }
     }
   }


### PR DESCRIPTION
This is necessary to implement script execution feedback in the the primary interface.