### PR TITLE
Add cppreference link to ignore list

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -36,6 +36,7 @@ jobs:
             --exclude '2013181\/gdb-causes-sem-wait-to-fail-with-eintr-error'
             --exclude 'https:\/\/lists\.apple\.com\/archives\/darwin-kernel\/2009\/Apr\/msg00010\.html'
             --exclude 'https:\/\/wiki\.linuxfoundation\.org\/realtime\/preempt_rt_versions'
+            --exclude 'https:\/\/en\.cppreference\.com\/w\/cpp\/string\/basic_string\/to_string'
             --max-concurrency 1
             './**/*.md' './**/*.html' './**/*.rst' './**/*.cpp' './**/*.h' './**/*.py'
       - name: Save lychee cache


### PR DESCRIPTION
The workflow gets a 403 on this

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just expands the lychee `--exclude` list to avoid a known 403, with no impact on runtime code or artifacts.
> 
> **Overview**
> Updates the `Check Links` GitHub Actions workflow to exclude a specific `cppreference.com` URL from lychee link checking, preventing CI failures caused by 403 responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849aa540abedb6a35ade044836549c55de449eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->