### PR TITLE
Release/2.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.12.0 (2026-05-19)
+-------------------
 * [CI] Make circular motion in example more compatible (`#508 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/508>`_)
 * [CI], [bugfix] Added a test to check all robot model parametrizations (`#505 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/505>`_)
 * [CI]Add cppreference link to ignore list (`#506 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/506>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [CI] Make circular motion in example more compatible (`#508 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/508>`_)
+* [CI], [bugfix] Added a test to check all robot model parametrizations (`#505 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/505>`_)
+* [CI]Add cppreference link to ignore list (`#506 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/506>`_)
+* [Instruction Executor], [wire-breaking] Allow joint and pose targets for all motion functions (`#491 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/491>`_)
+* Add parsing masterboard data (`#492 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/492>`_)
+* [Docs] Make default group tab point to PolyScope X (`#502 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/502>`_)
+* [Fix] primary_configuration_timeout as configurable field in UrDriverConfiguration (`#489 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/489>`_)
+* [CI] Add lyrical build and migrate rolling to resolute (`#499 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/499>`_)
+* Contributors: Felix Exner, Litzia Carla Vilchez
+
 2.11.0 (2026-05-05)
 -------------------
 * Remove programs.UR5 linking to /ursim/programs (`#500 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/500>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>2.11.0</version>
+  <version>2.12.0</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
Release as usual

Note: cb3 integration test job is expected to fail at this point, see #508 which should fix that. I went for making the release without it, since the fix is in the example only, but we can postpone this release, if desired, to also include #508.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (version + changelog) and does not modify runtime code paths.
> 
> **Overview**
> Publishes the `2.12.0` release by bumping the package version in `package.xml` from `2.11.0` to `2.12.0`.
> 
> Updates `CHANGELOG.rst` with the `2.12.0 (2026-05-19)` entry describing the included fixes/features and CI/doc changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b6fd9b2e1e0ddf442e2d5c95a14a13de184b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->