### PR TITLE
Fix OOB read vulnerability in bin parser

### DIFF
--- a/include/ur_client_library/comm/bin_parser.h
+++ b/include/ur_client_library/comm/bin_parser.h
@@ -121,7 +121,7 @@ public:
   template <typename T>
   T peek()
   {
-    if (buf_pos_ + sizeof(T) > buf_end_)
+    if (sizeof(T) > size_t(buf_end_ - buf_pos_))
       throw UrException("Could not parse received package. This can occur if the driver is started while the robot is "
                         "booting - please restart the driver once the robot has finished booting. "
                         "If the problem persists after the robot has booted, please contact the package maintainer.");

--- a/include/ur_client_library/comm/bin_parser.h
+++ b/include/ur_client_library/comm/bin_parser.h
@@ -108,7 +108,7 @@ public:
    */
   ~BinParser()
   {
-    parent_.buf_pos_ = buf_pos_;
+    parent_.buf_pos_ = buf_pos_ > parent_.buf_end_ ? parent_.buf_end_ : buf_pos_;
   }
 
   /*!
@@ -280,6 +280,8 @@ public:
    */
   void parse(std::string& val, size_t len)
   {
+    if (len > size_t(buf_end_ - buf_pos_))
+      throw UrException("Could not parse received package: requested string length exceeds remaining buffer size.");
     val.assign(reinterpret_cast<char*>(buf_pos_), len);
     buf_pos_ += len;
   }
@@ -341,6 +343,8 @@ public:
    */
   void consume(size_t bytes)
   {
+    if (bytes > size_t(buf_end_ - buf_pos_))
+      throw UrException("Could not parse received package: attempted to consume more bytes than remaining in buffer.");
     buf_pos_ += bytes;
   }
 

--- a/tests/test_bin_parser.cpp
+++ b/tests/test_bin_parser.cpp
@@ -469,6 +469,92 @@ TEST(bin_parser, peek_throws_when_past_end)
   EXPECT_THROW(bp.peek<uint16_t>(), UrException);
 }
 
+TEST(bin_parser, parse_string_too_long_throws)
+{
+  // Only 4 bytes available, but caller asks for 8.
+  uint8_t buffer[] = { 0x66, 0x6F, 0x6F, 0x67 };  // "foob"
+  comm::BinParser bp(buffer, sizeof(buffer));
+
+  std::string s;
+  EXPECT_THROW(bp.parse(s, 8), UrException);
+  // Buffer position must not have advanced on failure, so the data is still parseable.
+  std::string ok;
+  bp.parse(ok, 4);
+  EXPECT_EQ(ok, "foob");
+  EXPECT_TRUE(bp.empty());
+}
+
+TEST(bin_parser, parse_length_prefixed_string_truncated_throws)
+{
+  // Length prefix says 10 bytes follow, but only 3 are present.
+  uint8_t buffer[] = { 0x0a, 0x61, 0x62, 0x63 };
+  comm::BinParser bp(buffer, sizeof(buffer));
+
+  std::string s;
+  EXPECT_THROW(bp.parse(s), UrException);
+}
+
+TEST(bin_parser, consume_past_end_throws)
+{
+  uint8_t buffer[] = { 0x00, 0x01, 0x02, 0x03 };
+  comm::BinParser bp(buffer, sizeof(buffer));
+
+  EXPECT_THROW(bp.consume(sizeof(buffer) + 1), UrException);
+  // Consume must not have advanced the buffer position on failure.
+  EXPECT_TRUE(bp.checkSize(sizeof(buffer)));
+
+  // A subsequent full consume must still work and leave the parser empty
+  // (i.e. buf_pos_ is not past buf_end_, so checkSize reflects reality).
+  bp.consume(sizeof(buffer));
+  EXPECT_TRUE(bp.empty());
+  EXPECT_FALSE(bp.checkSize(1));
+}
+
+TEST(bin_parser, sub_parser_over_consume_throws_and_preserves_parent)
+{
+  uint8_t buffer[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+  comm::BinParser bp_parent(buffer, sizeof(buffer));
+
+  {
+    // Sub-parser covers only the first 4 bytes.
+    comm::BinParser bp_child(bp_parent, 4);
+    // Attempting to consume past the child's end must throw without advancing
+    // the child's buf_pos_, so the parent's state stays valid.
+    EXPECT_THROW(bp_child.consume(1000), UrException);
+  }
+
+  // Parent must still see all 8 bytes since the child never advanced.
+  EXPECT_TRUE(bp_parent.checkSize(sizeof(buffer)));
+  uint32_t val;
+  bp_parent.parse(val);
+  EXPECT_EQ(val, 0x00010203u);
+  bp_parent.parse(val);
+  EXPECT_EQ(val, 0x04050607u);
+  EXPECT_TRUE(bp_parent.empty());
+}
+
+TEST(bin_parser, sub_parser_destructor_clamps_to_parent_end)
+{
+  // Directly exercise the destructor's clamp: manually place the child's
+  // buf_pos_ past its buf_end_ using pointer manipulation via a raw buffer
+  // pointer, and verify the parent is not corrupted.
+  // We simulate this by using a sub-parser and manually consuming inside
+  // its bounds, then calling the destructor. The destructor must never set
+  // parent.buf_pos_ > parent.buf_end_.
+  uint8_t buffer[] = { 0x00, 0x01, 0x02, 0x03 };
+  comm::BinParser bp_parent(buffer, sizeof(buffer));
+
+  {
+    comm::BinParser bp_child(bp_parent, sizeof(buffer));
+    bp_child.consume(sizeof(buffer));  // Exactly at end - valid.
+    EXPECT_TRUE(bp_child.empty());
+  }
+
+  // Parent's buf_pos_ must equal buf_end_ after the child destructs.
+  EXPECT_TRUE(bp_parent.empty());
+  EXPECT_FALSE(bp_parent.checkSize(1));
+}
+
 TEST(bin_parser, parse_into_variant)
 {
   std::variant<uint32_t, int32_t, float> variant;

--- a/tests/test_bin_parser.cpp
+++ b/tests/test_bin_parser.cpp
@@ -545,8 +545,10 @@ TEST(bin_parser, sub_parser_destructor_clamps_to_parent_end)
   comm::BinParser bp_parent(buffer, sizeof(buffer));
 
   {
-    comm::BinParser bp_child(bp_parent, sizeof(buffer));
-    bp_child.consume(sizeof(buffer));  // Exactly at end - valid.
+    // Initialize a child parser with a wrong size (one byte too long). The child will consume to
+    // its end (which effectively only increments the internal buffer pointer), which is one byte past the parent's end.
+    comm::BinParser bp_child(bp_parent, sizeof(buffer) + 1);
+    bp_child.consume();
     EXPECT_TRUE(bp_child.empty());
   }
 

--- a/tests/test_bin_parser.cpp
+++ b/tests/test_bin_parser.cpp
@@ -472,7 +472,7 @@ TEST(bin_parser, peek_throws_when_past_end)
 TEST(bin_parser, parse_string_too_long_throws)
 {
   // Only 4 bytes available, but caller asks for 8.
-  uint8_t buffer[] = { 0x66, 0x6F, 0x6F, 0x67 };  // "foob"
+  uint8_t buffer[] = { 0x66, 0x6F, 0x6F, 0x62 };  // "foob"
   comm::BinParser bp(buffer, sizeof(buffer));
 
   std::string s;

--- a/tests/test_bin_parser.cpp
+++ b/tests/test_bin_parser.cpp
@@ -313,8 +313,22 @@ TEST(bin_parser, parse_outside_buffer_length)
 
   EXPECT_EQ(expected_int, parsed_int);
 
-  // Parse outside buffer length
+#if defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Warray-bounds"
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 6385)
+#endif
+  // Explicitly attempt to parse outside the buffer length, should throw an exception.
+  // Since compilers might have a static analysis that the buffer is too small, we disable the
+  // warning for this test.
   EXPECT_THROW(bp.parse<int32_t>(parsed_int), UrException);
+#if defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 }
 
 TEST(bin_parser, bin_parser_parent)


### PR DESCRIPTION
The bin parser didn't have protection against reading out of the buffer's bounds everywhere. This fixes that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level parsing on untrusted network payloads; changes are defensive bounds checks with clear failure modes rather than protocol semantics changes.
> 
> **Overview**
> Hardens **`BinParser`** so malformed or truncated robot protocol buffers cannot read past the end of the buffer.
> 
> **Bounds checks** now throw `UrException` when `peek`/`parse` would need more bytes than remain, when `parse(s, len)` requests a length beyond the buffer, and when `consume(n)` skips past the end. Failed operations do not advance the cursor, so later parsing stays consistent.
> 
> The **sub-parser destructor** clamps the parent’s position to `parent.buf_end_` so a child that over-advances cannot corrupt the parent’s state.
> 
> Tests cover truncated length-prefixed strings, over-consume on parent/child parsers, and the destructor clamp; the existing “parse past buffer” test uses compiler pragmas so static analysis still allows the intentional OOB attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0292f7f5a634ff71197e615df9ec257745aed1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->