### PR TITLE
Docs: Make default group tab point to PolyScope X

### DIFF
--- a/doc/setup/robot_setup.rst
+++ b/doc/setup/robot_setup.rst
@@ -9,10 +9,19 @@ The robot needs to be prepared before it can be used with the client library.
 
 .. tabs::
 
-   .. group-tab:: CB3
+   .. group-tab:: PolyScope X
 
-      CB3 robots can directly be used with the ur_client_library. No special preparation is needed.
+      **Enable services:**
 
+      #. Go to the hamburger menu -> settings.
+      #. Go to Security -> Services.
+      #. Unlock the menu using the admin password.
+      #. Enable the Primary Client Interface and Real-Time Data Exchange (RTDE) interfaces.
+      #. Lock the menu and press exit.
+
+      .. image:: ../images/initial_setup_images/services_polyscopex.png
+         :width: 600
+         :alt: Screenshot from PolyScope X screen.
 
    .. group-tab:: PolyScope 5
 
@@ -46,20 +55,10 @@ The robot needs to be prepared before it can be used with the client library.
             :width: 600
             :alt: Screenshot from PolyScope 5.xx services menu.
 
+   .. group-tab:: CB3
 
-   .. group-tab:: PolyScope X
+      CB3 robots can directly be used with the ur_client_library. No special preparation is needed.
 
-      **Enable services:**
-
-      #. Go to the hamburger menu -> settings.
-      #. Go to Security -> Services.
-      #. Unlock the menu using the admin password.
-      #. Enable the Primary Client Interface and Real-Time Data Exchange (RTDE) interfaces.
-      #. Lock the menu and press exit.
-
-      .. image:: ../images/initial_setup_images/services_polyscopex.png
-         :width: 600
-         :alt: Screenshot from PolyScope X screen.
 
 .. _install_urcap:
 
@@ -72,6 +71,131 @@ driver on the remote PC and then start a program from the tech pendant to connec
 application.
 
 .. tabs::
+
+   .. group-tab:: PolyScope X
+
+      The latest release can be downloaded from `GitHub (URCapX)
+      <https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCapX/releases>`_.
+
+      To install it you first have to copy it to a USB stick and plug that into the robot's teach
+      pendant.
+
+      On the welcome screen click on the hamburger menu in the top-left corner and select *System
+      Manager* to enter the robot's setup.  There select *URCaps* to enter the URCaps installation
+      screen. You'll have to press *unlock* and enter the admin password to be able to install new
+      URCaps.
+
+
+      .. image:: ../images/initial_setup_images/px_01_welcome.png
+         :target: initial_setup_images/px_01_welcome.png
+         :alt: Welcome screen of a PolyScope X robot
+
+
+      There, click the "+URCap" button at the top-right to open the file selector. There you should see
+      all urcap files stored on a plugged USB drive.  Select and open
+      the **external-control-X.Y.Z.urcapx** file and click *Confirm*. A popup should ask you to
+      confirm the installation.
+
+      .. image:: ../images/initial_setup_images/px_05_urcaps_installed.png
+         :target: initial_setup_images/px_05_urcaps_installed.png
+         :alt: URCaps screen with installed urcaps
+
+      Upon confirmation, the external-control URCap should be listed as installed.
+
+      After the robot rebooted you should find the **External Control** URCapX on the *Application*
+      Screen. If you open it, you will get to its configuration screen.
+
+      .. image:: ../images/initial_setup_images/px_07_installation_excontrol.png
+         :target: initial_setup_images/px_07_installation_excontrol.png
+         :alt: Configuration screen of External Control URCapX
+
+
+      Here you'll have to setup the IP address of the external PC which will be running the remote
+      application. Note that the robot and the external PC have to be in the same network, ideally in a
+      direct connection with each other to minimize network disturbances. The custom port should be left
+      untouched for now.
+
+      To use the new URCaps, create a new program and insert the **External Control** program node into
+      the program tree
+
+      .. image:: ../images/initial_setup_images/px_10_prog_structure_urcaps.png
+         :target: initial_setup_images/px_10_prog_structure_urcaps.png
+         :alt: Insert the external control node
+
+
+      .. image:: ../images/initial_setup_images/px_11_program_view_excontrol.png
+         :target: initial_setup_images/px_11_program_view_excontrol.png
+         :alt: Program view of external control
+
+
+      If you select the External Control program node, you'll see a button "Update program"
+      appearing next to it. With the external application started, press it to receive the script
+      code.
+
+   .. group-tab:: PolyScope 5
+
+      .. note::
+
+         A minimal PolyScope version of 5.9.4 is required to use this URCap
+
+      The latest release can be downloaded from `its own repository <https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/releases>`_.
+
+      To install it you first have to copy it to the robot's **programs** folder which can be done either
+      via scp or using a USB stick.
+
+      On the welcome screen click on the hamburger menu in the top-right corner and select *Settings* to enter the robot's setup.  There select *System* and then *URCaps* to enter the URCaps installation screen.
+
+
+      .. image:: ../images/initial_setup_images/es_01_welcome.png
+         :target: initial_setup_images/es_01_welcome.png
+         :alt: Welcome screen of an e-Series robot
+
+
+      There, click the little plus sign at the bottom to open the file selector. There you should see
+      all urcap files stored inside the robot's programs folder or a plugged USB drive.  Select and open
+      the **externalcontrol-X.Y.Z.urcap** file and click *open*. Your URCaps view should now show the
+      **External Control** in the list of active URCaps and a notification to restart the robot. Do that
+      now.
+
+
+      .. image:: ../images/initial_setup_images/es_05_urcaps_installed.png
+         :target: initial_setup_images/es_05_urcaps_installed.png
+         :alt: URCaps screen with installed urcaps
+
+
+      After the reboot you should find the **External Control** URCaps inside the *Installation* section.
+      For this select *Program Robot* on the welcome screen, select the *Installation* tab and select
+      **External Control** from the list.
+
+
+      .. image:: ../images/initial_setup_images/es_07_installation_excontrol.png
+         :target: initial_setup_images/es_07_installation_excontrol.png
+         :alt: Installation screen of URCaps
+
+
+      Here you'll have to setup the IP address of the external PC which will be running the remote
+      application. Note that the robot and the external PC have to be in the same network, ideally in a
+      direct connection with each other to minimize network disturbances. The custom port should be left
+      untouched for now.
+
+
+      .. image:: ../images/initial_setup_images/es_10_prog_structure_urcaps.png
+         :target: initial_setup_images/es_10_prog_structure_urcaps.png
+         :alt: Insert the external control node
+
+
+      To use the new URCaps, create a new program and insert the **External Control** program node into
+      the program tree
+
+
+      .. image:: ../images/initial_setup_images/es_11_program_view_excontrol.png
+         :target: initial_setup_images/es_11_program_view_excontrol.png
+         :alt: Program view of external control
+
+
+      If you click on the *command* tab again, you'll see the settings entered inside the *Installation*.
+      Check that they are correct, then save the program. Your robot is now ready to be used together with
+      this driver.
 
    .. group-tab:: CB3
 
@@ -139,128 +263,3 @@ application.
       If you click on the *command* tab again, you'll see the settings entered inside the *Installation*.
       Check that they are correct, then save the program. Your robot is now ready to be used together with
       this driver
-
-   .. group-tab:: PolyScope 5
-
-      .. note::
-
-         A minimal PolyScope version of 5.9.4 is required to use this URCap
-
-      The latest release can be downloaded from `its own repository <https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/releases>`_.
-
-      To install it you first have to copy it to the robot's **programs** folder which can be done either
-      via scp or using a USB stick.
-
-      On the welcome screen click on the hamburger menu in the top-right corner and select *Settings* to enter the robot's setup.  There select *System* and then *URCaps* to enter the URCaps installation screen.
-
-
-      .. image:: ../images/initial_setup_images/es_01_welcome.png
-         :target: initial_setup_images/es_01_welcome.png
-         :alt: Welcome screen of an e-Series robot
-
-
-      There, click the little plus sign at the bottom to open the file selector. There you should see
-      all urcap files stored inside the robot's programs folder or a plugged USB drive.  Select and open
-      the **externalcontrol-X.Y.Z.urcap** file and click *open*. Your URCaps view should now show the
-      **External Control** in the list of active URCaps and a notification to restart the robot. Do that
-      now.
-
-
-      .. image:: ../images/initial_setup_images/es_05_urcaps_installed.png
-         :target: initial_setup_images/es_05_urcaps_installed.png
-         :alt: URCaps screen with installed urcaps
-
-
-      After the reboot you should find the **External Control** URCaps inside the *Installation* section.
-      For this select *Program Robot* on the welcome screen, select the *Installation* tab and select
-      **External Control** from the list.
-
-
-      .. image:: ../images/initial_setup_images/es_07_installation_excontrol.png
-         :target: initial_setup_images/es_07_installation_excontrol.png
-         :alt: Installation screen of URCaps
-
-
-      Here you'll have to setup the IP address of the external PC which will be running the remote
-      application. Note that the robot and the external PC have to be in the same network, ideally in a
-      direct connection with each other to minimize network disturbances. The custom port should be left
-      untouched for now.
-
-
-      .. image:: ../images/initial_setup_images/es_10_prog_structure_urcaps.png
-         :target: initial_setup_images/es_10_prog_structure_urcaps.png
-         :alt: Insert the external control node
-
-
-      To use the new URCaps, create a new program and insert the **External Control** program node into
-      the program tree
-
-
-      .. image:: ../images/initial_setup_images/es_11_program_view_excontrol.png
-         :target: initial_setup_images/es_11_program_view_excontrol.png
-         :alt: Program view of external control
-
-
-      If you click on the *command* tab again, you'll see the settings entered inside the *Installation*.
-      Check that they are correct, then save the program. Your robot is now ready to be used together with
-      this driver.
-
-   .. group-tab:: PolyScope X
-
-      The latest release can be downloaded from `GitHub (URCapX)
-      <https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCapX/releases>`_.
-
-      To install it you first have to copy it to a USB stick and plug that into the robot's teach
-      pendant.
-
-      On the welcome screen click on the hamburger menu in the top-left corner and select *System
-      Manager* to enter the robot's setup.  There select *URCaps* to enter the URCaps installation
-      screen. You'll have to press *unlock* and enter the admin password to be able to install new
-      URCaps.
-
-
-      .. image:: ../images/initial_setup_images/px_01_welcome.png
-         :target: initial_setup_images/px_01_welcome.png
-         :alt: Welcome screen of a PolyScope X robot
-
-
-      There, click the "+URCap" button at the top-right to open the file selector. There you should see
-      all urcap files stored on a plugged USB drive.  Select and open
-      the **external-control-X.Y.Z.urcapx** file and click *Confirm*. A popup should ask you to
-      confirm the installation.
-
-      .. image:: ../images/initial_setup_images/px_05_urcaps_installed.png
-         :target: initial_setup_images/px_05_urcaps_installed.png
-         :alt: URCaps screen with installed urcaps
-
-      Upon confirmation, the external-control URCap should be listed as installed.
-
-      After the robot rebooted you should find the **External Control** URCapX on the *Application*
-      Screen. If you open it, you will get to its configuration screen.
-
-      .. image:: ../images/initial_setup_images/px_07_installation_excontrol.png
-         :target: initial_setup_images/px_07_installation_excontrol.png
-         :alt: Configuration screen of External Control URCapX
-
-
-      Here you'll have to setup the IP address of the external PC which will be running the remote
-      application. Note that the robot and the external PC have to be in the same network, ideally in a
-      direct connection with each other to minimize network disturbances. The custom port should be left
-      untouched for now.
-
-      To use the new URCaps, create a new program and insert the **External Control** program node into
-      the program tree
-
-      .. image:: ../images/initial_setup_images/px_10_prog_structure_urcaps.png
-         :target: initial_setup_images/px_10_prog_structure_urcaps.png
-         :alt: Insert the external control node
-
-
-      .. image:: ../images/initial_setup_images/px_11_program_view_excontrol.png
-         :target: initial_setup_images/px_11_program_view_excontrol.png
-         :alt: Program view of external control
-
-
-      If you select the External Control program node, you'll see a button "Update program"
-      appearing next to it. With the external application started, press it to receive the script
-      code.


### PR DESCRIPTION
By default landing on CB3 doesn't really make sense.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that reorder and clarify setup instructions; no runtime code paths are affected.
> 
> **Overview**
> **Reorders the `.. tabs::` in `doc/setup/robot_setup.rst` so *PolyScope X* becomes the first/default tab** for both *Robot setup* and *URCap installation* sections.
> 
> Also adjusts the PolyScope X instructions (service enablement + URCapX download/install steps and screenshots) while moving the CB3 content later, keeping the same overall guidance but changing what readers see first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d213ec1a4bb804ab5851f7e1047d9809ea87dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->