### PR TITLE
Use tcp_nodelay on socket server

### DIFF
--- a/include/ur_client_library/comm/socket_t.h
+++ b/include/ur_client_library/comm/socket_t.h
@@ -71,6 +71,8 @@ typedef int socket_t;
 #  define MSG_NOSIGNAL 0
 #endif
 
+#include "ur_client_library/log.h"
+
 /*!
  * \brief Get the last socket error as an std::error_code
  *
@@ -91,4 +93,15 @@ inline std::error_code getLastSocketErrorCode()
 inline std::system_error makeSocketError(const std::string& message)
 {
   return std::system_error(getLastSocketErrorCode(), message);
+}
+
+inline void setSocketOptionAndWarnOnError(socket_t socket, int level, int optname, const void* optval,
+                                          unsigned int optlen, const std::string& option_name)
+{
+  int result = ur_setsockopt(socket, level, optname, optval, optlen);
+  if (result != 0)
+  {
+    std::error_code error_code = getLastSocketErrorCode();
+    URCL_LOG_WARN("Failed to set socket option %s: %s", option_name.c_str(), error_code.message().c_str());
+  }
 }

--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -261,8 +261,11 @@ void TCPServer::handleConnect()
     }
   }
 
-  int flag = 1;
-  ur_setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
+  if (accepted)
+  {
+    constexpr int flag = 1;
+    setSocketOptionAndWarnOnError(client_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag), "TCP_NODELAY");
+  }
 
   {
     std::lock_guard<std::mutex> lk(callback_mutex_);

--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -26,7 +26,9 @@
  */
 //----------------------------------------------------------------------
 
-#include <netinet/tcp.h>
+#ifndef _WIN32
+#  include <netinet/tcp.h>
+#endif
 #include <ur_client_library/log.h>
 #include <ur_client_library/comm/tcp_server.h>
 

--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -70,11 +70,11 @@ void TCPServer::init()
   {
     throw makeSocketError("Failed to create socket endpoint");
   }
-  int flag = 1;
+  constexpr int flag = 1;
 #ifndef _WIN32
-  ur_setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(int));
+  setSocketOptionAndWarnOnError(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(flag), "SO_REUSEADDR");
 #endif
-  ur_setsockopt(listen_fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(int));
+  setSocketOptionAndWarnOnError(listen_fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag), "SO_KEEPALIVE");
 
   URCL_LOG_DEBUG("Created socket with FD %d", (int)listen_fd_);
 

--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -76,8 +76,6 @@ void TCPServer::init()
 #endif
   ur_setsockopt(listen_fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(int));
 
-  ur_setsockopt(listen_fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
-
   URCL_LOG_DEBUG("Created socket with FD %d", (int)listen_fd_);
 
   FD_ZERO(&masterfds_);
@@ -262,6 +260,10 @@ void TCPServer::handleConnect()
       ur_close(client_fd);
     }
   }
+
+  int flag = 1;
+  ur_setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
+
   {
     std::lock_guard<std::mutex> lk(callback_mutex_);
     if (new_connection_callback_ && accepted)

--- a/src/comm/tcp_server.cpp
+++ b/src/comm/tcp_server.cpp
@@ -26,6 +26,7 @@
  */
 //----------------------------------------------------------------------
 
+#include <netinet/tcp.h>
 #include <ur_client_library/log.h>
 #include <ur_client_library/comm/tcp_server.h>
 
@@ -72,6 +73,8 @@ void TCPServer::init()
   ur_setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(int));
 #endif
   ur_setsockopt(listen_fd_, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(int));
+
+  ur_setsockopt(listen_fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
 
   URCL_LOG_DEBUG("Created socket with FD %d", (int)listen_fd_);
 

--- a/src/comm/tcp_socket.cpp
+++ b/src/comm/tcp_socket.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <sstream>
 #include <thread>
+#include "ur_client_library/comm/socket_t.h"
 
 #ifndef _WIN32
 #  include <arpa/inet.h>
@@ -52,12 +53,12 @@ TCPSocket::~TCPSocket()
 
 void TCPSocket::setupOptions()
 {
-  int flag = 1;
-  ur_setsockopt(socket_fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
+  constexpr int flag = 1;
+  setSocketOptionAndWarnOnError(socket_fd_, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag), "TCP_NODELAY");
 
   // macOS does not have TCP_QUICKACK
 #ifdef TCP_QUICKACK
-  ur_setsockopt(socket_fd_, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(int));
+  setSocketOptionAndWarnOnError(socket_fd_, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(flag), "TCP_QUICKACK");
 #endif
 
   if (recv_timeout_ != nullptr)
@@ -65,9 +66,10 @@ void TCPSocket::setupOptions()
 #ifdef _WIN32
     DWORD value = recv_timeout_->tv_sec * 1000;
     value += recv_timeout_->tv_usec / 1000;
-    ur_setsockopt(socket_fd_, SOL_SOCKET, SO_RCVTIMEO, &value, sizeof(value));
+    setSocketOptionAndWarnOnError(socket_fd_, SOL_SOCKET, SO_RCVTIMEO, &value, sizeof(value), "SO_RCVTIMEO");
 #else
-    ur_setsockopt(socket_fd_, SOL_SOCKET, SO_RCVTIMEO, recv_timeout_.get(), sizeof(timeval));
+    setSocketOptionAndWarnOnError(socket_fd_, SOL_SOCKET, SO_RCVTIMEO, recv_timeout_.get(), sizeof(timeval),
+                                  "SO_RCVTIMEO");
 #endif
   }
 }


### PR DESCRIPTION
The sockets we use in this library should be optimized for real-time communication, not for throughput. Therefore, they should use tcp_nodelay by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-latency TCP tuning and non-fatal logging around setsockopt; no auth or data-model changes.
> 
> **Overview**
> **TCP sockets are tuned for lower latency** by enabling `TCP_NODELAY` on each **accepted** server connection (client outbound paths already set it in `TCPSocket::setupOptions`).
> 
> Socket option setup is centralized in **`setSocketOptionAndWarnOnError`**, which logs a warning when `setsockopt` fails instead of ignoring errors. **Listen socket** options (`SO_REUSEADDR`, `SO_KEEPALIVE`) and **client** options (`TCP_NODELAY`, `TCP_QUICKACK`, `SO_RCVTIMEO`) now go through that helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bab872535f72a89b303e61b7dfb70b65130def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->