### PR TITLE
Refactor TCPSocket::setup Timeout and Error Handling

### DIFF
--- a/include/ur_client_library/comm/tcp_socket.h
+++ b/include/ur_client_library/comm/tcp_socket.h
@@ -56,11 +56,6 @@ private:
   void setupOptions();
 
 protected:
-  static bool open(socket_t socket_fd, struct sockaddr* address, size_t address_len)
-  {
-    return ::connect(socket_fd, address, static_cast<socklen_t>(address_len)) == 0;
-  }
-
   bool setup(const std::string& host, const int port, const size_t max_num_tries = 0,
              const std::chrono::milliseconds reconnection_time = DEFAULT_RECONNECTION_TIME,
              const std::chrono::milliseconds timeout = DEFAULT_CONNECTION_TIME);

--- a/include/ur_client_library/comm/tcp_socket.h
+++ b/include/ur_client_library/comm/tcp_socket.h
@@ -62,12 +62,14 @@ protected:
   }
 
   bool setup(const std::string& host, const int port, const size_t max_num_tries = 0,
-             const std::chrono::milliseconds reconnection_time = DEFAULT_RECONNECTION_TIME);
+             const std::chrono::milliseconds reconnection_time = DEFAULT_RECONNECTION_TIME,
+             const std::chrono::milliseconds timeout = DEFAULT_CONNECTION_TIME);
 
   std::unique_ptr<timeval> recv_timeout_;
 
 public:
   static constexpr std::chrono::milliseconds DEFAULT_RECONNECTION_TIME{ 10000 };
+  static constexpr std::chrono::milliseconds DEFAULT_CONNECTION_TIME{ 500 };
   /*!
    * \brief Creates a TCPSocket object
    */

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -171,31 +171,33 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
         tv.tv_sec = static_cast<long>(timeout_ms / 1000);
         tv.tv_usec = static_cast<long>((timeout_ms % 1000) * 1000);
 
+        socket_t local_fd = socket_fd_.load();
+
         fd_set write_fds;
         FD_ZERO(&write_fds);
-        FD_SET(socket_fd_, &write_fds);
+        FD_SET(local_fd, &write_fds);
 
         fd_set except_fds;
         FD_ZERO(&except_fds);
-        FD_SET(socket_fd_, &except_fds);
+        FD_SET(local_fd, &except_fds);
 
-        int select_res = ::select(static_cast<int>(socket_fd_ + 1), nullptr, &write_fds, &except_fds, &tv);
+        int select_res = ::select(static_cast<int>(local_fd + 1), nullptr, &write_fds, &except_fds, &tv);
 
         if (select_res > 0)
         {
           int so_error = 0;
 #ifndef _WIN32
           socklen_t len = sizeof(so_error);
-          int opt_res = ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, &so_error, &len);
+          int opt_res = ::getsockopt(local_fd, SOL_SOCKET, SO_ERROR, &so_error, &len);
 #else
           int len = sizeof(so_error);
-          int opt_res = ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&so_error), &len);
+          int opt_res = ::getsockopt(local_fd, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&so_error), &len);
 #endif
           if (opt_res != 0)
           {
             socket_error = getLastSocketErrorCode();
           }
-          else if (so_error == 0 && FD_ISSET(socket_fd_, &write_fds))
+          else if (so_error == 0 && FD_ISSET(local_fd, &write_fds))
           {
             connect_success = true;
           }

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -50,9 +50,6 @@ TCPSocket::TCPSocket()
 TCPSocket::~TCPSocket()
 {
   close();
-#ifdef _WIN32
-  ::WSACleanup();
-#endif
 }
 
 void TCPSocket::setupOptions()

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -126,35 +126,58 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
         continue;
       }
 
+      bool connect_success = false;
+
 #ifndef _WIN32
       int flags = ::fcntl(socket_fd_, F_GETFL, 0);
+      if (flags < 0)
+      {
+        socket_error = getLastSocketErrorCode();
+        ::ur_close(socket_fd_);
+        socket_fd_ = INVALID_SOCKET;
+        continue;
+      }
       ::fcntl(socket_fd_, F_SETFL, flags | O_NONBLOCK);
+#else
+      unsigned long mode = 1;
+      ::ioctlsocket(socket_fd_, FIONBIO, &mode);
+#endif
 
+#ifndef _WIN32
       int connect_res = ::connect(socket_fd_, p->ai_addr, static_cast<socklen_t>(p->ai_addrlen));
-      bool connect_success = false;
+      bool is_in_progress = (connect_res != 0 && errno == EINPROGRESS);
+#else
+      int connect_res = ::connect(socket_fd_, p->ai_addr, static_cast<int>(p->ai_addrlen));
+      bool is_in_progress = (connect_res != 0 && ::WSAGetLastError() == WSAEWOULDBLOCK);
+#endif
 
       if (connect_res == 0)
       {
         connect_success = true;
       }
-      else if (errno == EINPROGRESS)
+      else if (is_in_progress)
       {
         auto timeout_ms = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
         struct timeval tv;
-        tv.tv_sec = timeout_ms / 1000;
-        tv.tv_usec = (timeout_ms % 1000) * 1000;
+        tv.tv_sec = static_cast<long>(timeout_ms / 1000);
+        tv.tv_usec = static_cast<long>((timeout_ms % 1000) * 1000);
 
         fd_set write_fds;
         FD_ZERO(&write_fds);
         FD_SET(socket_fd_, &write_fds);
 
-        int select_res = ::select(socket_fd_ + 1, nullptr, &write_fds, nullptr, &tv);
+        int select_res = ::select(static_cast<int>(socket_fd_ + 1), nullptr, &write_fds, nullptr, &tv);
 
         if (select_res > 0)
         {
           int so_error = 0;
+#ifndef _WIN32
           socklen_t len = sizeof(so_error);
           ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, &so_error, &len);
+#else
+          int len = sizeof(so_error);
+          ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&so_error), &len);
+#endif
           if (so_error == 0)
           {
             connect_success = true;
@@ -178,7 +201,12 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
         socket_error = getLastSocketErrorCode();
       }
 
+#ifndef _WIN32
       ::fcntl(socket_fd_, F_SETFL, flags);
+#else
+      mode = 0;
+      ::ioctlsocket(socket_fd_, FIONBIO, &mode);
+#endif
 
       if (connect_success)
       {
@@ -190,19 +218,6 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
         ::ur_close(socket_fd_);
         socket_fd_ = INVALID_SOCKET;
       }
-#else
-      if (open(socket_fd_, p->ai_addr, p->ai_addrlen))
-      {
-        connected = true;
-        break;
-      }
-      else
-      {
-        socket_error = getLastSocketErrorCode();
-        ::ur_close(socket_fd_);
-        socket_fd_ = INVALID_SOCKET;
-      }
-#endif
     }
 
     freeaddrinfo(result);

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -28,6 +28,8 @@
 #ifndef _WIN32
 #  include <arpa/inet.h>
 #  include <netinet/tcp.h>
+#  include <fcntl.h>
+#  include <sys/select.h>
 #endif
 
 #include "ur_client_library/log.h"
@@ -73,7 +75,7 @@ void TCPSocket::setupOptions()
 }
 
 bool TCPSocket::setup(const std::string& host, const int port, const size_t max_num_tries,
-                      const std::chrono::milliseconds reconnection_time)
+                      const std::chrono::milliseconds reconnection_time, const std::chrono::milliseconds timeout)
 {
   // This can be removed once we remove the setReconnectionTime() method
   auto reconnection_time_resolved = reconnection_time;
@@ -111,16 +113,96 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
       URCL_LOG_ERROR("Failed to get address for %s:%d", host.c_str(), port);
       return false;
     }
-    // loop through the list of addresses untill we find one that's connectable
+
+    std::error_code socket_error;
+
     for (struct addrinfo* p = result; p != nullptr; p = p->ai_next)
     {
       socket_fd_ = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
 
-      if (socket_fd_ != -1 && open(socket_fd_, p->ai_addr, p->ai_addrlen))
+      if (socket_fd_ == -1)
+      {
+        socket_error = getLastSocketErrorCode();
+        continue;
+      }
+
+#ifndef _WIN32
+      int flags = ::fcntl(socket_fd_, F_GETFL, 0);
+      ::fcntl(socket_fd_, F_SETFL, flags | O_NONBLOCK);
+
+      int connect_res = ::connect(socket_fd_, p->ai_addr, static_cast<socklen_t>(p->ai_addrlen));
+      bool connect_success = false;
+
+      if (connect_res == 0)
+      {
+        connect_success = true;
+      }
+      else if (errno == EINPROGRESS)
+      {
+        auto timeout_ms = std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count();
+        struct timeval tv;
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+        fd_set write_fds;
+        FD_ZERO(&write_fds);
+        FD_SET(socket_fd_, &write_fds);
+
+        int select_res = ::select(socket_fd_ + 1, nullptr, &write_fds, nullptr, &tv);
+
+        if (select_res > 0)
+        {
+          int so_error = 0;
+          socklen_t len = sizeof(so_error);
+          ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, &so_error, &len);
+          if (so_error == 0)
+          {
+            connect_success = true;
+          }
+          else
+          {
+            socket_error = std::error_code(so_error, std::generic_category());
+          }
+        }
+        else if (select_res == 0)
+        {
+          socket_error = std::make_error_code(std::errc::timed_out);
+        }
+        else
+        {
+          socket_error = getLastSocketErrorCode();
+        }
+      }
+      else
+      {
+        socket_error = getLastSocketErrorCode();
+      }
+
+      ::fcntl(socket_fd_, F_SETFL, flags);
+
+      if (connect_success)
       {
         connected = true;
         break;
       }
+      else
+      {
+        ::ur_close(socket_fd_);
+        socket_fd_ = INVALID_SOCKET;
+      }
+#else
+      if (open(socket_fd_, p->ai_addr, p->ai_addrlen))
+      {
+        connected = true;
+        break;
+      }
+      else
+      {
+        socket_error = getLastSocketErrorCode();
+        ::ur_close(socket_fd_);
+        socket_fd_ = INVALID_SOCKET;
+      }
+#endif
     }
 
     freeaddrinfo(result);
@@ -136,8 +218,8 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
       else
       {
         std::stringstream ss;
-        ss << "Failed to connect to robot on IP " << host_name << ":" << port
-           << ". Please check that the robot is booted and reachable on " << host_name << ". Retrying in "
+        ss << "Failed to connect to robot on IP " << host_name << ":" << port << ". Reason: " << socket_error.message()
+           << ". Retrying in "
            << std::chrono::duration_cast<std::chrono::duration<float>>(reconnection_time_resolved).count()
            << " seconds.";
         URCL_LOG_ERROR("%s", ss.str().c_str());

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -50,6 +50,9 @@ TCPSocket::TCPSocket()
 TCPSocket::~TCPSocket()
 {
   close();
+#ifdef _WIN32
+  ::WSACleanup();
+#endif
 }
 
 void TCPSocket::setupOptions()
@@ -114,7 +117,7 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
       return false;
     }
 
-    std::error_code socket_error;
+    std::error_code socket_error = std::make_error_code(std::errc::address_not_available);
 
     for (struct addrinfo* p = result; p != nullptr; p = p->ai_next)
     {
@@ -125,6 +128,15 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
         socket_error = getLastSocketErrorCode();
         continue;
       }
+#ifndef _WIN32
+      if (socket_fd_ >= FD_SETSIZE)
+      {
+        socket_error = std::make_error_code(std::errc::value_too_large);
+        ::ur_close(socket_fd_);
+        socket_fd_ = INVALID_SOCKET;
+        continue;
+      }
+#endif
 
       bool connect_success = false;
 
@@ -166,25 +178,44 @@ bool TCPSocket::setup(const std::string& host, const int port, const size_t max_
         FD_ZERO(&write_fds);
         FD_SET(socket_fd_, &write_fds);
 
-        int select_res = ::select(static_cast<int>(socket_fd_ + 1), nullptr, &write_fds, nullptr, &tv);
+        fd_set except_fds;
+        FD_ZERO(&except_fds);
+        FD_SET(socket_fd_, &except_fds);
+
+        int select_res = ::select(static_cast<int>(socket_fd_ + 1), nullptr, &write_fds, &except_fds, &tv);
 
         if (select_res > 0)
         {
           int so_error = 0;
 #ifndef _WIN32
           socklen_t len = sizeof(so_error);
-          ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, &so_error, &len);
+          int opt_res = ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, &so_error, &len);
 #else
           int len = sizeof(so_error);
-          ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&so_error), &len);
+          int opt_res = ::getsockopt(socket_fd_, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&so_error), &len);
 #endif
-          if (so_error == 0)
+          if (opt_res != 0)
+          {
+            socket_error = getLastSocketErrorCode();
+          }
+          else if (so_error == 0 && FD_ISSET(socket_fd_, &write_fds))
           {
             connect_success = true;
           }
           else
           {
-            socket_error = std::error_code(so_error, std::generic_category());
+            if (so_error != 0)
+            {
+#ifdef _WIN32
+              socket_error = std::error_code(so_error, std::system_category());
+#else
+              socket_error = std::error_code(so_error, std::generic_category());
+#endif
+            }
+            else
+            {
+              socket_error = std::make_error_code(std::errc::connection_refused);
+            }
           }
         }
         else if (select_res == 0)


### PR DESCRIPTION
## Refactor TCPSocket::setup 

### Description
This PR refactors the `TCPSocket::setup()` method to resolve the blocking behavior during network failures. 

The implementation now introduces an asynchronous approach to enforce a connection timeout and capture socket errors.

### Step-by-Step Modifications

**1. Signature Update (Timeout Parameter)**
* Added a new `timeout` parameter (`std::chrono::milliseconds`) to the `setup()` function. This makes it possible to define exactly how long to wait for a connection before giving up. Otherwise, the code blocks indefinitely, keeping the thread hanging even if the number of max tries is set to 1. The default value has been set to 500 ms. 

**2. Error Tracking (`std::error_code`)**
* Introduced a `std::error_code socket_error` variable. 
* Now, `getLastSocketErrorCode()` is called immediately after any failure to store the exact system reason (e.g., `ECONNREFUSED`, `EHOSTUNREACH`) so it can be reported later.

**3. Non-Blocking Connection Logic**
* **State Change:** The socket is temporarily set to non-blocking mode using `fcntl()` and `O_NONBLOCK`.
* **Async Connect:** `::connect()` is called. If it returns `EINPROGRESS`, the code now hands control over to `::select()`.
* **Timeout Enforcement:** `select()` waits for the socket to become writable, strictly bounded by the newly provided `timeout` parameter.
* **Error Verification:** If `select()` indicates readiness, `::getsockopt(..., SO_ERROR, ...)` is used to verify if the connection actually succeeded or if it failed in the background.
* **State Restoration:** The socket is restored to its original blocking state before proceeding.

**4. Proper Resource Cleanup on Failure**
* If `socket_fd_` is created but the connection attempt fails, it is now properly closed.
* Added `::ur_close(socket_fd_)` and reset to `INVALID_SOCKET` inside the failure branches within the `for` loop to properly release resources. Also added error capturing if `::socket()` creation fails directly.

**5. Improved Logging & Debugging**
* Replaced the generic and hardcoded log message (`"Please check that the robot is booted and reachable..."`) with the exact system string translated by `socket_error.message()`. 
* Logs will now report `"Reason: Connection refused"`, `"Reason: Operation not permitted"`, or `"Reason: Connection timed out"`, improving troubleshooting capabilities for end users.

### Testing Performed

- **Connection Refused:** Pointed to an active IP with a closed port. Verified the code bypasses `select()` and fails immediately.

<img width="957" height="159" alt="image" src="https://github.com/user-attachments/assets/e6f7ca85-4657-49c4-bb61-c617efe22dc1" />

- **Connection Timed Out:** Simulated a network blackhole (e.g., using a dead IP). Verified the code waits exactly for the `timeout` duration before logging a timeout error.

<img width="957" height="159" alt="image" src="https://github.com/user-attachments/assets/59415c12-eff1-458c-b994-85ee8f851bb5" />

- **Host Unreachable:** Pointed to an invalid subnet. Verified immediate routing error capture.

<img width="968" height="160" alt="image" src="https://github.com/user-attachments/assets/d43a0481-445d-4fdb-9282-55cdf28f8440" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core TCP connection establishment logic (non-blocking connect + `select()`/`getsockopt()`), which can affect connectivity behavior across platforms and edge cases like fd limits/timeouts.
> 
> **Overview**
> `TCPSocket::setup()` now accepts an additional `timeout` (default `500ms`) and uses a non-blocking connect with `select()` to enforce connection timeouts instead of potentially blocking indefinitely.
> 
> Connection attempts now capture and surface the underlying `std::error_code` reason in retry logs, add extra failure-path cleanup (close/reset fd), and include a non-Windows guard for `FD_SETSIZE` overflow before using `select()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b46158a2b92273be8bc6d3f667c90cf04e4f30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->