### PR TITLE
Remove programs.UR5 linking to /ursim/programs

### DIFF
--- a/tests/resources/dockerursim/programs/e-series/programs.UR5
+++ b/tests/resources/dockerursim/programs/e-series/programs.UR5
@@ -1,1 +1,0 @@
-/ursim/programs.UR5


### PR DESCRIPTION
It should not be necessary for the URSim instance, as it's autogenerated there and can trigger malicious code checkers to have a symlink to an absolute path.

Apparently, that's what has been holding back release for ROS lyrical and rolling on resolute, as there, python 3.14 was used to bloom the packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes an unused/undesired test fixture link and does not change runtime logic.
> 
> **Overview**
> Removes `tests/resources/dockerursim/programs/e-series/programs.UR5`, which contained an absolute-path reference to `/ursim/programs.UR5`.
> 
> This eliminates an unnecessary URSim fixture that could trip symlink/"malicious code" scanners during packaging or CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e897c35ce0a552ccae3d57d4ca258f518204659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->