### PR TITLE
Harden script_reader against vulnerabilities

### DIFF
--- a/include/ur_client_library/control/script_reader.h
+++ b/include/ur_client_library/control/script_reader.h
@@ -29,9 +29,11 @@
 // -- END LICENSE BLOCK ------------------------------------------------
 
 #pragma once
+#include <cstddef>
 #include <filesystem>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <variant>
 
 #include <ur_client_library/ur/datatypes.h>
@@ -100,8 +102,14 @@ private:
     bool parent_render;      // Is the parent block rendering?
   };
 
-  std::filesystem::path script_path_;
+  // Parameters for recursive script reading and include handling
+  static constexpr std::size_t MAX_INCLUDE_DEPTH = 32;
+  std::filesystem::path root_dir_;
+  std::filesystem::path current_dir_;
+  std::unordered_set<std::string> include_stack_;
+  std::size_t include_depth_ = 0;
 
+  std::string readScriptFileImpl(const std::filesystem::path& canonical_path, const DataDict& data);
   static std::string readFileContent(const std::string& file_path);
   void replaceIncludes(std::string& script_code, const DataDict& data);
   static void replaceVariables(std::string& script_code, const DataDict& data);

--- a/src/control/script_reader.cpp
+++ b/src/control/script_reader.cpp
@@ -133,25 +133,58 @@ bool operator==(const ScriptReader::DataVariant& lhs, const ScriptReader::DataVa
   throw std::runtime_error("Unknown variant type passed to equality check. Please contact the developers.");
 }
 
-std::string ScriptReader::readScriptFile(const std::string& filename, const DataDict& data)
+namespace
 {
-  // Top-level entry point: normalize the input path, set up the include root, reset the include
-  // stack/depth counters, then delegate to the internal impl.
-  std::filesystem::path input_path(filename);
-  std::filesystem::path canonical_input;
+// Returns true if `candidate` (already lexically-normalized) is inside `root` (also normalized).
+bool isPathInside(const std::filesystem::path& candidate, const std::filesystem::path& root)
+{
+  const auto rel = candidate.lexically_relative(root);
+  if (rel.empty())
+  {
+    // No relative path exists (e.g. different roots on Windows) -> definitely outside.
+    return false;
+  }
+  for (const auto& part : rel)
+  {
+    if (part == "..")
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Runs std::filesystem::weakly_canonical on `input` and wraps any filesystem_error in a UrException
+// with a message that includes `context` (e.g. "script file path" / "include path") and the raw
+// user-facing spelling of the path (`raw`). Both call sites in ScriptReader need identical wrapping
+// but with a different label and different raw string, so keep those parameters explicit.
+//
+// weakly_canonical is preferred over canonical because it tolerates trailing components that do
+// not yet exist -- we defer "file not found" reporting to readFileContent, which produces a nicer
+// error. Symlink cycles and similar low-level failures still throw here, and are what this helper
+// converts.
+std::filesystem::path canonicalizeOrThrow(const std::filesystem::path& input, const std::string& raw,
+                                          const char* context)
+{
   try
   {
-    // weakly_canonical works even if trailing components don't yet exist (we still want a useful
-    // error message from readFileContent below rather than a filesystem_error here). It also
-    // resolves symlinks in existing components, which matters for the containment check.
-    canonical_input = std::filesystem::weakly_canonical(input_path);
+    return std::filesystem::weakly_canonical(input);
   }
   catch (const std::filesystem::filesystem_error& e)
   {
     std::stringstream ss;
-    ss << "Could not resolve script file path '" << filename << "': " << e.what();
+    ss << "Could not resolve " << context << " '" << raw << "': " << e.what();
     throw UrException(ss.str().c_str());
   }
+}
+}  // namespace
+
+std::string ScriptReader::readScriptFile(const std::string& filename, const DataDict& data)
+{
+  // Top-level entry point: normalize the input path, set up the include root, reset the include
+  // stack/depth counters, then delegate to the internal impl.
+  const std::filesystem::path canonical_input =
+      canonicalizeOrThrow(std::filesystem::path(filename), filename, "script file path");
 
   root_dir_ = canonical_input.parent_path();
   current_dir_.clear();
@@ -225,28 +258,6 @@ std::string ScriptReader::readFileContent(const std::string& file_path)
   return content;
 }
 
-namespace
-{
-// Returns true if `candidate` (already lexically-normalized) is inside `root` (also normalized).
-bool isPathInside(const std::filesystem::path& candidate, const std::filesystem::path& root)
-{
-  const auto rel = candidate.lexically_relative(root);
-  if (rel.empty())
-  {
-    // No relative path exists (e.g. different roots on Windows) -> definitely outside.
-    return false;
-  }
-  for (const auto& part : rel)
-  {
-    if (part == "..")
-    {
-      return false;
-    }
-  }
-  return true;
-}
-}  // namespace
-
 void ScriptReader::replaceIncludes(std::string& script, const DataDict& data)
 {
   // Character class fixed: previously the regex used `['|"]` which matches `'`, `|`, or `"` (the
@@ -276,19 +287,9 @@ void ScriptReader::replaceIncludes(std::string& script, const DataDict& data)
       throw UrException(("Rooted or absolute include paths are not allowed: '" + raw + "'").c_str());
     }
 
-    std::filesystem::path resolved;
-    try
-    {
-      // weakly_canonical collapses `..` components and resolves symlinks where possible, which is
-      // what we need to make the containment check trustworthy.
-      resolved = std::filesystem::weakly_canonical(current_dir_ / requested);
-    }
-    catch (const std::filesystem::filesystem_error& e)
-    {
-      std::stringstream ss;
-      ss << "Could not resolve include path '" << raw << "': " << e.what();
-      throw UrException(ss.str().c_str());
-    }
+    // weakly_canonical collapses `..` components and resolves symlinks where possible, which is
+    // what we need to make the containment check trustworthy.
+    const std::filesystem::path resolved = canonicalizeOrThrow(current_dir_ / requested, raw, "include path");
 
     if (!isPathInside(resolved, root_dir_))
     {

--- a/src/control/script_reader.cpp
+++ b/src/control/script_reader.cpp
@@ -135,13 +135,73 @@ bool operator==(const ScriptReader::DataVariant& lhs, const ScriptReader::DataVa
 
 std::string ScriptReader::readScriptFile(const std::string& filename, const DataDict& data)
 {
-  script_path_ = filename;
-  std::string script_code = readFileContent(filename);
+  // Top-level entry point: normalize the input path, set up the include root, reset the include
+  // stack/depth counters, then delegate to the internal impl.
+  std::filesystem::path input_path(filename);
+  std::filesystem::path canonical_input;
+  try
+  {
+    // weakly_canonical works even if trailing components don't yet exist (we still want a useful
+    // error message from readFileContent below rather than a filesystem_error here). It also
+    // resolves symlinks in existing components, which matters for the containment check.
+    canonical_input = std::filesystem::weakly_canonical(input_path);
+  }
+  catch (const std::filesystem::filesystem_error& e)
+  {
+    std::stringstream ss;
+    ss << "Could not resolve script file path '" << filename << "': " << e.what();
+    throw UrException(ss.str().c_str());
+  }
 
-  replaceVariables(script_code, data);
-  replaceConditionals(script_code, data);
-  replaceIncludes(script_code, data);
+  root_dir_ = canonical_input.parent_path();
+  current_dir_.clear();
+  include_stack_.clear();
+  include_depth_ = 0;
 
+  return readScriptFileImpl(canonical_input, data);
+}
+
+std::string ScriptReader::readScriptFileImpl(const std::filesystem::path& canonical_path, const DataDict& data)
+{
+  const std::string path_key = canonical_path.string();
+
+  if (include_stack_.count(path_key) != 0)
+  {
+    throw UrException(("Circular include detected while processing script file: '" + path_key + "'").c_str());
+  }
+  if (include_depth_ >= MAX_INCLUDE_DEPTH)
+  {
+    std::stringstream ss;
+    ss << "Maximum include depth (" << MAX_INCLUDE_DEPTH << ") exceeded while processing script file: '" << path_key
+       << "'";
+    throw UrException(ss.str().c_str());
+  }
+
+  // Save-restore the per-file state so a nested include cannot corrupt the parent's include base.
+  const std::filesystem::path previous_dir = current_dir_;
+  current_dir_ = canonical_path.parent_path();
+  include_stack_.insert(path_key);
+  ++include_depth_;
+
+  std::string script_code;
+  try
+  {
+    script_code = readFileContent(path_key);
+    replaceVariables(script_code, data);
+    replaceConditionals(script_code, data);
+    replaceIncludes(script_code, data);
+  }
+  catch (...)
+  {
+    include_stack_.erase(path_key);
+    --include_depth_;
+    current_dir_ = previous_dir;
+    throw;
+  }
+
+  include_stack_.erase(path_key);
+  --include_depth_;
+  current_dir_ = previous_dir;
   return script_code;
 }
 
@@ -165,18 +225,81 @@ std::string ScriptReader::readFileContent(const std::string& file_path)
   return content;
 }
 
+namespace
+{
+// Returns true if `candidate` (already lexically-normalized) is inside `root` (also normalized).
+bool isPathInside(const std::filesystem::path& candidate, const std::filesystem::path& root)
+{
+  const auto rel = candidate.lexically_relative(root);
+  if (rel.empty())
+  {
+    // No relative path exists (e.g. different roots on Windows) -> definitely outside.
+    return false;
+  }
+  for (const auto& part : rel)
+  {
+    if (part == "..")
+    {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
+
 void ScriptReader::replaceIncludes(std::string& script, const DataDict& data)
 {
-  std::regex include_pattern(R"(\{\%\s*include\s*['|"]([^'"]+)['|"]\s*\%\})");
+  // Character class fixed: previously the regex used `['|"]` which matches `'`, `|`, or `"` (the
+  // `|` is literal inside a character class, not alternation).
+  std::regex include_pattern(R"(\{\%\s*include\s*['"]([^'"]+)['"]\s*\%\})");
 
   std::smatch match;
 
-  // Replace all include patterns in the line
+  // Replace all include patterns in the script.
   while (std::regex_search(script, match, include_pattern))
   {
-    std::filesystem::path relative_file_path(match[1].str());
-    std::string file_content =
-        readScriptFile((script_path_.parent_path() / relative_file_path.string()).string(), data);
+    const std::string raw = match[1].str();
+    std::filesystem::path requested(raw);
+
+    // Reject any path with a root name and/or a root directory. On POSIX this only rules out
+    // absolute paths (`/etc/passwd`). On Windows this additionally covers:
+    //   * `\evil.txt`         (root directory but no drive) — operator/= would prepend LHS's drive
+    //     and drop LHS's relative portion, yielding `C:\evil.txt` and escaping root_dir_.
+    //   * `C:evil.txt`        (drive-relative, no root directory) — safe when the drive matches
+    //     LHS, but for a different drive operator/= replaces LHS entirely.
+    //   * `\\server\share\x`  (UNC), `\\?\C:\x` (extended-length) — already caught by is_absolute()
+    //     but redundantly rejected here.
+    // std::filesystem::path::operator/ has surprising drop-LHS semantics in all these cases, so
+    // rejecting them up front is safer than relying on the containment check alone.
+    if (requested.is_absolute() || requested.has_root_name() || requested.has_root_directory())
+    {
+      throw UrException(("Rooted or absolute include paths are not allowed: '" + raw + "'").c_str());
+    }
+
+    std::filesystem::path resolved;
+    try
+    {
+      // weakly_canonical collapses `..` components and resolves symlinks where possible, which is
+      // what we need to make the containment check trustworthy.
+      resolved = std::filesystem::weakly_canonical(current_dir_ / requested);
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+      std::stringstream ss;
+      ss << "Could not resolve include path '" << raw << "': " << e.what();
+      throw UrException(ss.str().c_str());
+    }
+
+    if (!isPathInside(resolved, root_dir_))
+    {
+      std::stringstream ss;
+      ss << "Include path '" << raw << "' resolves outside of the script root directory '" << root_dir_.string()
+         << "' (resolved to '" << resolved.string() << "')";
+      throw UrException(ss.str().c_str());
+    }
+
+    // Recurse via the impl so include_stack_/include_depth_/current_dir_ stay consistent.
+    std::string file_content = readScriptFileImpl(resolved, data);
     script.replace(match.position(0), match.length(0), file_content);
   }
 }

--- a/tests/test_script_reader.cpp
+++ b/tests/test_script_reader.cpp
@@ -616,6 +616,180 @@ TEST_F(ScriptReaderTest, TestFrictionScalesConstantsAndHandler)
             std::string::npos);
 }
 
+// --- Security regression tests -------------------------------------------------------------------
+
+namespace
+{
+// Helper: create a script file inside `dir` with the given contents. Returns the full path.
+std::filesystem::path writeScriptFile(const std::filesystem::path& dir, const std::string& name,
+                                      const std::string& contents)
+{
+  const auto path = dir / name;
+  std::ofstream ofs(path);
+  ofs << contents;
+  ofs.close();
+  return path;
+}
+}  // namespace
+
+// Path traversal via `..` must be rejected: an include cannot escape the root script's directory.
+TEST_F(ScriptReaderTest, IncludeRejectsParentTraversal)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_traversal";
+  std::filesystem::remove_all(tmp_root);
+  const auto project_dir = tmp_root / "project";
+  const auto secret_dir = tmp_root / "secret";
+  std::filesystem::create_directories(project_dir);
+  std::filesystem::create_directories(secret_dir);
+  writeScriptFile(secret_dir, "leak.txt", "SECRET_CONTENT");
+  const auto main_script = writeScriptFile(project_dir, "main.urscript", "{% include \"../secret/leak.txt\" %}");
+
+  ScriptReader reader;
+  EXPECT_THROW(reader.readScriptFile(main_script.string()), urcl::UrException);
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+// Absolute include paths must be rejected outright. Prior to the fix, std::filesystem::path::operator/
+// silently discarded the LHS when the RHS was absolute, letting `{% include "/etc/..." %}` escape.
+TEST_F(ScriptReaderTest, IncludeRejectsAbsolutePath)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_absolute";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+  const auto target = writeScriptFile(tmp_root, "target.txt", "TARGET");
+  // The include payload is `/<absolute-path>/target.txt`.
+  const std::string include_body = "{% include \"" + target.string() + "\" %}";
+  // The main script lives elsewhere (its own root), so absolute-path escape is what's being tested.
+  const auto project_dir = tmp_root / "project";
+  std::filesystem::create_directories(project_dir);
+  const auto main_script = writeScriptFile(project_dir, "main.urscript", include_body);
+
+  ScriptReader reader;
+  EXPECT_THROW(reader.readScriptFile(main_script.string()), urcl::UrException);
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+// A file that includes itself must be rejected instead of recursing forever.
+TEST_F(ScriptReaderTest, IncludeSelfReferenceRejected)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_self";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+  const auto self = writeScriptFile(tmp_root, "self.urscript", "{% include \"self.urscript\" %}");
+
+  ScriptReader reader;
+  EXPECT_THROW(reader.readScriptFile(self.string()), urcl::UrException);
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+// A -> B -> A must be rejected instead of recursing forever.
+TEST_F(ScriptReaderTest, IncludeCycleRejected)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_cycle";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+  writeScriptFile(tmp_root, "a.urscript", "{% include \"b.urscript\" %}");
+  writeScriptFile(tmp_root, "b.urscript", "{% include \"a.urscript\" %}");
+
+  ScriptReader reader;
+  EXPECT_THROW(reader.readScriptFile((tmp_root / "a.urscript").string()), urcl::UrException);
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+// A deeply nested but non-cyclic include chain must be rejected once the depth cap is exceeded.
+// Uses N+1 distinct files chained a0 -> a1 -> ... -> aN where N is well past kMaxIncludeDepth.
+TEST_F(ScriptReaderTest, IncludeExceedingDepthLimitRejected)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_depth";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+
+  constexpr std::size_t kChainLen = 64;  // > ScriptReader::kMaxIncludeDepth (32)
+  for (std::size_t i = 0; i < kChainLen; ++i)
+  {
+    const std::string next = "a" + std::to_string(i + 1) + ".urscript";
+    writeScriptFile(tmp_root, "a" + std::to_string(i) + ".urscript", "{% include \"" + next + "\" %}");
+  }
+  writeScriptFile(tmp_root, "a" + std::to_string(kChainLen) + ".urscript", "leaf");
+
+  ScriptReader reader;
+  EXPECT_THROW(reader.readScriptFile((tmp_root / "a0.urscript").string()), urcl::UrException);
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+// A file including two siblings back-to-back must resolve BOTH relative to the parent's directory
+// (not relative to the first included file's directory).
+TEST_F(ScriptReaderTest, SiblingIncludesResolveRelativeToParent)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_siblings";
+  std::filesystem::remove_all(tmp_root);
+  const auto root_dir = tmp_root / "root";
+  const auto sub_dir = root_dir / "sub";
+  std::filesystem::create_directories(sub_dir);
+
+  // sub/child.urscript exists at sub/. If script_path_ were corrupted by processing sub/child,
+  // resolving `sibling.urscript` from root/ would fail (looking inside sub/).
+  writeScriptFile(sub_dir, "child.urscript", "CHILD");
+  writeScriptFile(root_dir, "sibling.urscript", "SIBLING");
+  const auto main_script = writeScriptFile(root_dir, "main.urscript",
+                                           "{% include \"sub/child.urscript\" %}\n"
+                                           "{% include \"sibling.urscript\" %}");
+
+  ScriptReader reader;
+  const std::string out = reader.readScriptFile(main_script.string());
+  EXPECT_EQ(out, "CHILD\nSIBLING");
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+#ifdef _WIN32
+// Windows-only regression: paths like `\evil.txt` (root directory, no drive) and `Z:evil.txt`
+// (drive-relative on a different drive) both slip past `path::is_absolute()` on Windows but would
+// still let `operator/=` drop the LHS. Verify the strengthened check (has_root_name /
+// has_root_directory) rejects them up front. Gated to Windows because on POSIX these are just
+// filenames with weird characters and the rejection path we want to exercise is not reachable.
+TEST_F(ScriptReaderTest, IncludeRejectsRootedWindowsStylePaths)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_rooted";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+  writeScriptFile(tmp_root, "target.txt", "TARGET");
+
+  const auto main_bs = writeScriptFile(tmp_root, "main_bs.urscript", "{% include \"\\target.txt\" %}");
+  ScriptReader reader;
+  EXPECT_THROW(reader.readScriptFile(main_bs.string()), urcl::UrException);
+
+  const auto main_drive = writeScriptFile(tmp_root, "main_drive.urscript", "{% include \"Z:target.txt\" %}");
+  ScriptReader reader2;
+  EXPECT_THROW(reader2.readScriptFile(main_drive.string()), urcl::UrException);
+
+  std::filesystem::remove_all(tmp_root);
+}
+#endif  // _WIN32
+
+// Regression for the character-class bug: previously `['|"]` accepted `|` as a quote character.
+TEST_F(ScriptReaderTest, IncludeRejectsPipeAsQuote)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_pipe";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+  writeScriptFile(tmp_root, "target.txt", "TARGET");
+  // `{% include |target.txt| %}` should NOT match the include pattern anymore.
+  const auto main_script = writeScriptFile(tmp_root, "main.urscript", "prefix {% include |target.txt| %} suffix");
+
+  ScriptReader reader;
+  const std::string out = reader.readScriptFile(main_script.string());
+  // Pattern doesn't match -> the line is emitted verbatim, no include performed.
+  EXPECT_EQ(out, "prefix {% include |target.txt| %} suffix");
+
+  std::filesystem::remove_all(tmp_root);
+}
+
 // A test that produce all script files to a subfolder for different software version to be manually inspected
 TEST_F(ScriptReaderTest, TestProduceAllScriptFiles)
 {

--- a/tests/test_script_reader.cpp
+++ b/tests/test_script_reader.cpp
@@ -790,6 +790,68 @@ TEST_F(ScriptReaderTest, IncludeRejectsPipeAsQuote)
   std::filesystem::remove_all(tmp_root);
 }
 
+#ifndef _WIN32
+// If `weakly_canonical` throws (e.g. on a symlink cycle), the top-level readScriptFile must
+// translate that filesystem_error into a UrException whose message names the input path.
+// Symlinks are POSIX-only in this project (Windows requires elevation), so gate the test.
+TEST_F(ScriptReaderTest, ReadScriptFileWrapsFilesystemError)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_readfile_fs_err";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+
+  // Self-referencing symlink: weakly_canonical resolves symlinks and will bail out with ELOOP.
+  const auto loop = tmp_root / "loop";
+  std::filesystem::create_symlink(loop, loop);
+
+  ScriptReader reader;
+  try
+  {
+    reader.readScriptFile(loop.string());
+    FAIL() << "Expected UrException from filesystem_error wrapping";
+  }
+  catch (const urcl::UrException& e)
+  {
+    // Message should mention the top-level context and the offending path so callers can debug.
+    const std::string what = e.what();
+    EXPECT_NE(what.find("script file path"), std::string::npos) << "unexpected message: " << what;
+    EXPECT_NE(what.find(loop.string()), std::string::npos) << "unexpected message: " << what;
+  }
+
+  std::filesystem::remove_all(tmp_root);
+}
+
+// Same idea, but for the include path resolution in replaceIncludes: the include target is a
+// symlink cycle, so weakly_canonical throws and we should surface it as a UrException.
+TEST_F(ScriptReaderTest, IncludeWrapsFilesystemError)
+{
+  const auto tmp_root = std::filesystem::temp_directory_path() / "urcl_script_reader_include_fs_err";
+  std::filesystem::remove_all(tmp_root);
+  std::filesystem::create_directories(tmp_root);
+
+  // Include target is a symlink that points to itself. The main script itself resolves fine, so
+  // the failure has to originate from replaceIncludes, not readScriptFile.
+  std::filesystem::create_symlink(tmp_root / "loop", tmp_root / "loop");
+  const auto main_script = writeScriptFile(tmp_root, "main.urscript", "{% include \"loop\" %}");
+
+  ScriptReader reader;
+  try
+  {
+    reader.readScriptFile(main_script.string());
+    FAIL() << "Expected UrException from filesystem_error wrapping";
+  }
+  catch (const urcl::UrException& e)
+  {
+    const std::string what = e.what();
+    EXPECT_NE(what.find("include path"), std::string::npos) << "unexpected message: " << what;
+    // The raw include spelling (what the user wrote, not the resolved path) should be in the msg.
+    EXPECT_NE(what.find("'loop'"), std::string::npos) << "unexpected message: " << what;
+  }
+
+  std::filesystem::remove_all(tmp_root);
+}
+#endif  // _WIN32
+
 // A test that produce all script files to a subfolder for different software version to be manually inspected
 TEST_F(ScriptReaderTest, TestProduceAllScriptFiles)
 {


### PR DESCRIPTION
This doesn't change anything in behavior, it merely enforces the behavior as it is described in the docs.

1. Path traversal (.. and absolute-path escape) — `replaceIncludes()` now rejects absolute include paths outright (avoiding the `path::operator/` LHS-drop trap) and requires every include's `weakly_canonical`-normalized target to be lexically inside 
`root_dir_` (the directory of the top-level script).

2. Unbounded / circular includes → stack overflow — added `include_stack_` (set of canonical paths currently being processed) for cycle detection and `include_depth_` bounded by a fixed threshold of 32. Both self-references and A→B→A cycles now throw `UrException`, as do chains beyond the depth cap.

3. `script_path_` state corruption from nested includes — removed the mutable `script_path_` member. The public `readScriptFile()` is now a thin wrapper that initializes state, and a new private `readScriptFileImpl()` save-restores `current_dir_` (and cleans up `include_stack_`/`include_depth_`) around every recursive include, even on exceptions.

4. Malformed include regex ['|"] — changed to ['"]. {% include |target.txt| %} is no longer treated as a valid include.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-sensitive filesystem include resolution for robot control scripts; legitimate deep include chains beyond 32 levels will now fail, and malicious or malformed include paths are rejected instead of read.
> 
> **Overview**
> **Hardens `ScriptReader` include handling** so nested `{% include %}` matches documented behavior and blocks path escape, unbounded recursion, and corrupted relative resolution.
> 
> `readScriptFile` now establishes a **script root** (`root_dir_`), tracks **current directory** per nesting level via private `readScriptFileImpl`, and replaces the mutable `script_path_` with `include_stack_` / `include_depth_` (cap **32**). Includes reject absolute and rooted paths, resolve targets with `weakly_canonical`, and require the result to stay under the root; cycles and depth overflow throw `UrException`. `filesystem_error` from canonicalization is wrapped with context for the main script path and include paths.
> 
> The include regex is fixed from `['|"]` to `['"]` so `|` is no longer treated as a quote. **Security regression tests** cover traversal, absolute paths, cycles, depth limits, sibling includes, Windows-style rooted paths, pipe-as-quote, and symlink canonicalization errors (POSIX).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c3f42371272eb53cd3e6b2d7fa872699c195e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->