### PR TITLE
Release/2.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [ScriptCommandInterface] Add set_target_payload support to ScriptCommandInterface (`#515 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/515>`_)
+* [Primary] sendScriptBlocking: Restart interface and resend script on readOnlyInterfaceException (`#522 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/522>`_)
+* [DashboardClientX] Apply httplib timeouts; wire setReceiveTimeout() (`#518 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/518>`_)
+* [Docs] Remove section about URCapX in development (`#521 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/521>`_)
+* [Primary] Send script blocking return refactor (`#520 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/520>`_)
+* Add missing robot types to helper functions (`#513 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/513>`_)
+* [RTDE] Add new controller_step RTDE field (`#514 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/514>`_)
+* [Primary] Primary client script execution feedback (`#484 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/484>`_)
+* Add robotSeriesString function (`#510 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/510>`_)
+* Contributors: Felix Exner, Sergi Romero, URJala, Vinicius de Oliveira, dependabot[bot]
+
 2.12.0 (2026-05-19)
 -------------------
 * [CI] Make circular motion in example more compatible (`#508 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/508>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.13.0 (2026-06-17)
+-------------------
 * [ScriptCommandInterface] Add set_target_payload support to ScriptCommandInterface (`#515 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/515>`_)
 * [Primary] sendScriptBlocking: Restart interface and resend script on readOnlyInterfaceException (`#522 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/522>`_)
 * [DashboardClientX] Apply httplib timeouts; wire setReceiveTimeout() (`#518 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/518>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>2.12.0</version>
+  <version>2.13.0</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
This makes a couple of features available in a release:

- Blocking Script execution with result
- Setting Payload with inertia
- Setup timeouts for RobotAPI
- Update RTDE client for 10.13 / 5.26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only packaging metadata and changelog; functional risk is whatever was merged in prior PRs, not new changes in this diff.
> 
> **Overview**
> **Release 2.13.0** — bumps `package.xml` from **2.12.0** to **2.13.0** and adds a **2.13.0 (2026-06-17)** section to `CHANGELOG.rst` listing what ships in this tag (no library code changes in the diff itself).
> 
> The changelog documents user-facing work already merged for this release: **blocking primary script execution with results and execution feedback**, **`set_target_payload` on `ScriptCommandInterface`**, **PolyScope X `DashboardClientX` HTTP/receive timeouts**, **new RTDE `controller_step` (PolyScope 10.13 / 5.26)**, plus smaller primary-interface robustness/refactors, robot-type helpers, and a docs tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68fcfa7d564442bace1faeb2f77ed8352516200f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->