### PR TITLE
Fix flaky reverse_interface test

### DIFF
--- a/tests/test_reverse_interface.cpp
+++ b/tests/test_reverse_interface.cpp
@@ -536,8 +536,11 @@ TEST_F(ReverseInterfaceTest, disconnected_callbacks_are_called)
   // Close the client connection
   client_->close();
   EXPECT_TRUE(waitForProgramState(1000, false));
-  std::unique_lock<std::mutex> lk(g_connection_mutex);
-  g_connection_condition.wait_for(lk, std::chrono::seconds(1), [&]() { return !reverse_interface_->connected.load(); });
+  {
+    std::unique_lock<std::mutex> lk(g_connection_mutex);
+    g_connection_condition.wait_for(lk, std::chrono::seconds(1),
+                                    [&]() { return !reverse_interface_->connected.load(); });
+  }
   EXPECT_TRUE(disconnect_called_1);
   EXPECT_TRUE(disconnect_called_2);
 
@@ -548,7 +551,11 @@ TEST_F(ReverseInterfaceTest, disconnected_callbacks_are_called)
   EXPECT_TRUE(waitForProgramState(1000, true));
   reverse_interface_->unregisterDisconnectionCallback(disconnection_callback_id_1);
   client_->close();
-  g_connection_condition.wait_for(lk, std::chrono::seconds(1), [&]() { return !reverse_interface_->connected.load(); });
+  {
+    std::unique_lock<std::mutex> lk(g_connection_mutex);
+    g_connection_condition.wait_for(lk, std::chrono::seconds(1),
+                                    [&]() { return !reverse_interface_->connected.load(); });
+  }
   EXPECT_TRUE(waitForProgramState(1000, false));
   EXPECT_FALSE(disconnect_called_1);
   EXPECT_TRUE(disconnect_called_2);
@@ -560,7 +567,11 @@ TEST_F(ReverseInterfaceTest, disconnected_callbacks_are_called)
   EXPECT_TRUE(waitForProgramState(1000, true));
   reverse_interface_->unregisterDisconnectionCallback(disconnection_callback_id_2);
   client_->close();
-  g_connection_condition.wait_for(lk, std::chrono::seconds(1), [&]() { return !reverse_interface_->connected.load(); });
+  {
+    std::unique_lock<std::mutex> lk(g_connection_mutex);
+    g_connection_condition.wait_for(lk, std::chrono::seconds(1),
+                                    [&]() { return !reverse_interface_->connected.load(); });
+  }
   EXPECT_TRUE(waitForProgramState(1000, false));
   EXPECT_FALSE(disconnect_called_1);
   EXPECT_FALSE(disconnect_called_2);


### PR DESCRIPTION
Scope g_connection_mutex only around each wait_for on g_connection_condition in ReverseInterfaceTest.disconnected_callbacks_are_called. Previously the test held the mutex from the first disconnect wait through the rest of the test, which blocked the TCPServer worker in TestableReverseInterface::connectionCallback while it waited for the same mutex. The worker never returned to select/recv, so later client closes were not observed and waitForProgramState(false) timed out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test synchronization, reducing lock contention that could deadlock the server thread and cause timeouts.
> 
> **Overview**
> Fixes flakiness in `ReverseInterfaceTest.disconnected_callbacks_are_called` by **scoping `g_connection_mutex` to each `g_connection_condition.wait_for`** instead of holding a single lock across multiple disconnect/reconnect phases.
> 
> This prevents the test thread from blocking the reverse interface’s connection/disconnection callback thread on the same mutex, so subsequent client closes are observed reliably and `waitForProgramState(false)` no longer intermittently times out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03272deac8faafc46c0a3fcfff7b28ceb0b68571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->