### PR TITLE
[start_ursim] Offer updating g5 urcap

### DIFF
--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -283,6 +283,37 @@ get_download_url_urcap()
   URCAP_DOWNLOAD_URL="https://github.com/UniversalRobots/Universal_Robots_ExternalControl_URCap/releases/download/v$URCAP_VERSION/externalcontrol-$URCAP_VERSION.jar"
 }
 
+# Prompt the user whether an already-installed External Control URCap should be
+# replaced by a newer version. If no answer is given within URCAP_PROMPT_TIMEOUT
+# seconds (default: 10), the prompt is cancelled and the existing version is kept.
+#
+# $1 the new URCap version that would be installed
+# reads URCAP_STORAGE for the prompt message
+# reads URCAP_PROMPT_TIMEOUT (env, optional) for the timeout in seconds
+# returns 0 if the user accepted the update, 1 otherwise (including on timeout)
+prompt_urcap_update()
+{
+  local new_version=$1
+  local timeout=${URCAP_PROMPT_TIMEOUT:-10}
+  local answer=""
+
+  echo "An older version of the External Control URCap is already present in ${URCAP_STORAGE}."
+  echo "Do you want to remove it and download the latest version (${new_version})? [y/N] (auto-N in ${timeout}s)"
+  if ! read -r -t "$timeout" answer; then
+    answer=""
+    echo # newline after the timed-out prompt
+    echo "No answer within ${timeout}s, continuing with the existing version."
+  fi
+  case "$answer" in
+    [yY][eE][sS]|[yY])
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 post_setup_polyscopex()
 {
 
@@ -486,24 +517,13 @@ main() {
       # if externalcontrol-<version>.jar does exist with another version, prompt the user whether
       # the newer version should be downloaded and used.
       if compgen -G "${URCAP_STORAGE}/externalcontrol-*.jar" > /dev/null; then
-        URCAP_PROMPT_TIMEOUT=${URCAP_PROMPT_TIMEOUT:-10}
-        echo "An older version of the External Control URCap is already present in ${URCAP_STORAGE}."
-        echo "Do you want to remove it and download the latest version (${URCAP_VERSION})? [y/N] (auto-N in ${URCAP_PROMPT_TIMEOUT}s)"
-        if ! read -r -t "$URCAP_PROMPT_TIMEOUT" answer; then
-          answer=""
-          echo # newline after the timed-out prompt
-          echo "No answer within ${URCAP_PROMPT_TIMEOUT}s, continuing with the existing version."
+        if prompt_urcap_update "$URCAP_VERSION"; then
+          echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
+          rm -f "${URCAP_STORAGE}/externalcontrol-"*.jar
+          curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
+        else
+          echo "Continuing without downloading the latest version. The older version will be used."
         fi
-        case "$answer" in
-          [yY][eE][sS]|[yY])
-            echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
-            rm -f "${URCAP_STORAGE}/externalcontrol-"*.jar
-            curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
-            ;;
-          *)
-            echo "Continuing without downloading the latest version. The older version will be used."
-            ;;
-        esac
       fi
     fi
     docker_cmd="docker run --rm -d --net ursim_net --ip $IP_ADDRESS\

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -517,7 +517,9 @@ main() {
     if [[ ! -f "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" ]]; then
       # if externalcontrol-<version>.jar does exist with another version, prompt the user whether
       # the newer version should be downloaded and used.
-      if compgen -G "${URCAP_STORAGE}/externalcontrol-*.jar" > /dev/null; then
+      shopt -s nullglob
+      existing_urcaps=( "${URCAP_STORAGE}"/externalcontrol-*.jar )
+      if ((${#existing_urcaps[@]})); then
         if prompt_urcap_update "$URCAP_VERSION"; then
           rm -f "${URCAP_STORAGE}/externalcontrol-"*.jar
           download_urcap=true
@@ -529,7 +531,11 @@ main() {
       fi
       if [[ $download_urcap = true ]]; then
         echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
-        curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
+        if curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"; then
+          if ((${#existing_urcaps[@]})); then
+            rm -f "${existing_urcaps[@]}"
+          fi
+        fi
       fi
     fi
     docker_cmd="docker run --rm -d --net ursim_net --ip $IP_ADDRESS\

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -513,17 +513,23 @@ main() {
 
     # Download external_control URCap
     get_download_url_urcap $URCAP_VERSION
+    download_urcap=false
     if [[ ! -f "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" ]]; then
       # if externalcontrol-<version>.jar does exist with another version, prompt the user whether
       # the newer version should be downloaded and used.
       if compgen -G "${URCAP_STORAGE}/externalcontrol-*.jar" > /dev/null; then
         if prompt_urcap_update "$URCAP_VERSION"; then
-          echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
           rm -f "${URCAP_STORAGE}/externalcontrol-"*.jar
-          curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
+          download_urcap=true
         else
           echo "Continuing without downloading the latest version. The older version will be used."
         fi
+      else
+        download_urcap=true
+      fi
+      if [[ $download_urcap = true ]]; then
+        echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
+        curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
       fi
     fi
     docker_cmd="docker run --rm -d --net ursim_net --ip $IP_ADDRESS\

--- a/scripts/start_ursim.sh
+++ b/scripts/start_ursim.sh
@@ -483,8 +483,28 @@ main() {
     # Download external_control URCap
     get_download_url_urcap $URCAP_VERSION
     if [[ ! -f "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" ]]; then
-      echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
-      curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
+      # if externalcontrol-<version>.jar does exist with another version, prompt the user whether
+      # the newer version should be downloaded and used.
+      if compgen -G "${URCAP_STORAGE}/externalcontrol-*.jar" > /dev/null; then
+        URCAP_PROMPT_TIMEOUT=${URCAP_PROMPT_TIMEOUT:-10}
+        echo "An older version of the External Control URCap is already present in ${URCAP_STORAGE}."
+        echo "Do you want to remove it and download the latest version (${URCAP_VERSION})? [y/N] (auto-N in ${URCAP_PROMPT_TIMEOUT}s)"
+        if ! read -r -t "$URCAP_PROMPT_TIMEOUT" answer; then
+          answer=""
+          echo # newline after the timed-out prompt
+          echo "No answer within ${URCAP_PROMPT_TIMEOUT}s, continuing with the existing version."
+        fi
+        case "$answer" in
+          [yY][eE][sS]|[yY])
+            echo "Downloading and installing External Control URCap version ${URCAP_VERSION}"
+            rm -f "${URCAP_STORAGE}/externalcontrol-"*.jar
+            curl -L -o "${URCAP_STORAGE}/externalcontrol-${URCAP_VERSION}.jar" "$URCAP_DOWNLOAD_URL"
+            ;;
+          *)
+            echo "Continuing without downloading the latest version. The older version will be used."
+            ;;
+        esac
+      fi
     fi
     docker_cmd="docker run --rm -d --net ursim_net --ip $IP_ADDRESS\
       -v ${URCAP_STORAGE}:/urcaps \

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -683,3 +683,43 @@ setup() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"auto-N in 7s"* ]]
 }
+
+@test "no_urcap_present_triggers_download" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  rm -rf "$URCAP_STORAGE"
+  mkdir -p "$URCAP_STORAGE"
+  URCAP_VERSION="latest"
+  get_download_url_urcap "$URCAP_VERSION"
+  run main -t -u ${URCAP_STORAGE}
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ -f "$URCAP_STORAGE/externalcontrol-$URCAP_VERSION.jar" ]
+}
+
+@test "Existing URCap with answering no doesn't trigger download" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  rm -rf "$URCAP_STORAGE"
+  mkdir -p "$URCAP_STORAGE"
+  URCAP_VERSION="latest"
+  get_download_url_urcap "$URCAP_VERSION"
+  touch "$URCAP_STORAGE/externalcontrol-0.0.1.jar"
+  run main -t -u ${URCAP_STORAGE} <<< "n"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ ! -f "$URCAP_STORAGE/externalcontrol-$URCAP_VERSION.jar" ]
+  [ -f "$URCAP_STORAGE/externalcontrol-0.0.1.jar" ]
+}
+
+@test "Existing URCap with answering yes does trigger download" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  rm -rf "$URCAP_STORAGE"
+  mkdir -p "$URCAP_STORAGE"
+  URCAP_VERSION="latest"
+  get_download_url_urcap "$URCAP_VERSION"
+  touch "$URCAP_STORAGE/externalcontrol-0.0.1.jar"
+  run main -t -u ${URCAP_STORAGE} <<< "y"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ -f "$URCAP_STORAGE/externalcontrol-$URCAP_VERSION.jar" ]
+  [ ! -f "$URCAP_STORAGE/externalcontrol-0.0.1.jar" ]
+}

--- a/tests/test_start_ursim.bats
+++ b/tests/test_start_ursim.bats
@@ -641,3 +641,45 @@ setup() {
 
 }
 
+@test "prompt_urcap_update accepts yes" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  URCAP_PROMPT_TIMEOUT=5
+  run prompt_urcap_update "1.0.5" <<< "y"
+  echo "$output"
+  [ "$status" -eq 0 ]
+}
+
+@test "prompt_urcap_update rejects no" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  URCAP_PROMPT_TIMEOUT=5
+  run prompt_urcap_update "1.0.5" <<< "n"
+  echo "$output"
+  [ "$status" -eq 1 ]
+}
+
+@test "prompt_urcap_update rejects empty answer" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  URCAP_PROMPT_TIMEOUT=5
+  run prompt_urcap_update "1.0.5" <<< ""
+  echo "$output"
+  [ "$status" -eq 1 ]
+}
+
+@test "prompt_urcap_update times out when no input is provided" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  URCAP_PROMPT_TIMEOUT=1
+  # Feed a stdin source that never produces a line before the timeout elapses.
+  run prompt_urcap_update "1.0.5" < <(sleep 3)
+  echo "$output"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No answer within 1s"* ]]
+}
+
+@test "prompt_urcap_update honours URCAP_PROMPT_TIMEOUT in prompt text" {
+  URCAP_STORAGE=/tmp/ursim-test-urcaps
+  URCAP_PROMPT_TIMEOUT=7
+  run prompt_urcap_update "1.0.5" <<< "n"
+  echo "$output"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"auto-N in 7s"* ]]
+}


### PR DESCRIPTION
Before that change, the script would automatically pull the latest version putting it aside the currently existing one. That would have unexpected side-effects.

With this change we check whether there is an externalcontrol urcap with a different version present already. In that case the user is prompted for updating it which will remove the old version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the local `start_ursim.sh` URCap download path for non-PolyScopeX URSim; no production robot or auth logic is touched.
> 
> **Overview**
> **PolyScope 5 / CB3 URSim startup** no longer downloads a newer `externalcontrol-*.jar` alongside an existing jar when the resolved version file is missing. It now detects other `externalcontrol-*.jar` files in `URCAP_STORAGE` and asks whether to remove them and install the target version.
> 
> A new **`prompt_urcap_update`** helper drives that choice with a **`[y/N]`** prompt, **`URCAP_PROMPT_TIMEOUT`** (default 10s), and timeout behavior that keeps the installed URCap. Declining skips the download; accepting removes matching jars before/after a successful **`curl`** fetch.
> 
> **Bats tests** cover the prompt (yes/no/empty/timeout) and **`main -t`** flows for fresh install, decline, and accept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee78ad21e62114dd8871db807f78e66bd9d1e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->