### PR TITLE
Fix traj point time precision

### DIFF
--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -70,3 +70,8 @@ where
 
 - ``MULT_JOINTSTATE``: 1000000
 - ``MULT_TIME``: 1000000
+
+.. note::
+   With ``MULT_TIME`` being 1000000, the maximum duration that can be sent is 2147 seconds, while
+   precision is cut off at 1 microsecond. (The same applies to the blend radius, respectively being
+   max 2147 m and 1 μm precision.)

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -59,14 +59,13 @@ representations in 21 datafields. The data fields have the following meaning:
           - 3: MOVEC
           - 51: SPLINE)
 
-   19     trajectory point time (in seconds, multiplied by ``MULT_TIME``)
+   19     trajectory point time (in seconds, multiplied by ``MULT_JOINTSTATE``)
    20     depending on trajectory point type
 
-          - MOVEJ, MOVEL, MOVEP and MOVEC: point blend radius (in meters, multiplied by ``MULT_TIME``)
+          - MOVEJ, MOVEL, MOVEP and MOVEC: point blend radius (in meters, multiplied by ``MULT_JOINTSTATE``)
           - SPLINE: spline type (1: CUBIC, 2: QUINTIC)
    =====  =====
 
 where
 
 - ``MULT_JOINTSTATE``: 1000000
-- ``MULT_TIME``: 1000

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -59,13 +59,14 @@ representations in 21 datafields. The data fields have the following meaning:
           - 3: MOVEC
           - 51: SPLINE)
 
-   19     trajectory point time (in seconds, multiplied by ``MULT_JOINTSTATE``)
+   19     trajectory point time (in seconds, multiplied by ``MULT_TIME``)
    20     depending on trajectory point type
 
-          - MOVEJ, MOVEL, MOVEP and MOVEC: point blend radius (in meters, multiplied by ``MULT_JOINTSTATE``)
+          - MOVEJ, MOVEL, MOVEP and MOVEC: point blend radius (in meters, multiplied by ``MULT_TIME``)
           - SPLINE: spline type (1: CUBIC, 2: QUINTIC)
    =====  =====
 
 where
 
 - ``MULT_JOINTSTATE``: 1000000
+- ``MULT_TIME``: 1000000

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -148,6 +148,8 @@ protected:
   virtual void messageCallback(const socket_t filedescriptor, char* buffer, int nbytesrecv) override;
 
 private:
+  const double MAX_GOAL_TIME_ = static_cast<double>(std::numeric_limits<int32_t>::max()) / MULT_TIME;
+
   std::list<HandlerFunction<void(TrajectoryResult)>> trajectory_end_callbacks_;
   uint32_t next_done_callback_id_ = 0;
 };

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -63,7 +63,7 @@ std::string trajectoryResultToString(const TrajectoryResult result);
 class TrajectoryPointInterface : public ReverseInterface
 {
 public:
-  static const int32_t MULT_TIME = 1000;
+  static const int32_t MULT_TIME = 1000000;
   static const int MESSAGE_LENGTH = 21;
 
   TrajectoryPointInterface() = delete;

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -550,8 +550,8 @@ thread trajectoryThread():
 
     if raw_point[0] > 0:
       local q = [raw_point[1] / MULT_jointstate, raw_point[2] / MULT_jointstate, raw_point[3] / MULT_jointstate, raw_point[4] / MULT_jointstate, raw_point[5] / MULT_jointstate, raw_point[6] / MULT_jointstate]
-      local tmptime = raw_point[INDEX_TIME] / MULT_time
-      local blend_radius = raw_point[INDEX_BLEND] / MULT_time
+      local tmptime = raw_point[INDEX_TIME] / MULT_jointstate
+      local blend_radius = raw_point[INDEX_BLEND] / MULT_jointstate
       local is_last_point = False
       if trajectory_points_left == 0:
         blend_radius = 0.0

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -550,8 +550,8 @@ thread trajectoryThread():
 
     if raw_point[0] > 0:
       local q = [raw_point[1] / MULT_jointstate, raw_point[2] / MULT_jointstate, raw_point[3] / MULT_jointstate, raw_point[4] / MULT_jointstate, raw_point[5] / MULT_jointstate, raw_point[6] / MULT_jointstate]
-      local tmptime = raw_point[INDEX_TIME] / MULT_jointstate
-      local blend_radius = raw_point[INDEX_BLEND] / MULT_jointstate
+      local tmptime = raw_point[INDEX_TIME] / MULT_time
+      local blend_radius = raw_point[INDEX_BLEND] / MULT_time
       local is_last_point = False
       if trajectory_points_left == 0:
         blend_radius = 0.0

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -215,12 +215,12 @@ bool TrajectoryPointInterface::writeTrajectoryPoint(const vector6d_t* positions,
     primitive = std::make_shared<MoveLPrimitive>(
         urcl::Pose{ (*positions)[0], (*positions)[1], (*positions)[2], (*positions)[3], (*positions)[4],
                     (*positions)[5] },
-        blend_radius, std::chrono::milliseconds(static_cast<int>(goal_time * 1000)), acceleration, velocity);
+        blend_radius, std::chrono::duration<double>(static_cast<double>(goal_time)), acceleration, velocity);
   }
   else
   {
     primitive = std::make_shared<MoveJPrimitive>(*positions, blend_radius,
-                                                 std::chrono::milliseconds(static_cast<int>(goal_time * 1000)),
+                                                 std::chrono::duration<double>(static_cast<double>(goal_time)),
                                                  acceleration, velocity);
   }
 
@@ -255,7 +255,7 @@ bool TrajectoryPointInterface::writeTrajectorySplinePoint(const vector6d_t* posi
   }
 
   return writeMotionPrimitive(std::make_shared<SplinePrimitive>(
-      *positions, *velocities, target_accelerations, std::chrono::milliseconds(static_cast<int>(goal_time * 1000))));
+      *positions, *velocities, target_accelerations, std::chrono::duration<double>(static_cast<double>(goal_time))));
 }
 
 void TrajectoryPointInterface::connectionCallback(const socket_t filedescriptor)

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -180,7 +180,7 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
     index++;
   }
 
-  int32_t val = static_cast<int32_t>(round(primitive->duration.count() * MULT_TIME));
+  int32_t val = static_cast<int32_t>(round(primitive->duration.count() * MULT_JOINTSTATE));
   buffer[index] = htobe32(val);
   index++;
 
@@ -190,7 +190,7 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   }
   else
   {
-    val = static_cast<int32_t>(round(primitive->blend_radius * MULT_TIME));
+    val = static_cast<int32_t>(round(primitive->blend_radius * MULT_JOINTSTATE));
   }
   buffer[index] = htobe32(val);
   index++;

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -69,6 +69,12 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
     return false;
   }
 
+  if (primitive->duration.count() > MAX_GOAL_TIME_)
+  {
+    URCL_LOG_ERROR("Motion primitive duration is too long. Maximum allowed duration is %f seconds.", MAX_GOAL_TIME_);
+    return false;
+  }
+
   if (client_fd_ == -1)
   {
     return false;

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -180,7 +180,7 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
     index++;
   }
 
-  int32_t val = static_cast<int32_t>(round(primitive->duration.count() * MULT_JOINTSTATE));
+  int32_t val = static_cast<int32_t>(round(primitive->duration.count() * MULT_TIME));
   buffer[index] = htobe32(val);
   index++;
 
@@ -190,7 +190,7 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   }
   else
   {
-    val = static_cast<int32_t>(round(primitive->blend_radius * MULT_JOINTSTATE));
+    val = static_cast<int32_t>(round(primitive->blend_radius * MULT_TIME));
   }
   buffer[index] = htobe32(val);
   index++;

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -34,6 +34,7 @@
 #include <ur_client_library/comm/tcp_socket.h>
 #include <ur_client_library/control/motion_primitives.h>
 #include <cmath>
+#include <limits>
 #include "ur_client_library/exceptions.h"
 
 using namespace urcl;
@@ -512,6 +513,29 @@ TEST_F(TrajectoryPointInterfaceTest, write_goal_time_preserves_submillisecond_pr
   EXPECT_EQ(expected_encoded, client_->getGoalTime());
   traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc, precise_goal_time);
   EXPECT_EQ(expected_precise, client_->getGoalTime());
+}
+
+// Segment duration is capped by int32 microseconds on the wire (~35.79 minutes).
+TEST_F(TrajectoryPointInterfaceTest, write_rejects_goal_time_above_max_encodable_duration)
+{
+  const double max_goal_time_seconds = static_cast<double>(std::numeric_limits<int32_t>::max()) /
+                                       static_cast<double>(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  const float too_long_goal_time = static_cast<float>(max_goal_time_seconds + 1.0);
+  const float almost_too_long_goal_time = static_cast<float>(max_goal_time_seconds - 1.0);
+
+  urcl::vector6d_t send_positions = { 0, 0, 0, 0, 0, 0 };
+  EXPECT_FALSE(traj_point_interface_->writeTrajectoryPoint(&send_positions, too_long_goal_time, 0, false));
+  EXPECT_FALSE(traj_point_interface_->writeTrajectoryPoint(&send_positions, 1.4f, 1.05f, too_long_goal_time, 0, false));
+  EXPECT_TRUE(traj_point_interface_->writeTrajectoryPoint(&send_positions, almost_too_long_goal_time, 0, false));
+  EXPECT_TRUE(
+      traj_point_interface_->writeTrajectoryPoint(&send_positions, 1.4f, 1.05f, almost_too_long_goal_time, 0, false));
+
+  urcl::vector6d_t send_vel = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  urcl::vector6d_t send_acc = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  EXPECT_FALSE(
+      traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc, too_long_goal_time));
+  EXPECT_TRUE(traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc,
+                                                                almost_too_long_goal_time));
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_acceleration_velocity)

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -227,8 +227,8 @@ protected:
                 (double)spl.pos[4] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                 (double)spl.pos[5] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             },
-            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
-            std::chrono::milliseconds(spl.goal_time),
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            std::chrono::microseconds(spl.goal_time),
             (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
       }
@@ -241,8 +241,8 @@ protected:
                         ((double)spl.pos[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                         ((double)spl.pos[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                         ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
-            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
-            std::chrono::milliseconds(spl.goal_time),
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_JOINTSTATE,
+            std::chrono::microseconds(spl.goal_time),
             (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
       }
@@ -255,7 +255,7 @@ protected:
                         ((double)spl.pos[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                         ((double)spl.pos[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                         ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
-            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.vel[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE);
       }
@@ -274,7 +274,7 @@ protected:
                         ((double)spl.pos[3]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                         ((double)spl.pos[4]) / control::TrajectoryPointInterface::MULT_JOINTSTATE,
                         ((double)spl.pos[5]) / control::TrajectoryPointInterface::MULT_JOINTSTATE },
-            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_TIME,
+            (double)spl.blend_radius_or_spline_type / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.acc[1] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             (double)spl.acc[0] / control::TrajectoryPointInterface::MULT_JOINTSTATE,
             static_cast<int32_t>(round((double)spl.acc[2] / control::TrajectoryPointInterface::MULT_JOINTSTATE)));
@@ -384,7 +384,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
   EXPECT_EQ(send_acc[5], ((double)received_data.acc[5]) / traj_point_interface_->MULT_JOINTSTATE);
 
   // Goal time
-  EXPECT_EQ(send_goal_time, ((double)received_data.goal_time / traj_point_interface_->MULT_TIME));
+  EXPECT_EQ(send_goal_time, ((double)received_data.goal_time / traj_point_interface_->MULT_JOINTSTATE));
 
   // Spline type
   EXPECT_EQ(static_cast<int32_t>(control::TrajectorySplineType::SPLINE_QUINTIC),
@@ -428,7 +428,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
   EXPECT_EQ(send_acc[5], ((double)received_data.acc[5]) / traj_point_interface_->MULT_JOINTSTATE);
 
   // Goal time
-  EXPECT_EQ(send_goal_time, ((double)received_data.goal_time) / traj_point_interface_->MULT_TIME);
+  EXPECT_EQ(send_goal_time, ((double)received_data.goal_time) / traj_point_interface_->MULT_JOINTSTATE);
 
   // Spline type
   EXPECT_EQ(static_cast<int32_t>(control::TrajectorySplineType::SPLINE_CUBIC),
@@ -479,7 +479,39 @@ TEST_F(TrajectoryPointInterfaceTest, write_goal_time)
   traj_point_interface_->writeTrajectoryPoint(&send_positions, send_goal_time, 0, false);
   int32_t received_goal_time = client_->getGoalTime();
 
-  EXPECT_EQ(send_goal_time, ((float)received_goal_time) / traj_point_interface_->MULT_TIME);
+  EXPECT_EQ(send_goal_time, ((float)received_goal_time) / traj_point_interface_->MULT_JOINTSTATE);
+}
+
+// Wire format: int32 microseconds (MULT_JOINTSTATE). Duration must reach writeMotionPrimitive as seconds
+// in double form so encoding uses round(seconds * MULT_JOINTSTATE), not trunc(int(ms)).
+TEST_F(TrajectoryPointInterfaceTest, write_goal_time_preserves_submillisecond_precision)
+{
+  urcl::vector6d_t send_positions = { 0, 0, 0, 0, 0, 0 };
+  const float send_goal_time = 0.5006f;
+  const int32_t expected_encoded = static_cast<int32_t>(
+      std::round(static_cast<double>(send_goal_time) * static_cast<double>(traj_point_interface_->MULT_JOINTSTATE)));
+
+  traj_point_interface_->writeTrajectoryPoint(&send_positions, send_goal_time, 0, false);
+  EXPECT_EQ(expected_encoded, client_->getGoalTime());
+
+  traj_point_interface_->writeTrajectoryPoint(&send_positions, 1.4f, 1.05f, send_goal_time, 0, false);
+  EXPECT_EQ(expected_encoded, client_->getGoalTime());
+
+  // High-precision duration: must match round(goal_time * MULT_JOINTSTATE), not trunc(goal_time * MULT_JOINTSTATE).
+  const float precise_goal_time = 1.234567f;
+  const int32_t expected_precise = static_cast<int32_t>(
+      std::round(static_cast<double>(precise_goal_time) * static_cast<double>(traj_point_interface_->MULT_JOINTSTATE)));
+  traj_point_interface_->writeTrajectoryPoint(&send_positions, precise_goal_time, 0, false);
+  EXPECT_EQ(expected_precise, client_->getGoalTime());
+  traj_point_interface_->writeTrajectoryPoint(&send_positions, 1.4f, 1.05f, precise_goal_time, 0, false);
+  EXPECT_EQ(expected_precise, client_->getGoalTime());
+
+  urcl::vector6d_t send_vel = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  urcl::vector6d_t send_acc = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc, send_goal_time);
+  EXPECT_EQ(expected_encoded, client_->getGoalTime());
+  traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc, precise_goal_time);
+  EXPECT_EQ(expected_precise, client_->getGoalTime());
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_acceleration_velocity)
@@ -500,7 +532,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_acceleration_velocity)
 
   EXPECT_EQ(send_move_acceleration, ((float)received_move_acceleration) / traj_point_interface_->MULT_JOINTSTATE);
   EXPECT_EQ(send_move_velocity, ((float)received_move_velocity) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_goal_time, ((float)received_goal_time) / traj_point_interface_->MULT_TIME);
+  EXPECT_EQ(send_goal_time, ((float)received_goal_time) / traj_point_interface_->MULT_JOINTSTATE);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_blend_radius)
@@ -510,7 +542,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_blend_radius)
   traj_point_interface_->writeTrajectoryPoint(&send_positions, 0, send_blend_radius, false);
   int32_t received_blend_radius = client_->getBlendRadius();
 
-  EXPECT_EQ(send_blend_radius, ((float)received_blend_radius) / traj_point_interface_->MULT_TIME);
+  EXPECT_EQ(send_blend_radius, ((float)received_blend_radius) / traj_point_interface_->MULT_JOINTSTATE);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_cartesian)

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -482,14 +482,14 @@ TEST_F(TrajectoryPointInterfaceTest, write_goal_time)
   EXPECT_EQ(send_goal_time, ((float)received_goal_time) / traj_point_interface_->MULT_JOINTSTATE);
 }
 
-// Wire format: int32 microseconds (MULT_JOINTSTATE). Duration must reach writeMotionPrimitive as seconds
-// in double form so encoding uses round(seconds * MULT_JOINTSTATE), not trunc(int(ms)).
+// Wire format: int32 microseconds (MULT_TIME). Duration must reach writeMotionPrimitive as seconds
+// in double form so encoding uses round(seconds * MULT_TIME), not trunc(int(ms)).
 TEST_F(TrajectoryPointInterfaceTest, write_goal_time_preserves_submillisecond_precision)
 {
   urcl::vector6d_t send_positions = { 0, 0, 0, 0, 0, 0 };
   const float send_goal_time = 0.5006f;
   const int32_t expected_encoded = static_cast<int32_t>(
-      std::round(static_cast<double>(send_goal_time) * static_cast<double>(traj_point_interface_->MULT_JOINTSTATE)));
+      std::round(static_cast<double>(send_goal_time) * static_cast<double>(traj_point_interface_->MULT_TIME)));
 
   traj_point_interface_->writeTrajectoryPoint(&send_positions, send_goal_time, 0, false);
   EXPECT_EQ(expected_encoded, client_->getGoalTime());
@@ -497,10 +497,10 @@ TEST_F(TrajectoryPointInterfaceTest, write_goal_time_preserves_submillisecond_pr
   traj_point_interface_->writeTrajectoryPoint(&send_positions, 1.4f, 1.05f, send_goal_time, 0, false);
   EXPECT_EQ(expected_encoded, client_->getGoalTime());
 
-  // High-precision duration: must match round(goal_time * MULT_JOINTSTATE), not trunc(goal_time * MULT_JOINTSTATE).
+  // High-precision duration: must match round(goal_time * MULT_TIME), not trunc(goal_time * MULT_TIME).
   const float precise_goal_time = 1.234567f;
   const int32_t expected_precise = static_cast<int32_t>(
-      std::round(static_cast<double>(precise_goal_time) * static_cast<double>(traj_point_interface_->MULT_JOINTSTATE)));
+      std::round(static_cast<double>(precise_goal_time) * static_cast<double>(traj_point_interface_->MULT_TIME)));
   traj_point_interface_->writeTrajectoryPoint(&send_positions, precise_goal_time, 0, false);
   EXPECT_EQ(expected_precise, client_->getGoalTime());
   traj_point_interface_->writeTrajectoryPoint(&send_positions, 1.4f, 1.05f, precise_goal_time, 0, false);


### PR DESCRIPTION
Precision of trajectory point duration was using floor-rounding on millisecond precision. Thus, e.g. `0.019998 sec` would be transferred as `19 ms`.

This PR changes the following:

- Change time precision for time from milliseconds to microseconds. This effectively makes the longest duration for a trajectory point ~36 minutes, which in my opinion is fair.
- Use nearest integer round instead of floor round if time with more precision than 1 microsecond is given
- Use Micrometer precision for the blend radius. Probably not that much relevant, but it is using the same multiplier constant.

Backwards compatibility should be given, as long as users haven't hardcoded the constant's value. The change on the wire protocol is injected by the application, so even a custom script code would get the updated constant injected correctly decoding the changed wire data.