### PR TITLE
Release/2.14.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.14.1 (2026-08-07)
+-------------------
 * fix: teardown blocks indefinitely when a reconnect thread is active and the robot is unreachable (`#519 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/519>`_)
 * Harden script_reader against vulnerabilities (`#546 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/546>`_)
 * Add missing keys to RTDEInvalidKeyException

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* fix: teardown blocks indefinitely when a reconnect thread is active and the robot is unreachable (`#519 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/519>`_)
+* Harden script_reader against vulnerabilities (`#546 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/546>`_)
+* Add missing keys to RTDEInvalidKeyException
+* Fix OOB read vulnerability in bin parser (`#545 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/545>`_)
+* [start_ursim] Offer updating g5 urcap (`#543 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/543>`_)
+* Link urcl to rt on non-Apple Unix (`#540 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/540>`_)
+* Fix dependencies for bats (`#542 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/542>`_)
+* Bump actions/setup-python from 6 to 7 (`#541 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/541>`_)
+* Contributors: Felix Exner, Rune Søe-Knudsen, Tobias Fischer, dependabot[bot]
+
 2.14.0 (2026-07-17)
 -------------------
 * RTDE: Add target_base_wrench field (`#539 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/539>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>2.14.0</version>
+  <version>2.14.1</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
Release latest fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release packaging with no library or runtime behavior changes in the diff.
> 
> **Overview**
> **Release 2.14.1** — bumps `package.xml` from **2.14.0** to **2.14.1** and documents the release in `CHANGELOG.rst`.
> 
> The changelog entry summarizes fixes and tooling updates already merged on the branch (teardown/reconnect hang, `script_reader` and bin-parser security hardening, RTDE exception keys, `start_ursim` g5 URCap, linking `rt` on non-Apple Unix, bats deps, CI `setup-python` bump). This PR does not introduce those code changes itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d823d09d46a8a9690ba18431d626be2405f45708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->