### PR TITLE
Add missing robot types

### DIFF
--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -144,11 +144,10 @@ inline std::string robotModeString(const RobotMode& mode)
       return "RUNNING";
     case RobotMode::UPDATING_FIRMWARE:
       return "UPDATING_FIRMWARE";
-    default:
-      std::stringstream ss;
-      ss << "Unknown robot mode: " << static_cast<int>(mode);
-      throw std::invalid_argument(ss.str());
+    case RobotMode::UNKNOWN:
+      return "UNKNOWN";
   }
+  throw std::invalid_argument("Unknown robot mode: " + std::to_string(static_cast<int>(mode)));
 }
 
 inline std::string safetyModeString(const SafetyMode& mode)
@@ -197,11 +196,8 @@ inline std::string safetyModeString(const SafetyMode& mode)
       return "PROFISAFE_EMERGENCY_STOP";
     case SafetyMode::SAFETY_API_SAFEGUARD_STOP:
       return "SAFETY_API_SAFEGUARD_STOP";
-    default:
-      std::stringstream ss;
-      ss << "Unknown safety mode: " << static_cast<int>(mode);
-      throw std::invalid_argument(ss.str());
   }
+  throw std::invalid_argument("Unknown safety mode: " + std::to_string(static_cast<int>(mode)));
 }
 
 inline std::string safetyStatusString(const SafetyStatus& status)
@@ -234,11 +230,8 @@ inline std::string safetyStatusString(const SafetyStatus& status)
       return "AUTOMATIC_MODE_SAFEGUARD_STOP";
     case SafetyStatus::SYSTEM_THREE_POSITION_ENABLING_STOP:
       return "SYSTEM_THREE_POSITION_ENABLING_STOP";
-    default:
-      std::stringstream ss;
-      ss << "Unknown safety status: " << static_cast<int>(status);
-      throw std::invalid_argument(ss.str());
   }
+  throw std::invalid_argument("Unknown safety status: " + std::to_string(static_cast<int>(status)));
 }
 
 inline std::string robotTypeString(const RobotType& type)
@@ -263,12 +256,10 @@ inline std::string robotTypeString(const RobotType& type)
       return "UR20";
     case RobotType::UR30:
       return "UR30";
-    default:
-      std::stringstream ss;
-      ss << "Unknown Robot Type: " << static_cast<int>(type);
-      URCL_LOG_WARN(ss.str().c_str());
+    case RobotType::UNDEFINED:
       return "UNDEFINED";
   }
+  throw std::invalid_argument("Unknown robot type: " + std::to_string(static_cast<int>(type)));
 }
 
 /**
@@ -290,12 +281,10 @@ inline std::string robotSeriesString(const RobotSeries& series)
       return "E_SERIES";
     case RobotSeries::UR_SERIES:
       return "UR_SERIES";
-    default:
-      std::stringstream ss;
-      ss << "Unknown Robot Series: " << static_cast<int>(series);
-      URCL_LOG_WARN(ss.str().c_str());
+    case RobotSeries::UNDEFINED:
       return "UNDEFINED";
   }
+  throw std::invalid_argument("Unknown robot series: " + std::to_string(static_cast<int>(series)));
 }
 
 }  // namespace urcl

--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -249,12 +249,16 @@ inline std::string robotTypeString(const RobotType& type)
       return "UR3";
     case RobotType::UR5:
       return "UR5";
+    case urcl::RobotType::UR8LONG:
+      return "UR8_LONG";
     case RobotType::UR10:
       return "UR10";
     case RobotType::UR15:
       return "UR15";
     case RobotType::UR16:
       return "UR16";
+    case urcl::RobotType::UR18:
+      return "UR18";
     case RobotType::UR20:
       return "UR20";
     case RobotType::UR30:

--- a/include/ur_client_library/ur/datatypes.h
+++ b/include/ur_client_library/ur/datatypes.h
@@ -242,7 +242,7 @@ inline std::string robotTypeString(const RobotType& type)
       return "UR3";
     case RobotType::UR5:
       return "UR5";
-    case urcl::RobotType::UR8LONG:
+    case RobotType::UR8LONG:
       return "UR8_LONG";
     case RobotType::UR10:
       return "UR10";
@@ -250,7 +250,7 @@ inline std::string robotTypeString(const RobotType& type)
       return "UR15";
     case RobotType::UR16:
       return "UR16";
-    case urcl::RobotType::UR18:
+    case RobotType::UR18:
       return "UR18";
     case RobotType::UR20:
       return "UR20";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -289,6 +289,11 @@ target_link_libraries(types_tests PRIVATE ur_client_library::urcl GTest::gtest_m
 gtest_add_tests(TARGET types_tests
 )
 
+add_executable(datatypes_tests test_datatypes.cpp)
+target_link_libraries(datatypes_tests PRIVATE ur_client_library::urcl GTest::gtest_main)
+gtest_add_tests(TARGET datatypes_tests
+)
+
 add_executable(motion_primitives_tests test_motion_primitives.cpp)
 target_link_libraries(motion_primitives_tests PRIVATE ur_client_library::urcl GTest::gtest_main)
 gtest_add_tests(TARGET motion_primitives_tests

--- a/tests/test_datatypes.cpp
+++ b/tests/test_datatypes.cpp
@@ -1,0 +1,162 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2026 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include <ur_client_library/ur/datatypes.h>
+
+using namespace urcl;
+
+TEST(TestDatatypes, RobotModeString_all_values)
+{
+  EXPECT_EQ(robotModeString(RobotMode::UNKNOWN), "UNKNOWN");
+  EXPECT_EQ(robotModeString(RobotMode::NO_CONTROLLER), "NO_CONTROLLER");
+  EXPECT_EQ(robotModeString(RobotMode::DISCONNECTED), "DISCONNECTED");
+  EXPECT_EQ(robotModeString(RobotMode::CONFIRM_SAFETY), "CONFIRM_SAFETY");
+  EXPECT_EQ(robotModeString(RobotMode::BOOTING), "BOOTING");
+  EXPECT_EQ(robotModeString(RobotMode::POWER_OFF), "POWER_OFF");
+  EXPECT_EQ(robotModeString(RobotMode::POWER_ON), "POWER_ON");
+  EXPECT_EQ(robotModeString(RobotMode::IDLE), "IDLE");
+  EXPECT_EQ(robotModeString(RobotMode::BACKDRIVE), "BACKDRIVE");
+  EXPECT_EQ(robotModeString(RobotMode::RUNNING), "RUNNING");
+  EXPECT_EQ(robotModeString(RobotMode::UPDATING_FIRMWARE), "UPDATING_FIRMWARE");
+}
+
+TEST(TestDatatypes, RobotModeString_invalid_throws)
+{
+  const RobotMode invalid = static_cast<RobotMode>(99);
+  EXPECT_THROW(robotModeString(invalid), std::invalid_argument);
+}
+
+TEST(TestDatatypes, SafetyModeString_all_values)
+{
+  EXPECT_EQ(safetyModeString(SafetyMode::NORMAL), "NORMAL");
+  EXPECT_EQ(safetyModeString(SafetyMode::REDUCED), "REDUCED");
+  EXPECT_EQ(safetyModeString(SafetyMode::PROTECTIVE_STOP), "PROTECTIVE_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::RECOVERY), "RECOVERY");
+  EXPECT_EQ(safetyModeString(SafetyMode::SAFEGUARD_STOP), "SAFEGUARD_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::SYSTEM_EMERGENCY_STOP), "SYSTEM_EMERGENCY_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::ROBOT_EMERGENCY_STOP), "ROBOT_EMERGENCY_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::VIOLATION), "VIOLATION");
+  EXPECT_EQ(safetyModeString(SafetyMode::FAULT), "FAULT");
+  EXPECT_EQ(safetyModeString(SafetyMode::VALIDATE_JOINT_ID), "VALIDATE_JOINT_ID");
+  EXPECT_EQ(safetyModeString(SafetyMode::UNDEFINED_SAFETY_MODE), "UNDEFINED_SAFETY_MODE");
+  EXPECT_EQ(safetyModeString(SafetyMode::AUTOMATIC_MODE_SAFEGUARD_STOP), "AUTOMATIC_MODE_SAFEGUARD_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::SYSTEM_THREE_POSITION_ENABLING_STOP), "SYSTEM_THREE_POSITION_ENABLING_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::TP_THREE_POSITION_ENABLING_STOP), "TP_THREE_POSITION_ENABLING_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::IMMI_EMERGENCY_STOP), "IMMI_EMERGENCY_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::IMMI_SAFEGUARD_STOP), "IMMI_SAFEGUARD_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::PROFISAFE_WAITING_FOR_PARAMETERS), "PROFISAFE_WAITING_FOR_PARAMETERS");
+  EXPECT_EQ(safetyModeString(SafetyMode::PROFISAFE_AUTOMATIC_MODE_SAFEGUARD_STOP), "PROFISAFE_AUTOMATIC_MODE_SAFEGUARD_"
+                                                                                   "STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::PROFISAFE_SAFEGUARD_STOP), "PROFISAFE_SAFEGUARD_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::PROFISAFE_EMERGENCY_STOP), "PROFISAFE_EMERGENCY_STOP");
+  EXPECT_EQ(safetyModeString(SafetyMode::SAFETY_API_SAFEGUARD_STOP), "SAFETY_API_SAFEGUARD_STOP");
+}
+
+TEST(TestDatatypes, SafetyModeString_invalid_throws)
+{
+  const SafetyMode invalid = static_cast<SafetyMode>(0);
+  EXPECT_THROW(safetyModeString(invalid), std::invalid_argument);
+
+  const SafetyMode also_invalid = static_cast<SafetyMode>(250);
+  EXPECT_THROW(safetyModeString(also_invalid), std::invalid_argument);
+}
+
+TEST(TestDatatypes, SafetyStatusString_all_values)
+{
+  EXPECT_EQ(safetyStatusString(SafetyStatus::NORMAL), "NORMAL");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::REDUCED), "REDUCED");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::PROTECTIVE_STOP), "PROTECTIVE_STOP");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::RECOVERY), "RECOVERY");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::SAFEGUARD_STOP), "SAFEGUARD_STOP");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::SYSTEM_EMERGENCY_STOP), "SYSTEM_EMERGENCY_STOP");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::ROBOT_EMERGENCY_STOP), "ROBOT_EMERGENCY_STOP");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::VIOLATION), "VIOLATION");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::FAULT), "FAULT");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::VALIDATE_JOINT_ID), "VALIDATE_JOINT_ID");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::UNDEFINED_SAFETY_MODE), "UNDEFINED_SAFETY_MODE");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::AUTOMATIC_MODE_SAFEGUARD_STOP), "AUTOMATIC_MODE_SAFEGUARD_STOP");
+  EXPECT_EQ(safetyStatusString(SafetyStatus::SYSTEM_THREE_POSITION_ENABLING_STOP), "SYSTEM_THREE_POSITION_ENABLING_"
+                                                                                   "STOP");
+}
+
+TEST(TestDatatypes, SafetyStatusString_invalid_throws)
+{
+  const SafetyStatus invalid = static_cast<SafetyStatus>(0);
+  EXPECT_THROW(safetyStatusString(invalid), std::invalid_argument);
+
+  const SafetyStatus also_invalid = static_cast<SafetyStatus>(99);
+  EXPECT_THROW(safetyStatusString(also_invalid), std::invalid_argument);
+}
+
+TEST(TestDatatypes, RobotTypeString_all_values)
+{
+  EXPECT_EQ(robotTypeString(RobotType::UNDEFINED), "UNDEFINED");
+  EXPECT_EQ(robotTypeString(RobotType::UR3), "UR3");
+  EXPECT_EQ(robotTypeString(RobotType::UR5), "UR5");
+  EXPECT_EQ(robotTypeString(RobotType::UR8LONG), "UR8_LONG");
+  EXPECT_EQ(robotTypeString(RobotType::UR10), "UR10");
+  EXPECT_EQ(robotTypeString(RobotType::UR15), "UR15");
+  EXPECT_EQ(robotTypeString(RobotType::UR16), "UR16");
+  EXPECT_EQ(robotTypeString(RobotType::UR18), "UR18");
+  EXPECT_EQ(robotTypeString(RobotType::UR20), "UR20");
+  EXPECT_EQ(robotTypeString(RobotType::UR30), "UR30");
+}
+
+TEST(TestDatatypes, RobotTypeString_invalid_throws)
+{
+  const RobotType invalid = static_cast<RobotType>(0);
+  EXPECT_THROW(robotTypeString(invalid), std::invalid_argument);
+
+  const RobotType also_invalid = static_cast<RobotType>(99);
+  EXPECT_THROW(robotTypeString(also_invalid), std::invalid_argument);
+}
+
+TEST(TestDatatypes, RobotSeriesString_all_values)
+{
+  EXPECT_EQ(robotSeriesString(RobotSeries::UNDEFINED), "UNDEFINED");
+  EXPECT_EQ(robotSeriesString(RobotSeries::CB3), "CB3");
+  EXPECT_EQ(robotSeriesString(RobotSeries::E_SERIES), "E_SERIES");
+  EXPECT_EQ(robotSeriesString(RobotSeries::UR_SERIES), "UR_SERIES");
+}
+
+TEST(TestDatatypes, RobotSeriesString_invalid_throws)
+{
+  const RobotSeries invalid = static_cast<RobotSeries>(0);
+  EXPECT_THROW(robotSeriesString(invalid), std::invalid_argument);
+
+  const RobotSeries also_invalid = static_cast<RobotSeries>(42);
+  EXPECT_THROW(robotSeriesString(also_invalid), std::invalid_argument);
+}


### PR DESCRIPTION
This consists of two commits:

- Adding missing robot types to type string conversion
- Removing default branches in helper function switch cases. This way, adding a new enum entry will raise a compiler warning, which we will treat as an error in CI.

I pushed both commits into this PR, as for the type string conversion this is highly related / the cause why this wasn't detected earlier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Invalid or future enum values now throw instead of returning UNDEFINED or only logging for robot type/series, which can change error handling for callers; safety/mode string behavior is similarly stricter for unknown values.
> 
> **Overview**
> Extends **`robotTypeString`** with **`UR8LONG`** → `"UR8_LONG"` and **`UR18`** → `"UR18"`, and tightens enum-to-string helpers in `datatypes.h` so new enum values are less likely to be missed at compile time.
> 
> The **`default`** branches are removed from the switches on **`robotModeString`**, **`safetyModeString`**, **`safetyStatusString`**, **`robotTypeString`**, and **`robotSeriesString`**. Known sentinel values (**`RobotMode::UNKNOWN`**, **`RobotType::UNDEFINED`**, **`RobotSeries::UNDEFINED`**) are handled explicitly; any other unrecognized numeric value throws **`std::invalid_argument`** (using **`std::to_string`** instead of **`stringstream`**). **`robotTypeString`** / **`robotSeriesString`** no longer log and return **`"UNDEFINED"`** for unknown enum integers.
> 
> Adds **`datatypes_tests`** (`test_datatypes.cpp`) and wires it in **`tests/CMakeLists.txt`** to cover all known enum mappings and invalid-value throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf7711c7da93aaaea74f5773aaabbbf5801e3570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->