### PR TITLE
enable running integration tests against host networked ursim

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,11 +25,17 @@ include(GoogleTest)
 option(INTEGRATION_TESTS "Build the integration tests that require a running robot / URSim" OFF)
 option(POLYSCOPE_X_TESTS_WITH_REMOTE_CONTROL "Run Polyscope X tests that require remote control" OFF)
 option(CHECK_RTDE_DOCS_RECIPE "Fetch the RTDE documentation to auto-generate a recipe containing all output fields and check that with the RTDE client. Requires python3 and pandas and an internet connection." OFF)
+set(INTEGRATION_TESTS_ROBOT_IP "" CACHE STRING "If set, override the default robot IP (192.168.56.101) compiled into each integration test main() by passing --robot_ip <ip> to every ctest-registered integration test.")
 # Build Tests
 if (INTEGRATION_TESTS)
-  # Integration tests require a robot reachable at 192.168.56.101. Therefore, they have to be
-  # activated separately.
-  
+  # Integration tests require a reachable robot / URSim. The compiled-in default
+  # address is 192.168.56.101; configure with -DINTEGRATION_TESTS_ROBOT_IP=<ip>
+  # to override (e.g. 127.0.0.1 for a host-networked URSim).
+  set(INTEGRATION_TESTS_ROBOT_IP_ARG "")
+  if(INTEGRATION_TESTS_ROBOT_IP)
+    set(INTEGRATION_TESTS_ROBOT_IP_ARG --robot_ip ${INTEGRATION_TESTS_ROBOT_IP})
+  endif()
+
   if(POLYSCOPE_X_TESTS_WITH_REMOTE_CONTROL)
     add_compile_definitions(POLYSCOPE_X_TESTS_WITH_REMOTE_CONTROL=1 )
   endif()
@@ -38,6 +44,7 @@ if (INTEGRATION_TESTS)
   target_link_libraries(rtde_tests PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      rtde_tests
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  EXTRA_ARGS ${INTEGRATION_TESTS_ROBOT_IP_ARG}
   )
   if (CHECK_RTDE_DOCS_RECIPE)
     find_package(Python3 COMPONENTS Interpreter REQUIRED)
@@ -49,12 +56,14 @@ if (INTEGRATION_TESTS)
   add_executable(dashboard_client_g5_tests test_dashboard_client_g5.cpp)
   target_link_libraries(dashboard_client_g5_tests PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      dashboard_client_g5_tests
+                  EXTRA_ARGS ${INTEGRATION_TESTS_ROBOT_IP_ARG}
   )
 
   add_executable(dashboard_client_x_tests test_dashboard_client_x.cpp)
   target_link_libraries(dashboard_client_x_tests PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      dashboard_client_x_tests
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  EXTRA_ARGS ${INTEGRATION_TESTS_ROBOT_IP_ARG}
   )
 
   # Spline tests
@@ -62,14 +71,14 @@ if (INTEGRATION_TESTS)
   target_link_libraries(spline_tests_urcap PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      spline_tests_urcap
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless false
+                  EXTRA_ARGS --headless false ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _urcap
   )
   add_executable(spline_tests_headless test_spline_interpolation.cpp)
   target_link_libraries(spline_tests_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      spline_tests_headless
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless true
+                  EXTRA_ARGS --headless true ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _headless
   )
 
@@ -78,14 +87,14 @@ if (INTEGRATION_TESTS)
   target_link_libraries(ur_driver_tests_urcap PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      ur_driver_tests_urcap
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless false
+                  EXTRA_ARGS --headless false ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _urcap
   )
   add_executable(ur_driver_tests_headless test_ur_driver.cpp)
   target_link_libraries(ur_driver_tests_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      ur_driver_tests_headless
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless true
+                  EXTRA_ARGS --headless true ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _headless
   )
 
@@ -94,14 +103,14 @@ if (INTEGRATION_TESTS)
   target_link_libraries(external_control_program_tests_urcap PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      external_control_program_tests_urcap
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless false
+                  EXTRA_ARGS --headless false ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _urcap
   )
   add_executable(external_control_program_tests_headless test_external_control_program.cpp)
   target_link_libraries(external_control_program_tests_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET      external_control_program_tests_headless
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless true
+                  EXTRA_ARGS --headless true ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _headless
   )
 
@@ -110,14 +119,14 @@ if (INTEGRATION_TESTS)
   target_link_libraries(instruction_executor_test_urcap PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET instruction_executor_test_urcap
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless false
+                  EXTRA_ARGS --headless false ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _urcap
   )
   add_executable(instruction_executor_test_headless test_instruction_executor.cpp)
   target_link_libraries(instruction_executor_test_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET instruction_executor_test_headless
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  EXTRA_ARGS --headless true
+                  EXTRA_ARGS --headless true ${INTEGRATION_TESTS_ROBOT_IP_ARG}
                   TEST_SUFFIX _headless
   )
 
@@ -125,12 +134,14 @@ if (INTEGRATION_TESTS)
   target_link_libraries(primary_client_test_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET primary_client_test_headless
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  EXTRA_ARGS ${INTEGRATION_TESTS_ROBOT_IP_ARG}
   )
 
   add_executable(ur_driver_deprecated_constructor_test test_deprecated_ur_driver_construction.cpp)
   target_link_libraries(ur_driver_deprecated_constructor_test PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET ur_driver_deprecated_constructor_test
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  EXTRA_ARGS ${INTEGRATION_TESTS_ROBOT_IP_ARG}
   )
 else()
   message(STATUS "Skipping integration tests.")

--- a/tests/test_dashboard_client_g5.cpp
+++ b/tests/test_dashboard_client_g5.cpp
@@ -667,7 +667,7 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_dashboard_client_x.cpp
+++ b/tests/test_dashboard_client_x.cpp
@@ -516,7 +516,7 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_deprecated_ur_driver_construction.cpp
+++ b/tests/test_deprecated_ur_driver_construction.cpp
@@ -122,13 +122,13 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
     if (std::string(argv[i]) == "--headless" && i + 1 < argc)
     {
       std::string headless = argv[i + 1];
       g_HEADLESS = headless == "true" || headless == "1" || headless == "True" || headless == "TRUE";
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -580,13 +580,13 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
     if (std::string(argv[i]) == "--headless" && i + 1 < argc)
     {
       std::string headless = argv[i + 1];
       g_HEADLESS = headless == "true" || headless == "1" || headless == "True" || headless == "TRUE";
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_primary_client.cpp
+++ b/tests/test_primary_client.cpp
@@ -763,7 +763,7 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_rtde_client.cpp
+++ b/tests/test_rtde_client.cpp
@@ -821,7 +821,7 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_spline_interpolation.cpp
+++ b/tests/test_spline_interpolation.cpp
@@ -1232,13 +1232,13 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
     if (std::string(argv[i]) == "--headless" && i + 1 < argc)
     {
       std::string headless = argv[i + 1];
       g_HEADLESS = headless == "true" || headless == "1" || headless == "True" || headless == "TRUE";
-      break;
+      ++i;
     }
   }
 

--- a/tests/test_ur_driver.cpp
+++ b/tests/test_ur_driver.cpp
@@ -503,13 +503,13 @@ int main(int argc, char* argv[])
     if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
     {
       g_ROBOT_IP = argv[i + 1];
-      break;
+      ++i;
     }
     if (std::string(argv[i]) == "--headless" && i + 1 < argc)
     {
       std::string headless = argv[i + 1];
       g_HEADLESS = headless == "true" || headless == "1" || headless == "True" || headless == "TRUE";
-      break;
+      ++i;
     }
   }
 


### PR DESCRIPTION
Fixes #530. This was pulled out from #528, as requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CMake-only changes; no production library or runtime behavior is modified.
> 
> **Overview**
> Integration tests can target a robot or URSim at an address other than the compiled-in default **`192.168.56.101`**, which supports host-networked URSim (e.g. **`127.0.0.1`**).
> 
> CMake adds **`INTEGRATION_TESTS_ROBOT_IP`**. When set at configure time, every ctest-registered integration test receives **`--robot_ip <ip>`** via **`gtest_add_tests` `EXTRA_ARGS`**, alongside existing flags like **`--headless`**.
> 
> Test **`main()`** handlers no longer **`break`** after the first recognized flag; they **`++i`** past flag values so **`--robot_ip`** and **`--headless`** can both apply when ctest passes multiple arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69eb4019567e6ea51899ee5ae9c33acf6f083bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->