### PR TITLE
Release/2.14.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* RTDE: Add target_base_wrench field (`#539 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/539>`_)
+* Use tcp_nodelay on socket server (`#537 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/537>`_)
+* Streaming API for trajectory forwarding (`#528 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/528>`_)
+* background Enable FIFO scheduling by default for RTDE producer thread (`#536 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/536>`_)
+* Update cpp-httplib to version 0.49.0 (`#534 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/534>`_)
+* Update ici config with host-mounted urcap storage and test upload (`#532 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/532>`_)
+* Bump actions/cache from 5 to 6 (`#533 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/533>`_)
+* [tests] Enable running integration tests against a custom robot IP (`#531 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/531>`_)
+* Fix RTDE control_step (`#529 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/529>`_)
+* Enhance robot program state logging with clearer messages for running… (`#527 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/527>`_)
+* Add 10.13 to test matrix (`#517 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/517>`_)
+* Bump actions/checkout from 6 to 7 (`#525 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/525>`_)
+* Contributors: Andrew C. Morrow, Felix Exner, Rune Søe-Knudsen, Sergi Romero, dependabot[bot]
+
 2.13.0 (2026-06-17)
 -------------------
 * [ScriptCommandInterface] Add set_target_payload support to ScriptCommandInterface (`#515 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/515>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.14.0 (2026-07-17)
+-------------------
 * RTDE: Add target_base_wrench field (`#539 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/539>`_)
 * Use tcp_nodelay on socket server (`#537 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/537>`_)
 * Streaming API for trajectory forwarding (`#528 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/528>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>2.13.0</version>
+  <version>2.14.0</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release metadata with no runtime code changes in the PR diff.
> 
> **Overview**
> **Release 2.14.0** — bumps `package.xml` from **2.13.0** to **2.14.0** and adds a **2.14.0 (2026-07-17)** section to `CHANGELOG.rst`. The PR diff does not include library or source changes; it only updates version metadata and documents what shipped in this release.
> 
> The new changelog entry summarizes work already merged on the release branch, including RTDE **`target_base_wrench`**, a **streaming API for trajectory forwarding**, **`tcp_nodelay`** on the socket server, default **FIFO scheduling** for the RTDE producer thread, an RTDE **`control_step`** fix, clearer robot program state logging, **cpp-httplib 0.49.0**, and CI/test updates (PolyScope **10.13**, custom robot IP for integration tests, action bumps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36d305bd01eb57379726c147069060c81f4ac24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->