### PR TITLE
Fix dependencies for bats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
         id: setup-bats
         uses: bats-core/bats-action@4.0.0
       - name: Install Ruby dependencies
-        run: bundle update --bundler && bundle install
+        run: bundle install
       - name: Run unittests
         shell: bash
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@
 
 source 'https://rubygems.org'
 
-gem 'bashcov'
-gem 'simplecov'
-gem 'simplecov-cobertura'
+gem 'bashcov', '~> 3.3'
+gem 'simplecov', '~> 0.22'
+gem 'simplecov-cobertura', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bashcov (3.3.0)
+      simplecov (~> 0.21)
+    docile (1.4.1)
+    rexml (3.4.4)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.2.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux-gnu
+
+DEPENDENCIES
+  bashcov (~> 3.3)
+  simplecov (~> 0.22)
+  simplecov-cobertura (~> 3.0)
+
+CHECKSUMS
+  bashcov (3.3.0) sha256=9a761b6e36598f74897ead922cc04f85de3d1362f54a595c8eb6fcf5cb139c31
+  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-cobertura (3.2.0) sha256=70d702658677fcb20e5aceb6915ccf8bc62ff2ccd38b62b3ad5c9db5c0888740
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+
+BUNDLED WITH
+  4.0.16


### PR DESCRIPTION
This way it will not suddenly break if depedency updates break API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Ruby dependency pinning for Bats coverage; no application or runtime code changes.
> 
> **Overview**
> **Pins** the Ruby gems used for Bats shell coverage (`bashcov`, `simplecov`, `simplecov-cobertura`) with pessimistic version constraints in the `Gemfile` and **adds** a committed `Gemfile.lock` so CI installs the same resolved versions every run.
> 
> The `test_start_ursim` job now runs **`bundle install` only** (drops `bundle update --bundler` before install), relying on the lockfile instead of floating latest gem releases that could break the bashcov/Bats integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e947b6c8347f88a87fed40198ae6d6f585fd72a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->