### PR TITLE
Added a test to check all robot model parametrizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
         env:
           URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
@@ -300,29 +300,6 @@ jobs:
           flags: check_version_${{ matrix.env.ROBOT_MODEL }}-${{ matrix.env.URSIM_VERSION }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Generate URSim log files
-        if: ${{ always() && steps.check_polyscopex.outputs.is_polyscopex == 'false' }}
-        run: |
-          nc -q 1 192.168.56.101 29999 <<END
-          saveLog
-          END
-          mkdir -p ursim_logs
-          docker cp ursim:/ursim/URControl.log ursim_logs/URControl.log
-          docker cp ursim:/ursim/polyscope.log ursim_logs/polyscope.log
-          docker cp ursim:/ursim/log_history.txt ursim_logs/log_history.txt
-      - name: Copy flight reports
-        if: ${{ failure() && steps.check_polyscopex.outputs.is_polyscopex == 'false' }}
-        run: |
-          mkdir -p ursim_logs/flightreports
-          docker cp ursim:/ursim/flightreports/. ursim_logs/flightreports/
-      - name: Upload logfiles
-        uses: actions/upload-artifact@v7
-        if: ${{ always() && steps.check_polyscopex.outputs.is_polyscopex == 'false' }}
-        with:
-          name: ${{matrix.env.ROBOT_MODEL}}_${{matrix.env.URSIM_VERSION}}_model_check_URSim_Logs
-          path: ursim_logs
-          if-no-files-found: error
-          retention-days: 10
 
   test_start_ursim:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
       - name: Access PolyScope
         if: ${{ steps.check_polyscopex.outputs.is_polyscopex  == 'true' }}
         run: chrome --no-sandbox --disable-settuid-sandbox --headless=new 192.168.56.101 &
+      - name: Install Python dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3-pandas python3-lxml
       - name: Generate rtde outputs lists
         run: python3 tests/resources/generate_rtde_outputs.py 
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,48 @@ on:
     - cron: '38 2 * * *'
 
 jobs:
-  build:
+  ubuntu_build:
+    name: ubuntu_build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install build-tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake python3-pandas python3-lxml
+      - name: configure
+        run: >
+          mkdir build &&
+          cd build &&
+          cmake ..
+          -DBUILDING_TESTS=1
+          -DINTEGRATION_TESTS=1
+          -DWITH_ASAN=ON
+          -DPRIMARY_CLIENT_STRICT_PARSING_=ON
+          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+          -DCHECK_RTDE_DOCS_RECIPE=ON
+        env:
+          CXXFLAGS: -g -O2 -fprofile-arcs -ftest-coverage
+          CFLAGS: -g -O2 -fprofile-arcs -ftest-coverage
+          LDFLAGS: -fprofile-arcs -ftest-coverage
+      - name: build
+        id: build
+        run: cmake --build build --config Debug
+      - name: Archive CMake build directory
+        if: steps.build.outcome == 'success'
+        run: tar -czf build.tar.gz build
+      - name: Upload CMake build archive
+        if: steps.build.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          path: build.tar.gz
+          if-no-files-found: error
+          retention-days: 5
+          archive: false
+
+  run_tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    name: build (${{matrix.env.URSIM_VERSION}}-${{matrix.env.ROBOT_MODEL}})
+    name: run_tests (${{matrix.env.URSIM_VERSION}}-${{matrix.env.ROBOT_MODEL}})
+    needs: ubuntu_build
     strategy:
       fail-fast: false
       matrix:
@@ -46,8 +84,6 @@ jobs:
           ROBOT_MODEL: ${{matrix.env.ROBOT_MODEL}}
           URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
           PROGRAM_FOLDER: ${{matrix.env.PROGRAM_FOLDER}}
-      - name: install-pips
-        run: pip install pandas lxml
       - id: check_polyscopex
         run: |
           if [[ "${{matrix.env.URSIM_VERSION}}" == "10."* ]]; then
@@ -57,29 +93,19 @@ jobs:
           fi
       - name: setup chrome
         uses: browser-actions/setup-chrome@v2
-      - name: configure
-        run: >
-          mkdir build &&
-          cd build &&
-          cmake ..
-          -DBUILDING_TESTS=1
-          -DINTEGRATION_TESTS=1
-          -DWITH_ASAN=ON
-          -DPRIMARY_CLIENT_STRICT_PARSING=ON
-          -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
-          -DCHECK_RTDE_DOCS_RECIPE=ON
-        env:
-          CXXFLAGS: -g -O2 -fprofile-arcs -ftest-coverage
-          CFLAGS: -g -O2 -fprofile-arcs -ftest-coverage
-          LDFLAGS: -fprofile-arcs -ftest-coverage
-      - name: build
-        id: build
-        run: cmake --build build --config Debug
+      - name: Download CMake build archive
+        uses: actions/download-artifact@v8
+        with:
+          name: build.tar.gz
+      - name: Extract CMake build directory
+        run: tar -xzf build.tar.gz
       - name: Create folder for test artifacts
         run: mkdir -p test_artifacts
       - name: Access PolyScope
         if: ${{ steps.check_polyscopex.outputs.is_polyscopex  == 'true' }}
         run: chrome --no-sandbox --disable-settuid-sandbox --headless=new 192.168.56.101 &
+      - name: Generate rtde outputs lists
+        run: python3 tests/resources/generate_rtde_outputs.py 
       - name: test
         run: cd build && ctest --output-on-failure --output-junit junit.xml
         env:
@@ -96,13 +122,10 @@ jobs:
       - name: run examples
         run: ./run_examples.sh "192.168.56.101" 1
       - name: install gcovr
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: sudo apt-get install -y gcovr
       - name: gcovr
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: cd build && gcovr -r .. --xml coverage.xml --gcov-ignore-parse-errors negative_hits.warn_once_per_file --exclude "../3rdparty"
       - name: Upload coverage reports to Codecov with GitHub Action
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
@@ -148,6 +171,155 @@ jobs:
           name: ${{matrix.env.ROBOT_MODEL}}_${{matrix.env.URSIM_VERSION}}_generated_scripts
           path: test_artifacts/generated_scripts
           if-no-files-found: warn
+          retention-days: 10
+
+  robot_model_check:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    needs: ubuntu_build
+    name: check_model (${{matrix.env.URSIM_VERSION}}-${{matrix.env.ROBOT_MODEL}})
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+          - ROBOT_MODEL: 'ur3'
+            URSIM_VERSION: '3.14.3'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/cb3'
+          - ROBOT_MODEL: 'ur5'
+            URSIM_VERSION: '3.15.8'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/cb3'
+          - ROBOT_MODEL: 'ur10'
+            URSIM_VERSION: '3.15.8'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/cb3'
+          - ROBOT_MODEL: 'ur3e'
+            URSIM_VERSION: '5.9.4'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur5e'
+            URSIM_VERSION: '5.12.8'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur7e'
+            URSIM_VERSION: '5.22.2'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur10e'
+            URSIM_VERSION: '5.15.2'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur12e'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur16e'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur8long'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur15'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur18'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur20'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur30'
+            URSIM_VERSION: '5.25.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/e-series'
+          - ROBOT_MODEL: 'ur3e'
+            URSIM_VERSION: '10.11.0'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur5e'
+            URSIM_VERSION: '10.11.0'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur7e'
+            URSIM_VERSION: '10.11.0'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur10e'
+            URSIM_VERSION: '10.11.0'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur12e'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur16e'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur8long'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur15'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur18'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur20'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+          - ROBOT_MODEL: 'ur30'
+            URSIM_VERSION: '10.12.1'
+            PROGRAM_FOLDER: 'tests/resources/dockerursim/programs/polyscopex'
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: start ursim
+        run: |
+          scripts/start_ursim.sh -m $ROBOT_MODEL -v $URSIM_VERSION -p $PROGRAM_FOLDER -d -f DISABLED
+        env:
+          DOCKER_RUN_OPTS: --network ursim_net
+          ROBOT_MODEL: ${{matrix.env.ROBOT_MODEL}}
+          URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
+          PROGRAM_FOLDER: ${{matrix.env.PROGRAM_FOLDER}}
+      - name: Download CMake build archive
+        uses: actions/download-artifact@v8
+        with:
+          name: build.tar.gz
+        env:
+          DOCKER_RUN_OPTS: --network ursim_net
+          ROBOT_MODEL: ${{matrix.env.ROBOT_MODEL}}
+          URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
+          PROGRAM_FOLDER: ${{matrix.env.PROGRAM_FOLDER}}
+      - name: Extract CMake build directory
+        run: tar -xzf build.tar.gz
+      - name: inspect build folder
+        run: ls -la build && ls -la build/tests
+      - name: test robot type
+        run: cd build && ctest -R PrimaryClientTest.test_robot_type --verbose --output-junit junit.xml
+        env:
+          URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
+          ROBOT_MODEL: ${{matrix.env.ROBOT_MODEL}}
+      - name: install gcovr
+        run: sudo apt-get install -y gcovr
+      - name: gcovr
+        run: cd build && gcovr -r .. --xml coverage.xml --gcov-ignore-parse-errors negative_hits.warn_once_per_file --exclude "../3rdparty"
+      - name: Upload coverage reports to Codecov with GitHub Action
+        uses: codecov/codecov-action@v6
+        with:
+          fail_ci_if_error: true
+          files: build/coverage.xml
+          flags: check_version_${{ matrix.env.ROBOT_MODEL }}-${{ matrix.env.URSIM_VERSION }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Generate URSim log files
+        if: ${{ always() && steps.check_polyscopex.outputs.is_polyscopex == 'false' }}
+        run: |
+          nc -q 1 192.168.56.101 29999 <<END
+          saveLog
+          END
+          mkdir -p ursim_logs
+          docker cp ursim:/ursim/URControl.log ursim_logs/URControl.log
+          docker cp ursim:/ursim/polyscope.log ursim_logs/polyscope.log
+          docker cp ursim:/ursim/log_history.txt ursim_logs/log_history.txt
+      - name: Copy flight reports
+        if: ${{ failure() && steps.check_polyscopex.outputs.is_polyscopex == 'false' }}
+        run: |
+          mkdir -p ursim_logs/flightreports
+          docker cp ursim:/ursim/flightreports/. ursim_logs/flightreports/
+      - name: Upload logfiles
+        uses: actions/upload-artifact@v7
+        if: ${{ always() && steps.check_polyscopex.outputs.is_polyscopex == 'false' }}
+        with:
+          name: ${{matrix.env.ROBOT_MODEL}}_${{matrix.env.URSIM_VERSION}}_model_check_URSim_Logs
+          path: ursim_logs
+          if-no-files-found: error
           retention-days: 10
 
   test_start_ursim:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,11 +274,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: build.tar.gz
-        env:
-          DOCKER_RUN_OPTS: --network ursim_net
-          ROBOT_MODEL: ${{matrix.env.ROBOT_MODEL}}
-          URSIM_VERSION: ${{matrix.env.URSIM_VERSION}}
-          PROGRAM_FOLDER: ${{matrix.env.PROGRAM_FOLDER}}
       - name: Extract CMake build directory
         run: tar -xzf build.tar.gz
       - name: inspect build folder

--- a/include/ur_client_library/helpers.h
+++ b/include/ur_client_library/helpers.h
@@ -169,6 +169,14 @@ void clampToUnitRange(std::array<T, N>& values)
  */
 RobotSeries robotSeriesFromTypeAndVersion(const RobotType type, const VersionInformation& version);
 
+/*!
+ * \brief Get the robot type from a string.
+ *
+ * \param robot_type_str The string representation of the robot type as used in the start_ursim.sh
+ * script. All lower-case, e.g. "ur3e", "ur5", "ur10e", "ur16e", "ur7e", "ur15e", "ur30", "ur8long".
+ *
+ * \returns The robot type corresponding to the given string.
+ */
 RobotType robotTypeFromString(const std::string& robot_type_str);
 
 }  // namespace urcl

--- a/include/ur_client_library/helpers.h
+++ b/include/ur_client_library/helpers.h
@@ -172,8 +172,15 @@ RobotSeries robotSeriesFromTypeAndVersion(const RobotType type, const VersionInf
 /*!
  * \brief Get the robot type from a string.
  *
+ * The \c RobotType enum has no dedicated entries for UR7 and UR12, so "ur7e" is mapped to
+ * \c RobotType::UR5 and "ur12e" is mapped to \c RobotType::UR10, matching what the robot
+ * reports over the primary interface.
+ *
  * \param robot_type_str The string representation of the robot type as used in the start_ursim.sh
- * script. All lower-case, e.g. "ur3e", "ur5", "ur10e", "ur16e", "ur7e", "ur15e", "ur30", "ur8long".
+ * script. Must be all lower-case, e.g. "ur3e", "ur5", "ur10e", "ur16e", "ur7e", "ur15", "ur30",
+ * "ur8long".
+ *
+ * \throws std::invalid_argument if \p robot_type_str does not match a known robot type.
  *
  * \returns The robot type corresponding to the given string.
  */

--- a/include/ur_client_library/helpers.h
+++ b/include/ur_client_library/helpers.h
@@ -169,5 +169,7 @@ void clampToUnitRange(std::array<T, N>& values)
  */
 RobotSeries robotSeriesFromTypeAndVersion(const RobotType type, const VersionInformation& version);
 
+RobotType robotTypeFromString(const std::string& robot_type_str);
+
 }  // namespace urcl
 #endif  // ifndef UR_CLIENT_LIBRARY_HELPERS_H_INCLUDED

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -129,7 +129,13 @@ strip_robot_model()
     if [[ "$robot_model" = @(ur3e|ur5e|ur10e|ur16e) ]]; then
       ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
     elif [[ "$robot_model" = @(ur7e|ur12e) ]]; then
-      ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}e")
+      # PolyScope X uses UR7e and UR12e, but PolyScope 5 uses UR7 and UR12. So we
+      # need to strip the "e" for PolyScope 5
+      if [[ "$robot_series" == "polyscopex" ]]; then
+        ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}e")
+      else
+        ROBOT_MODEL=$(echo "${ROBOT_MODEL:0:$((${#ROBOT_MODEL}-1))}")
+      fi
     fi
   fi
 }

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -35,7 +35,9 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 #include <thread>
+#include <unordered_map>
 
 // clang-format off
 // We want to keep the URL in one line to avoid formatting issues. This will make it easier to

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -203,4 +203,69 @@ RobotSeries robotSeriesFromTypeAndVersion(const RobotType type, const VersionInf
   return RobotSeries::UNDEFINED;
 }
 
+RobotType robotTypeFromString(const std::string& robot_type_str)
+{
+  if (robot_type_str == "ur3")
+  {
+    return RobotType::UR3;
+  }
+  else if (robot_type_str == "ur3e")
+  {
+    return RobotType::UR3;
+  }
+  else if (robot_type_str == "ur5")
+  {
+    return RobotType::UR5;
+  }
+  else if (robot_type_str == "ur5e")
+  {
+    return RobotType::UR5;
+  }
+  else if (robot_type_str == "ur7e")
+  {  // UR7e reports as UR5
+    return RobotType::UR5;
+  }
+  else if (robot_type_str == "ur10")
+  {
+    return RobotType::UR10;
+  }
+  else if (robot_type_str == "ur10e")
+  {
+    return RobotType::UR10;
+  }
+  else if (robot_type_str == "ur12e")
+  {  // UR12e reports as UR10
+    return RobotType::UR10;
+  }
+  else if (robot_type_str == "ur16e")
+  {
+    return RobotType::UR16;
+  }
+  else if (robot_type_str == "ur15")
+  {
+    return RobotType::UR15;
+  }
+  else if (robot_type_str == "ur18")
+  {
+    return RobotType::UR18;
+  }
+  else if (robot_type_str == "ur20")
+  {
+    return RobotType::UR20;
+  }
+  else if (robot_type_str == "ur30")
+  {
+    return RobotType::UR30;
+  }
+  else if (robot_type_str == "ur8long")
+  {
+    return RobotType::UR8LONG;
+  }
+  else
+  {
+    return RobotType::UR5;
+    throw std::invalid_argument("Unknown robot type: " + robot_type_str);
+  }
+}
+
 }  // namespace urcl

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -205,66 +205,22 @@ RobotSeries robotSeriesFromTypeAndVersion(const RobotType type, const VersionInf
 
 RobotType robotTypeFromString(const std::string& robot_type_str)
 {
-  if (robot_type_str == "ur3")
-  {
-    return RobotType::UR3;
-  }
-  else if (robot_type_str == "ur3e")
-  {
-    return RobotType::UR3;
-  }
-  else if (robot_type_str == "ur5")
-  {
-    return RobotType::UR5;
-  }
-  else if (robot_type_str == "ur5e")
-  {
-    return RobotType::UR5;
-  }
-  else if (robot_type_str == "ur7e")
-  {  // UR7e reports as UR5
-    return RobotType::UR5;
-  }
-  else if (robot_type_str == "ur10")
-  {
-    return RobotType::UR10;
-  }
-  else if (robot_type_str == "ur10e")
-  {
-    return RobotType::UR10;
-  }
-  else if (robot_type_str == "ur12e")
-  {  // UR12e reports as UR10
-    return RobotType::UR10;
-  }
-  else if (robot_type_str == "ur16e")
-  {
-    return RobotType::UR16;
-  }
-  else if (robot_type_str == "ur15")
-  {
-    return RobotType::UR15;
-  }
-  else if (robot_type_str == "ur18")
-  {
-    return RobotType::UR18;
-  }
-  else if (robot_type_str == "ur20")
-  {
-    return RobotType::UR20;
-  }
-  else if (robot_type_str == "ur30")
-  {
-    return RobotType::UR30;
-  }
-  else if (robot_type_str == "ur8long")
-  {
-    return RobotType::UR8LONG;
-  }
-  else
+  // RobotType has no dedicated entries for UR7/UR12, so UR7e and UR12e are mapped to their
+  // closest siblings UR5 and UR10 respectively, matching what the robot reports over primary.
+  static const std::unordered_map<std::string, RobotType> string_to_robot_type{
+    { "ur3", RobotType::UR3 },    { "ur3e", RobotType::UR3 },        { "ur5", RobotType::UR5 },
+    { "ur5e", RobotType::UR5 },   { "ur7e", RobotType::UR5 },        { "ur10", RobotType::UR10 },
+    { "ur10e", RobotType::UR10 }, { "ur12e", RobotType::UR10 },      { "ur16e", RobotType::UR16 },
+    { "ur15", RobotType::UR15 },  { "ur18", RobotType::UR18 },       { "ur20", RobotType::UR20 },
+    { "ur30", RobotType::UR30 },  { "ur8long", RobotType::UR8LONG },
+  };
+
+  const auto it = string_to_robot_type.find(robot_type_str);
+  if (it == string_to_robot_type.end())
   {
     throw std::invalid_argument("Unknown robot type: " + robot_type_str);
   }
+  return it->second;
 }
 
 }  // namespace urcl

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -263,7 +263,6 @@ RobotType robotTypeFromString(const std::string& robot_type_str)
   }
   else
   {
-    return RobotType::UR5;
     throw std::invalid_argument("Unknown robot type: " + robot_type_str);
   }
 }

--- a/tests/test_primary_client.cpp
+++ b/tests/test_primary_client.cpp
@@ -267,6 +267,27 @@ TEST_F(PrimaryClientTest, test_configuration_data)
   EXPECT_NE(client_->getRobotType(), RobotType::UNDEFINED);
 }
 
+TEST_F(PrimaryClientTest, test_robot_type)
+{
+  if (std::getenv("ROBOT_MODEL") == nullptr)
+  {
+    GTEST_SKIP() << "ROBOT_MODEL environment variable not set. Skipping test.";
+  }
+  EXPECT_NO_THROW(client_->start());
+
+  // Wait until we have received configuration data so that the robot type is known.
+  auto start_time = std::chrono::system_clock::now();
+  const auto timeout = std::chrono::seconds(10);
+  while (client_->getConfigurationData() == nullptr && std::chrono::system_clock::now() - start_time < timeout)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_NE(client_->getConfigurationData(), nullptr);
+  const std::string robot_model_env = std::getenv("ROBOT_MODEL");
+  const RobotType expected_series_from_env = robotTypeFromString(robot_model_env);
+  EXPECT_EQ(client_->getRobotType(), expected_series_from_env);
+}
+
 TEST_F(PrimaryClientTest, test_kinematics_info)
 {
   EXPECT_NO_THROW(client_->start());

--- a/tests/test_primary_client.cpp
+++ b/tests/test_primary_client.cpp
@@ -284,8 +284,8 @@ TEST_F(PrimaryClientTest, test_robot_type)
   }
   ASSERT_NE(client_->getConfigurationData(), nullptr);
   const std::string robot_model_env = std::getenv("ROBOT_MODEL");
-  const RobotType expected_series_from_env = robotTypeFromString(robot_model_env);
-  EXPECT_EQ(client_->getRobotType(), expected_series_from_env);
+  const RobotType expected_robot_type = robotTypeFromString(robot_model_env);
+  EXPECT_EQ(client_->getRobotType(), expected_robot_type);
 }
 
 TEST_F(PrimaryClientTest, test_kinematics_info)

--- a/tests/test_primary_client.cpp
+++ b/tests/test_primary_client.cpp
@@ -273,11 +273,16 @@ TEST_F(PrimaryClientTest, test_robot_type)
   {
     GTEST_SKIP() << "ROBOT_MODEL environment variable not set. Skipping test.";
   }
-  EXPECT_NO_THROW(client_->start());
+  // When this test runs as the only test against a freshly started URSim (as it does in the
+  // robot_model_check CI matrix), the robot may still be initialising and drop the first
+  // primary connection. Use a short socket reconnection interval so that the producer retries
+  // quickly, and a generous outer timeout so we can ride out URSim's full warm-up.
+  constexpr auto reconnection_time = std::chrono::milliseconds(500);
+  EXPECT_NO_THROW(client_->start(/*max_num_tries=*/0, reconnection_time));
 
   // Wait until we have received configuration data so that the robot type is known.
-  auto start_time = std::chrono::system_clock::now();
-  const auto timeout = std::chrono::seconds(10);
+  const auto start_time = std::chrono::system_clock::now();
+  const auto timeout = std::chrono::seconds(60);
   while (client_->getConfigurationData() == nullptr && std::chrono::system_clock::now() - start_time < timeout)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -415,9 +415,17 @@ setup() {
 
   strip_robot_model ur7e e-series
   echo "Robot model is: $ROBOT_MODEL"
+  [ "$ROBOT_MODEL" = "UR7" ]
+
+  strip_robot_model ur7e polyscopex
+  echo "Robot model is: $ROBOT_MODEL"
   [ "$ROBOT_MODEL" = "UR7e" ]
 
   strip_robot_model ur12e e-series
+  echo "Robot model is: $ROBOT_MODEL"
+  [ "$ROBOT_MODEL" = "UR12" ]
+
+  strip_robot_model ur12e polyscopex
   echo "Robot model is: $ROBOT_MODEL"
   [ "$ROBOT_MODEL" = "UR12e" ]
 }


### PR DESCRIPTION
This PR adds a workflow to check the robot model as reported from the primary interface with the model argument provided to `start_ursim.sh`.

This also fixes passing ur7e or ur12e to PolyScope 5.

To reduce build resources, this PR splits the integration tests into a "build" stage and two "test" stages utilizing that build. This probably doesn't save any time, but build resources and makes handling a failed build easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it restructures CI execution and modifies `start_ursim.sh` model normalization for UR7e/UR12e, which could break integration test orchestration or URSim startup if misconfigured.
> 
> **Overview**
> **Splits the integration workflow into a dedicated Ubuntu build job and downstream test jobs** by archiving/uploading the CMake `build` directory and reusing it in `run_tests` (and a new check job), reducing repeated compilation.
> 
> **Adds a new CI job to validate robot model parametrizations across many URSim versions/models** by running only `PrimaryClientTest.test_robot_type` and reporting coverage with distinct Codecov flags.
> 
> **Fixes UR7e/UR12e handling in `scripts/start_ursim.sh`** so PolyScope 5 strips the trailing `e` while PolyScope X keeps `UR7e`/`UR12e`, with updated Bats assertions.
> 
> **Introduces `robotTypeFromString` in `helpers` and a new GTest** that compares the primary interface-reported robot type against the `ROBOT_MODEL` env var mapping (including UR7e→UR5 and UR12e→UR10).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb96c9b35bd804a0556277b32a123c0ef59797b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->