### PR TITLE
RTDE: Add target_base_wrench field

### DIFF
--- a/src/rtde/data_package.cpp
+++ b/src/rtde/data_package.cpp
@@ -455,6 +455,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "target_gravity", vector3d_t() },
   { "target_base_acceleration", vector6d_t() },
   { "control_step", uint64_t() },
+  { "target_base_wrench", vector6d_t() },
 
   // NOT IN OFFICIAL DOCS
   { "tool_digital_output_mask", uint8_t() },

--- a/tests/resources/exhaustive_rtde_output_recipe.txt
+++ b/tests/resources/exhaustive_rtde_output_recipe.txt
@@ -403,3 +403,4 @@ time_scale_source
 target_gravity
 target_base_acceleration
 control_step
+target_base_wrench


### PR DESCRIPTION
This field was added in 5.26 / 10.13, see https://docs.universal-robots.com/tutorials/communication-protocol-tutorials/rtde-guide.html

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive RTDE schema entry with no behavior change unless clients request the new field; the Ruby pin only affects CI.
> 
> **Overview**
> Adds support for the **`target_base_wrench`** RTDE output (PolyScope 5.26 / 10.13), typed as **`vector6d_t`** in `DataPackage::g_type_list` so recipes that include the field parse and serialize correctly.
> 
> The exhaustive RTDE output recipe fixture is updated so **`CHECK_RTDE_DOCS_RECIPE`** / integration checks stay aligned with the documented output set.
> 
> CI **`test_start_ursim`** pins Ruby **3.2** instead of **3.3** for the Bats job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e2908947fb0c22c6ab3831b7a6a0b1790bb2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->