### PR TITLE
Add getKinematicsInfo accessor to PrimaryClient

### DIFF
--- a/include/ur_client_library/primary/primary_client.h
+++ b/include/ur_client_library/primary/primary_client.h
@@ -259,6 +259,20 @@ public:
   }
 
   /*!
+   * \brief Get the latest kinematics info.
+   *
+   * The kinematics info contains the controller's calibrated DH parameters: the nominal model
+   * combined with the per-arm calibration deltas, plus the calibration checksum/status. It
+   * will be updated in the background. This will always show the latest received kinematics
+   * info independent of the time that has passed since receiving it. If no kinematics info
+   * has been received yet, this will return a nullptr.
+   */
+  std::shared_ptr<KinematicsInfo> getKinematicsInfo()
+  {
+    return consumer_->getKinematicsInfo();
+  }
+
+  /*!
    * \brief Get the Robot type
    *
    * If no robot type data has been received yet, this will return UNDEFINED.

--- a/include/ur_client_library/primary/primary_consumer.h
+++ b/include/ur_client_library/primary/primary_consumer.h
@@ -107,6 +107,7 @@ public:
   virtual bool consume(KinematicsInfo& pkg) override
   {
     URCL_LOG_DEBUG("%s", pkg.toString().c_str());
+    std::scoped_lock lock(kinematics_info_mutex_);
     kinematics_info_ = std::make_shared<KinematicsInfo>(pkg);
     return true;
   }
@@ -203,6 +204,7 @@ public:
    */
   std::shared_ptr<KinematicsInfo> getKinematicsInfo()
   {
+    std::scoped_lock lock(kinematics_info_mutex_);
     return kinematics_info_;
   }
 
@@ -259,6 +261,7 @@ public:
 private:
   std::function<void(ErrorCode&)> error_code_message_callback_;
   std::shared_ptr<KinematicsInfo> kinematics_info_;
+  std::mutex kinematics_info_mutex_;
   std::mutex robot_mode_mutex_;
   std::shared_ptr<RobotModeData> robot_mode_;
   std::mutex version_information_mutex_;

--- a/tests/test_primary_client.cpp
+++ b/tests/test_primary_client.cpp
@@ -268,6 +268,24 @@ TEST_F(PrimaryClientTest, test_configuration_data)
   EXPECT_NE(client_->getRobotType(), RobotType::UNDEFINED);
 }
 
+TEST_F(PrimaryClientTest, test_kinematics_info)
+{
+  EXPECT_NO_THROW(client_->start());
+
+  // Once we connect to the primary client we should receive kinematics info
+  auto start_time = std::chrono::system_clock::now();
+  const auto timeout = std::chrono::seconds(1);
+  auto kinematics_info = client_->getKinematicsInfo();
+  while (kinematics_info == nullptr && std::chrono::system_clock::now() - start_time < timeout)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    kinematics_info = client_->getKinematicsInfo();
+  }
+
+  // We should have received a kinematics info package
+  EXPECT_NE(kinematics_info, nullptr);
+}
+
 TEST_F(PrimaryClientTest, test_get_robot_series)
 {
   EXPECT_NO_THROW(client_->start());


### PR DESCRIPTION
Closes issue https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/495

Adds a `getKinematicsInfo()` accessor on `PrimaryClient` that forwards to the internal `PrimaryConsumer`'s existing accessor. This mirrors the pattern of `getConfigurationData()`

Also adds the missing mutex around `kinematics_info_` in `PrimaryConsumer`, matching the synchronization pattern already uses in every other captures packet member (`robot_mode_`, `configuration_data_`, `version_information_`, etc). Without it the new public accessor  would expose a data race between the pipeline  thread that writes `kinematics_info_` and the caller thread that reads it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only accessor and aligns `KinematicsInfo` storage with existing mutex-protected packet caches, reducing the chance of data races.
> 
> **Overview**
> Exposes controller calibration/kinematics data via a new `PrimaryClient::getKinematicsInfo()` accessor that forwards the latest `KinematicsInfo` received by the primary pipeline.
> 
> Fixes thread-safety in `PrimaryConsumer` by protecting `kinematics_info_` reads/writes with a dedicated mutex, and adds a unit/integration test that waits for non-null kinematics info after connecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fcda3603f846d5f71501120d9ebb75713f3aaa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->