### PR TITLE
Fix RTDE control_step

### DIFF
--- a/src/rtde/data_package.cpp
+++ b/src/rtde/data_package.cpp
@@ -454,7 +454,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "time_scale_source", int32_t() },
   { "target_gravity", vector3d_t() },
   { "target_base_acceleration", vector6d_t() },
-  { "controller_step", uint64_t() },
+  { "control_step", uint64_t() },
 
   // NOT IN OFFICIAL DOCS
   { "tool_digital_output_mask", uint8_t() },

--- a/tests/resources/exhaustive_rtde_output_recipe.txt
+++ b/tests/resources/exhaustive_rtde_output_recipe.txt
@@ -402,4 +402,4 @@ script_control_line
 time_scale_source
 target_gravity
 target_base_acceleration
-controller_step
+control_step


### PR DESCRIPTION
Correct RTDE register name to control_step
Is available from Polyscope version 5.26.0 and 10.13.0
