### PR TITLE
Throw RTDEInvalidKeyException on unknown RTDE key

### DIFF
--- a/include/ur_client_library/exceptions.h
+++ b/include/ur_client_library/exceptions.h
@@ -286,12 +286,20 @@ public:
   {
   }
 
+  explicit RTDEInvalidKeyException(const std::vector<std::string>& invalid_keys, const std::string& text = "")
+    : std::runtime_error(text)
+  {
+    this->invalid_keys = invalid_keys;
+  }
+
   virtual ~RTDEInvalidKeyException() = default;
 
   virtual const char* what() const noexcept override
   {
     return std::runtime_error::what();
   }
+
+  std::vector<std::string> invalid_keys;
 };
 
 class RTDEInputConflictException : public UrException

--- a/src/rtde/rtde_client.cpp
+++ b/src/rtde/rtde_client.cpp
@@ -419,7 +419,7 @@ bool RTDEClient::setupOutputs()
         else
         {
           URCL_LOG_ERROR("%s", error_message.str().c_str());
-          throw UrException(error_message.str());
+          throw RTDEInvalidKeyException(unavailable_variables, error_message.str());
         }
       }
       else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ if (INTEGRATION_TESTS)
   endif()
 
   add_executable(rtde_tests test_rtde_client.cpp fake_rtde_server.cpp)
-  target_link_libraries(rtde_tests PRIVATE ur_client_library::urcl GTest::gtest_main)
+  target_link_libraries(rtde_tests PRIVATE ur_client_library::urcl GTest::gmock_main)
   gtest_add_tests(TARGET      rtde_tests
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   EXTRA_ARGS ${INTEGRATION_TESTS_ROBOT_IP_ARG}

--- a/tests/test_rtde_client.cpp
+++ b/tests/test_rtde_client.cpp
@@ -27,13 +27,12 @@
 //----------------------------------------------------------------------
 
 #include <algorithm>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <thread>
-#include <unordered_map>
-#include <utility>
 #include <iostream>
 #include "ur_client_library/comm/tcp_server.h"
 #include "ur_client_library/exceptions.h"
@@ -49,6 +48,25 @@ using namespace urcl;
 
 std::string g_ROBOT_IP = "192.168.56.101";
 uint32_t g_FAKE_RTDE_PORT = 13875;
+
+class TestableRTDEClient : public rtde_interface::RTDEClient
+{
+public:
+  TestableRTDEClient() = delete;
+  TestableRTDEClient(std::string robot_ip, comm::INotifier& notifier, const std::vector<std::string>& output_recipe,
+                     const std::vector<std::string>& input_recipe, double target_frequency = 0.0,
+                     bool ignore_unavailable_outputs = false, const uint32_t port = UR_RTDE_PORT)
+    : rtde_interface::RTDEClient(robot_ip, notifier, output_recipe, input_recipe, target_frequency,
+                                 ignore_unavailable_outputs, port)
+  {
+  }
+
+  // replace the member directly
+  void injectOutputRecipe(const std::vector<std::string>& output_recipe)
+  {
+    output_recipe_ = output_recipe;
+  }
+};
 
 class RTDEClientTest : public ::testing::Test
 {
@@ -276,9 +294,30 @@ TEST_F(RTDEClientTest, input_recipe_with_invalid_key)
   std::vector<std::string> actual_input_recipe = resources_input_recipe_;
   actual_input_recipe.push_back("i_do_not_exist");
 
-  EXPECT_THROW(client_.reset(new rtde_interface::RTDEClient(g_ROBOT_IP, notifier_, resources_output_recipe_,
-                                                            actual_input_recipe)),
-               RTDEInvalidKeyException);
+  EXPECT_THAT(
+      [&]() {
+        client_.reset(
+            new rtde_interface::RTDEClient(g_ROBOT_IP, notifier_, resources_output_recipe_, actual_input_recipe));
+      },
+      testing::ThrowsMessage<RTDEInvalidKeyException>(testing::HasSubstr("i_do_not_exist")));
+}
+
+TEST_F(RTDEClientTest, output_recipe_with_invalid_key)
+{
+  std::vector<std::string> actual_output_recipe = resources_output_recipe_;
+  actual_output_recipe.push_back("i_do_not_exist");
+
+  EXPECT_THAT(
+      [&]() {
+        client_.reset(
+            new rtde_interface::RTDEClient(g_ROBOT_IP, notifier_, actual_output_recipe, resources_input_recipe_));
+      },
+      testing::ThrowsMessage<RTDEInvalidKeyException>(testing::HasSubstr("i_do_not_exist")));
+
+  TestableRTDEClient client(g_ROBOT_IP, notifier_, resources_output_recipe_, resources_input_recipe_);
+  client.injectOutputRecipe(actual_output_recipe);
+  EXPECT_THAT([&]() { client.init(); }, testing::ThrowsMessage<RTDEInvalidKeyException>(testing::HasSubstr("i_do_not_"
+                                                                                                           "exist")));
 }
 
 TEST_F(RTDEClientTest, recipe_comparison)


### PR DESCRIPTION
This allows parsing information about failed fields. Since RTDEInvalidKeyException inherits from UrException, this is not API-breaking.

This should help in generate an explicit user output in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1551

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error typing and exception payload on RTDE recipe validation; still inherits from UrException so existing catch-by-base behavior largely holds, with clearer structured data for new handlers.
> 
> **Overview**
> When RTDE output setup fails because recipe keys are unknown to the robot (and unavailable outputs are not ignored), the client now throws **`RTDEInvalidKeyException`** instead of a generic **`UrException`**, carrying the list of bad keys and the existing error text.
> 
> **`RTDEInvalidKeyException`** gains a constructor that accepts **`invalid_keys`** plus optional message text, and exposes **`invalid_keys`** as a public field so callers (e.g. ROS2 driver) can report which fields failed without parsing **`what()`**.
> 
> Tests for invalid input/output recipe keys use GMock **`ThrowsMessage`** / **`HasSubstr`**, link **`rtde_tests`** against **`gmock_main`**, and add **`TestableRTDEClient`** to exercise **`init()`** with an injected bad output recipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544404489720a802afae2fa360935a9e2e27e820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->