### PR TITLE
Fix: primary_configuration_timeout as configurable field in UrDriverConfiguration

### DIFF
--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -136,6 +136,11 @@ struct UrDriverConfiguration
    */
   std::chrono::milliseconds rtde_initialization_timeout = std::chrono::seconds(5);
 
+  /*!
+   * \brief Timeout for waiting for primary client configuration data.
+   */
+  std::chrono::milliseconds primary_configuration_timeout = std::chrono::seconds(1);
+
   bool non_blocking_read = false;
 
   // TODO: Remove on 2027-05

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -136,11 +136,6 @@ struct UrDriverConfiguration
    */
   std::chrono::milliseconds rtde_initialization_timeout = std::chrono::seconds(5);
 
-  /*!
-   * \brief Timeout for waiting for primary client configuration data.
-   */
-  std::chrono::milliseconds primary_configuration_timeout = std::chrono::seconds(1);
-
   bool non_blocking_read = false;
 
   // TODO: Remove on 2027-05

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -98,7 +98,7 @@ void UrDriver::init(const UrDriverConfiguration& config)
 
   startPrimaryClientCommunication();
 
-  std::chrono::milliseconds timeout(1000);
+  std::chrono::milliseconds timeout(config.primary_configuration_timeout);
   try
   {
     waitFor([this]() { return primary_client_->getConfigurationData() != nullptr; }, timeout);

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -98,7 +98,7 @@ void UrDriver::init(const UrDriverConfiguration& config)
 
   startPrimaryClientCommunication();
 
-  std::chrono::milliseconds timeout(1000);
+  std::chrono::milliseconds timeout(10000);
   try
   {
     waitFor([this]() { return primary_client_->getConfigurationData() != nullptr; }, timeout);

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -98,7 +98,7 @@ void UrDriver::init(const UrDriverConfiguration& config)
 
   startPrimaryClientCommunication();
 
-  std::chrono::milliseconds timeout(config.primary_configuration_timeout);
+  std::chrono::milliseconds timeout(1000);
   try
   {
     waitFor([this]() { return primary_client_->getConfigurationData() != nullptr; }, timeout);


### PR DESCRIPTION
This PR adds primary_configuration_timeout as a configurable field in UrDriverConfiguration, replacing the previously hardcoded 1000 ms timeout used when waiting for primary client configuration data during driver initialization, since in some network environments, the hard coded value is insufficient and causes initialization failures.

This change is a prerequisite for [Universal_Robots_ROS2_Driver#primary_configuration_timeout as hardware interface parameter], which wires this parameter through the ROS 2 hardware interface and URDF/xacro description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only replaces a hardcoded 1s initialization timeout with a config-driven value, changing startup behavior but not runtime control logic.
> 
> **Overview**
> Makes the primary-client configuration wait timeout configurable via a new `UrDriverConfiguration::primary_configuration_timeout` field (defaulting to 1s).
> 
> Driver initialization now uses this value instead of a hardcoded 1000ms when waiting for `primary_client_->getConfigurationData()`, improving robustness in slower network environments and producing the same `TimeoutException` with the configured duration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f84afd77dbb455ff4e7ac5d962c76c857d194c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->