### PR TITLE
Link urcl to rt on non-Apple Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ endif()
 if(CMAKE_THREAD_LIBS_INIT)
   target_link_libraries(urcl PUBLIC "${CMAKE_THREAD_LIBS_INIT}")
 endif()
+if(UNIX AND NOT APPLE)
+  target_link_libraries(urcl PUBLIC "rt")
+endif()
 
 # When warnings are treated as errors, also enable high warning level for all targets
 if(CMAKE_COMPILE_WARNING_AS_ERROR)


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-ur-client-library.osx.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: Linux builds may need librt for realtime-related symbols, while macOS does not provide a separate rt library; gating the link on non-Apple Unix keeps both platforms working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional CMake link line for platform-specific library resolution; no runtime logic or security-sensitive changes.
> 
> **Overview**
> **Links `urcl` against `librt` on Linux and other non-Apple Unix targets** so builds resolve realtime-related symbols (e.g. from `clock_gettime` in queue synchronization code) that may live in librt on some Linux setups.
> 
> The link is **gated with `UNIX AND NOT APPLE`** so macOS builds are unchanged, since macOS does not ship a separate `rt` library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c4113414fffdee084edbcce4ee7a527eeca32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->