### PR TITLE
Enable FIFO scheduling by default for RTDE communication thread

### DIFF
--- a/include/ur_client_library/comm/pipeline.h
+++ b/include/ur_client_library/comm/pipeline.h
@@ -303,7 +303,7 @@ public:
    * \param producer_fifo_scheduling Should the producer thread use FIFO scheduling?
    */
   Pipeline(IProducer<T>& producer, IConsumer<T>* consumer, std::string name, INotifier& notifier,
-           const bool producer_fifo_scheduling = true)
+           const bool producer_fifo_scheduling = false)
     : producer_(producer)
     , consumer_(consumer)
     , name_(name)
@@ -322,7 +322,7 @@ public:
    * \param notifier The notifier to use
    * \param producer_fifo_scheduling Should the producer thread use FIFO scheduling?
    */
-  Pipeline(IProducer<T>& producer, std::string name, INotifier& notifier, const bool producer_fifo_scheduling = true)
+  Pipeline(IProducer<T>& producer, std::string name, INotifier& notifier, const bool producer_fifo_scheduling = false)
     : producer_(producer)
     , consumer_(nullptr)
     , name_(name)

--- a/include/ur_client_library/comm/pipeline.h
+++ b/include/ur_client_library/comm/pipeline.h
@@ -303,7 +303,7 @@ public:
    * \param producer_fifo_scheduling Should the producer thread use FIFO scheduling?
    */
   Pipeline(IProducer<T>& producer, IConsumer<T>* consumer, std::string name, INotifier& notifier,
-           const bool producer_fifo_scheduling = false)
+           const bool producer_fifo_scheduling = true)
     : producer_(producer)
     , consumer_(consumer)
     , name_(name)
@@ -322,7 +322,7 @@ public:
    * \param notifier The notifier to use
    * \param producer_fifo_scheduling Should the producer thread use FIFO scheduling?
    */
-  Pipeline(IProducer<T>& producer, std::string name, INotifier& notifier, const bool producer_fifo_scheduling = false)
+  Pipeline(IProducer<T>& producer, std::string name, INotifier& notifier, const bool producer_fifo_scheduling = true)
     : producer_(producer)
     , consumer_(nullptr)
     , name_(name)

--- a/src/rtde/rtde_client.cpp
+++ b/src/rtde/rtde_client.cpp
@@ -30,6 +30,7 @@
 #include "ur_client_library/exceptions.h"
 #include "ur_client_library/log.h"
 #include "ur_client_library/rtde/data_package.h"
+#include "ur_client_library/helpers.h"
 #include <algorithm>
 #include <chrono>
 #include <string>
@@ -964,6 +965,10 @@ void RTDEClient::stopBackgroundRead()
 
 void RTDEClient::backgroundReadThreadFunc()
 {
+  pthread_t this_thread = pthread_self();
+  const int max_thread_priority = sched_get_priority_max(SCHED_FIFO);
+  setFiFoScheduling(this_thread, max_thread_priority);
+
   while (background_read_running_)
   {
     std::unique_lock<std::mutex> lock(reconnect_mutex_, std::defer_lock);


### PR DESCRIPTION

## Description

This PR improves the scheduling configuration of the thread responsible for receiving and processing robot communication data.


### RTDE background read thread

When `read_packages_in_background` is enabled, the RTDE client creates a dedicated background thread for continuously receiving RTDE data packages.

Previously, this thread was executed using the operating system's default scheduling policy. Under system load, scheduling delays could introduce additional latency and timing jitter while processing incoming RTDE data.

This PR configures the RTDE background read thread to request the highest available FIFO scheduling priority using the existing helper functions.

```cpp
pthread_t this_thread = pthread_self();
const int max_thread_priority = sched_get_priority_max(SCHED_FIFO);
setFiFoScheduling(this_thread, max_thread_priority);
```

This follows the same approach already used by the producer thread inside `Pipeline::runProducer()`.

https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/8b4495cdb6064e036fdad58c20c4ecf9ca38b66d/include/ur_client_library/comm/pipeline.h#L429-L437


### Pipeline default scheduling

The `Pipeline` constructor previously defaulted `producer_fifo_scheduling` to `false`, meaning that FIFO scheduling was not requested unless explicitly enabled.

https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/8b4495cdb6064e036fdad58c20c4ecf9ca38b66d/include/ur_client_library/comm/pipeline.h#L305-L306

This PR changes the default value to `true`, making the producer thread request FIFO scheduling by default.

As a result, both the RTDE background read thread and the pipeline producer thread now consistently request FIFO scheduling unless explicitly disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to thread scheduling hints with graceful fallback on failure; no protocol, auth, or data-path logic changes.
> 
> **Overview**
> When background RTDE package reading is enabled, the dedicated read thread now requests **maximum `SCHED_FIFO` priority** at thread entry via `setFiFoScheduling`, matching the approach already used in the pipeline producer thread.
> 
> This adds the `helpers.h` include needed for that helper. The goal is to reduce scheduling latency and jitter on incoming RTDE data under system load; if the process lacks permission for FIFO scheduling, existing helper behavior applies (warning, thread continues with default scheduling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d93a8508f78e2bbb4381fcc3528b60b85c1e69a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->