### PR TITLE
Make sure motion control returns to main thread before stopping

### DIFF
--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -1083,6 +1083,13 @@ while control_mode > MODE_STOPPED:
     end
   else:
     textmsg("Socket timed out waiting for command on reverse_socket. The script will exit now.")
+    if control_mode == MODE_FREEDRIVE:
+      end_freedrive_mode()
+    end
+    control_mode = MODE_STOPPED
+    join thread_move
+    kill thread_trajectory
+    kill thread_script_commands
     stopj(STOPJ_ACCELERATION)
     halt
   end

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -1087,7 +1087,7 @@ while control_mode > MODE_STOPPED:
       end_freedrive_mode()
     end
     control_mode = MODE_STOPPED
-    join thread_move
+    kill thread_move
     kill thread_trajectory
     kill thread_script_commands
     stopj(STOPJ_ACCELERATION)


### PR DESCRIPTION
When the watchdog times out, we halt in the external_control script and call stopj() just before that. However, ongoing motion will never happen in the main thread, but we always use a motion thread. Thus, calling stopj() here will result in an error that currently another thread is controlling the robot's motion.

Since we still want to stop the robot using the predefined deceleration, we have to stop all motion beforehand. Effectively returning motion control to the main thread before calling stopj().

Alternatively, we could remove the `stopj()` command (it is effectively not doing anything right now, anyway), but that would result in a very sudden stop of the robot.

This effectively fixes #479 