### PR TITLE
Release/2.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove programs.UR5 linking to /ursim/programs (`#500 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/500>`_)
+* Fix data race (`#498 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/498>`_)
+* Fix flaky reverse_interface test (`#497 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/497>`_)
+* Add getKinematicsInfo accessor to PrimaryClient (`#496 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/496>`_)
+* Make downloading and checking RTDE outputs from docs optional (`#493 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/493>`_)
+* Add helper function to get robot series (`#488 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/488>`_)
+* Make sure motion control returns to main thread before stopping (`#490 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/490>`_)
+* Fix broken links (`#487 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/487>`_)
+* Contributors: Felix Exner, Nick Franczak
+
 2.10.0 (2026-04-17)
 -------------------
 * [primary] Add new fields to ConfigurationData object (`#485 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/485>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.11.0 (2026-05-05)
+-------------------
 * Remove programs.UR5 linking to /ursim/programs (`#500 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/500>`_)
 * Fix data race (`#498 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/498>`_)
 * Fix flaky reverse_interface test (`#497 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/497>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>2.10.0</version>
+  <version>2.11.0</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
Small release, basically to trigger a new ROS release for Lyrical and Rolling on Resolute.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only metadata updates (version bump and changelog entry) with no functional code changes, so risk is low and limited to packaging/release automation.
> 
> **Overview**
> Prepares the `2.11.0` release by **bumping the package version** in `package.xml` and **adding a `2.11.0` section** to `CHANGELOG.rst` summarizing the included fixes/features.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb8e68023b9380eb2dbe03b49ec53e21308f609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->