### PR TITLE
Add new controller_step RTDE field

### DIFF
--- a/src/rtde/data_package.cpp
+++ b/src/rtde/data_package.cpp
@@ -454,6 +454,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "time_scale_source", int32_t() },
   { "target_gravity", vector3d_t() },
   { "target_base_acceleration", vector6d_t() },
+  { "controller_step", uint64_t() },
 
   // NOT IN OFFICIAL DOCS
   { "tool_digital_output_mask", uint8_t() },

--- a/tests/resources/exhaustive_rtde_output_recipe.txt
+++ b/tests/resources/exhaustive_rtde_output_recipe.txt
@@ -402,3 +402,4 @@ script_control_line
 time_scale_source
 target_gravity
 target_base_acceleration
+controller_step


### PR DESCRIPTION
RTDE gets a new field called "controller_step", see https://docs.universal-robots.com/tutorials/communication-protocol-tutorials/rtde-guide.html

This PR adds it to the list of possible data fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema entry only; no changes to control or communication logic beyond accepting and parsing one new optional recipe field.
> 
> **Overview**
> Registers Universal Robots’ new RTDE output field **`controller_step`** so clients can include it in output recipes and receive parsed values.
> 
> The field is added to **`DataPackage::g_type_list`** as **`uint64_t`**, alongside other recent output keys such as `target_base_acceleration`. The exhaustive RTDE output recipe test resource is updated so coverage stays aligned with the supported field set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be55b90e655e2d49344b96b176eebca283f99e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->