### PR TITLE
Make circular motion in example more compatible

### DIFF
--- a/examples/instruction_executor.cpp
+++ b/examples/instruction_executor.cpp
@@ -138,10 +138,11 @@ int main(int argc, char* argv[])
 
   // For moveC via and target can be a Pose or Q. When brace-init style lists are given, values are
   // interpreted as Pose.
-  instruction_executor->moveC(urcl::Pose{ -0.1, 0.463, 0.559, 0.68, -1.083, -2.076 },
-                              urcl::Pose{ -0.3203, 0.303, 0.559, 0.68, -1.083, -2.076 });
-  instruction_executor->moveC(urcl::Pose{ -0.1, 0.463, 0.559, 0.68, -1.083, -2.076 },
-                              urcl::Q{ -1.57, -1.83, 1.707, -0.833, 0.782, 0.479 });
+  instruction_executor->moveP(urcl::Pose{ -0.2, 0.5, 0.5, 0.68, -1.083, -2.076 }, 0.2, 0.2);
+  instruction_executor->moveC(urcl::Pose{ -0.2, 0.4, 0.4, 0.68, -1.083, -2.076 },
+                              urcl::Pose{ -0.2, 0.4, 0.6, 0.68, -1.083, -2.076 });
+  instruction_executor->moveC(urcl::Pose{ -0.2, 0.5, 0.5, 0.68, -1.083, -2.076 },
+                              urcl::Q{ -1.84, -1.8, 2.7, 4.2, 0.6, -4.0 });
 
   // For optimove functions, the same target rules as for moveJ and moveL apply.
   instruction_executor->optimoveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 0.2 }, 1.0, 1.0);


### PR DESCRIPTION
This motion should work on

- UR5
- UR5e
- UR20

These are all the models we currently use during tests.

Another approach would be to use relative target positions, but I would like to leave that for a later iteration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an example program’s hardcoded motion waypoints and should not affect library behavior. Main risk is the updated demo trajectory still failing or behaving unexpectedly on some robot configurations.
> 
> **Overview**
> Adjusts the `examples/instruction_executor.cpp` motion demo to make the showcased circular move (`moveC`) more broadly executable across UR5/UR5e/UR20.
> 
> Specifically replaces the previous `moveC` via/target waypoints with a preceding `moveP` and new via/target pose + joint targets intended to be more compatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4bd1a14e2de7e23a3083e5ebfcc2e7ffbc2433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->