### PR TITLE
Add robotSeriesString function

### DIFF
--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -267,4 +267,31 @@ inline std::string robotTypeString(const RobotType& type)
   }
 }
 
+/**
+ * @brief Converts a RobotSeries enum value to its corresponding string representation.
+ *
+ * This function takes a RobotSeries enum value and returns a string that represents the robot series.
+ * If the provided RobotSeries value does not match any known series, it logs a warning and returns "UNDEFINED".
+ *
+ * @param series The RobotSeries enum value to convert.
+ * @return A string representation of the robot series.
+ */
+inline std::string robotSeriesString(const RobotSeries& series)
+{
+  switch (series)
+  {
+    case RobotSeries::CB3:
+      return "CB3";
+    case RobotSeries::E_SERIES:
+      return "E_SERIES";
+    case RobotSeries::UR_SERIES:
+      return "UR_SERIES";
+    default:
+      std::stringstream ss;
+      ss << "Unknown Robot Series: " << static_cast<int>(series);
+      URCL_LOG_WARN(ss.str().c_str());
+      return "UNDEFINED";
+  }
+}
+
 }  // namespace urcl

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -137,3 +137,11 @@ TEST(TestHelpers, robotSeriesFromTypeAndVersion)
   EXPECT_EQ(robotSeriesFromTypeAndVersion(RobotType::UNDEFINED, cb3_version), RobotSeries::UNDEFINED);
   EXPECT_EQ(robotSeriesFromTypeAndVersion(RobotType::UNDEFINED, polyscope_x_version), RobotSeries::UNDEFINED);
 }
+
+TEST(TestHelpers, robotSeriesString)
+{
+  EXPECT_EQ(robotSeriesString(RobotSeries::CB3), "CB3");
+  EXPECT_EQ(robotSeriesString(RobotSeries::E_SERIES), "E_SERIES");
+  EXPECT_EQ(robotSeriesString(RobotSeries::UR_SERIES), "UR_SERIES");
+  EXPECT_EQ(robotSeriesString(RobotSeries::UNDEFINED), "UNDEFINED");
+}


### PR DESCRIPTION
Converts the `RobotSeries` enum value to a `std::string`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small header-only enum-to-string helper and a unit test, with no changes to runtime control flow beyond optional warning logs for unknown values.
> 
> **Overview**
> Adds `robotSeriesString()` in `ur/datatypes.h` to convert `RobotSeries` enum values to stable string representations, logging a warning and returning `"UNDEFINED"` for unknown values.
> 
> Extends `tests/test_helpers.cpp` with coverage for the new helper across all defined series values and the `UNDEFINED` case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885b7748a15b69ad8a516e030e70c20997b62f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->