### PR TITLE
Update ici config with host-mounted urcap storage and test upload

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -65,6 +65,7 @@ jobs:
           CLANG_TIDY: ${{matrix.ROS_DISTRO.CLANG_TIDY}}
           OS_CODE_NAME: ${{matrix.ROS_DISTRO.OS_CODE_NAME}}
       - name: Upload test artifacts
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: ur_test_artifacts-${{matrix.ROS_DISTRO.NAME}}-${{matrix.ROS_REPO}}

--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -32,11 +32,28 @@ jobs:
           - main
           - testing
     env:
-      DOCKER_RUN_OPTS: '-v /var/run/docker.sock:/var/run/docker.sock --network ursim_net'
+      # /tmp/ur_test_artifacts: collection point for test artifacts (e.g. VNC
+      #     snapshots) written from inside the ICI container.
+      # /tmp/ursim_urcaps: shared storage for the External Control URCap.
+      #     Mounted at the same path in the ICI container AND used as the bind
+      #     source for the URSim container that start_ursim.sh launches via the
+      #     host docker daemon, so the URCap downloaded inside the ICI container
+      #     is actually visible to URSim's /urcaps mount.
+      # Both paths are kept outside ${{ github.workspace }} so they do not
+      # collide with industrial_ci's read-only bind-mount of TARGET_REPO_PATH.
+      DOCKER_RUN_OPTS: '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp/ur_test_artifacts:/test_artifacts -v /tmp/ursim_urcaps:/tmp/ursim_urcaps -e UR_TEST_ARTIFACTS_DIR=/test_artifacts -e UR_CI_URCAP_FOLDER=/tmp/ursim_urcaps --network ursim_net --ip 192.168.56.1'
     steps:
       - uses: actions/checkout@v7
-      - run: docker network create --subnet=192.168.56.0/24 ursim_net
+      - run: docker network create --subnet=192.168.56.0/24 --gateway 192.168.56.254 ursim_net 
         if: ${{ !env.ACT }}
+      - name: Create shared host directories
+        run: |
+          mkdir -p /tmp/ur_test_artifacts /tmp/ursim_urcaps
+          # Allow the container (running as root) to write here while keeping
+          # the directory readable by the runner user for upload-artifact, and
+          # writable by the host docker daemon when it bind-mounts /tmp/ursim_urcaps
+          # into the URSim container.
+          chmod 777 /tmp/ur_test_artifacts /tmp/ursim_urcaps
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           IMMEDIATE_TEST_OUTPUT: true
@@ -47,3 +64,8 @@ jobs:
           ROS_REPO: ${{matrix.ROS_REPO}}
           CLANG_TIDY: ${{matrix.ROS_DISTRO.CLANG_TIDY}}
           OS_CODE_NAME: ${{matrix.ROS_DISTRO.OS_CODE_NAME}}
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ur_test_artifacts-${{matrix.ROS_DISTRO.NAME}}-${{matrix.ROS_REPO}}
+          path: /tmp/ur_test_artifacts


### PR DESCRIPTION
This is a requirement for running URCap-based tests in the ROS driver.

Since the ROS 2 driver received an integration test based on the external_control URCap in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1678, we need to update the ICI run in this repo, as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no runtime product impact; minor exposure from world-writable `/tmp` dirs on the ephemeral runner.
> 
> **Overview**
> Updates the **industrial_ci** workflow so downstream **external_control URCap** integration tests can share files between the ICI container and a **URSim** container started via the host Docker socket.
> 
> **`DOCKER_RUN_OPTS`** now bind-mounts `/tmp/ur_test_artifacts` and `/tmp/ursim_urcaps` (outside the workspace to avoid industrial_ci’s read-only repo mount), sets **`UR_TEST_ARTIFACTS_DIR`** and **`UR_CI_URCAP_FOLDER`**, and pins the ICI container to **`--ip 192.168.56.1`** on **`ursim_net`**. The **`ursim_net`** create step adds an explicit **gateway** (`192.168.56.254`).
> 
> A pre-ICI step **creates and chmods** those host directories so the runner can upload artifacts and the host daemon can mount URCaps into URSim. A final **`upload-artifact`** step ( **`always()`** ) publishes **`/tmp/ur_test_artifacts`** per matrix job for debugging (e.g. VNC snapshots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a71d2203021e71e75154cad1efb61c0b1896aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->