### PR TITLE
Separate standalone instruction executor test into its own file

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -143,6 +143,22 @@ if (INTEGRATION_TESTS)
                   TEST_SUFFIX _headless
   )
 
+  # InstructionExecutor standalone tests
+  add_executable(instruction_executor_standalone_test_urcap test_instruction_executor_standalone.cpp)
+  target_link_libraries(instruction_executor_standalone_test_urcap PRIVATE ur_client_library::urcl GTest::gtest_main)
+  gtest_add_tests(TARGET instruction_executor_standalone_test_urcap
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  EXTRA_ARGS --headless false ${INTEGRATION_TESTS_ROBOT_IP_ARG}
+                  TEST_SUFFIX _urcap
+  )
+  add_executable(instruction_executor_standalone_test_headless test_instruction_executor_standalone.cpp)
+  target_link_libraries(instruction_executor_standalone_test_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
+  gtest_add_tests(TARGET instruction_executor_standalone_test_headless
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  EXTRA_ARGS --headless true ${INTEGRATION_TESTS_ROBOT_IP_ARG}
+                  TEST_SUFFIX _headless
+  )
+
   add_executable(primary_client_test_headless test_primary_client.cpp fake_primary_server.cpp)
   target_link_libraries(primary_client_test_headless PRIVATE ur_client_library::urcl GTest::gtest_main)
   gtest_add_tests(TARGET primary_client_test_headless

--- a/tests/test_instruction_executor.cpp
+++ b/tests/test_instruction_executor.cpp
@@ -252,53 +252,6 @@ TEST_F(InstructionExecutorTest, canceling_without_running_trajectory_returns_fal
   ASSERT_FALSE(executor_->cancelMotion());
 }
 
-TEST(InstructionExecutorTestStandalone, canceling_without_receiving_answer_returns_false)
-{
-  if (!(robotVersionLessThan(g_ROBOT_IP, "10.0.0") || g_HEADLESS))
-  {
-    GTEST_SKIP_("Running URCap tests for PolyScope X is currently not supported.");
-  }
-
-  std::ifstream in_file(SCRIPT_FILE);
-  std::ofstream out_file;
-  const std::string test_script_file = "test_script.urscript";
-  out_file.open(test_script_file);
-
-  std::string line;
-  std::string pattern = "socket_send_int(TRAJECTORY_RESULT_CANCELED, \"trajectory_socket\")";
-  while (std::getline(in_file, line))
-  {
-    if (line.find(pattern) == std::string::npos)
-    {
-      out_file << line << std::endl;
-    }
-  }
-  out_file.close();
-  auto my_robot = std::make_unique<ExampleRobotWrapper>(g_ROBOT_IP, OUTPUT_RECIPE, INPUT_RECIPE, g_HEADLESS,
-                                                        "external_control.urp", test_script_file);
-  auto executor = std::make_unique<InstructionExecutor>(my_robot->getUrDriver());
-  my_robot->clearProtectiveStop();
-  // Make sure script is running on the robot
-  if (!my_robot->waitForProgramRunning())
-  {
-    my_robot->resendRobotProgram();
-    ASSERT_TRUE(my_robot->waitForProgramRunning());
-  }
-  ASSERT_TRUE(executor->moveJ({ -1.59, -1.72, -2.2, -0.8, 1.6, 0.2 }, 2.0, 2.0));
-  std::thread move_thread([&executor]() { executor->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 2.7 }, 0.1, 0.1); });
-  bool is_trajectory_running = false;
-  std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-  while (!is_trajectory_running || std::chrono::steady_clock::now() > start + std::chrono::seconds(5))
-  {
-    is_trajectory_running = executor->isTrajectoryRunning();
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  ASSERT_TRUE(executor->isTrajectoryRunning());
-  ASSERT_FALSE(executor->cancelMotion());
-  move_thread.join();
-  std::remove(test_script_file.c_str());
-}
-
 TEST_F(InstructionExecutorTest, canceling_with_running_trajectory_succeeds)
 {
   ASSERT_TRUE(executor_->moveJ({ -1.59, -1.72, -2.2, -0.8, 1.6, 0.2 }, 2.0, 2.0));

--- a/tests/test_instruction_executor_standalone.cpp
+++ b/tests/test_instruction_executor_standalone.cpp
@@ -87,7 +87,7 @@ TEST(InstructionExecutorTestStandalone, canceling_without_receiving_answer_retur
   std::thread move_thread([&executor]() { executor->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 2.7 }, 0.1, 0.1); });
   bool is_trajectory_running = false;
   std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-  while (!is_trajectory_running || std::chrono::steady_clock::now() > start + std::chrono::seconds(5))
+  while (!is_trajectory_running && std::chrono::steady_clock::now() < start + std::chrono::seconds(5))
   {
     is_trajectory_running = executor->isTrajectoryRunning();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/tests/test_instruction_executor_standalone.cpp
+++ b/tests/test_instruction_executor_standalone.cpp
@@ -1,0 +1,121 @@
+// -- BEGIN LICENSE BLOCK ----------------------------------------------
+// Copyright 2026 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// -- END LICENSE BLOCK ------------------------------------------------
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <thread>
+#include "ur_client_library/ur/instruction_executor.h"
+
+#include "test_utils.h"
+
+#include <ur_client_library/example_robot_wrapper.h>
+
+using namespace urcl;
+
+const std::string SCRIPT_FILE = "../resources/external_control.urscript";
+const std::string OUTPUT_RECIPE = "resources/rtde_output_recipe.txt";
+const std::string INPUT_RECIPE = "resources/rtde_input_recipe.txt";
+const std::string CALIBRATION_CHECKSUM = "calib_12788084448423163542";
+std::string g_ROBOT_IP = "192.168.56.101";
+bool g_HEADLESS = true;
+
+/*
+    This test was moved to its own file, as the ExampleRobotWrapper initialisation in this test was clashing with the
+    static one initialised in the InstructionExecutorTest test suite. This was causing flaky test behavior in the CI.
+    Other Instruction Executor tests that require a separate robot wrapper should also be put here.
+*/
+TEST(InstructionExecutorTestStandalone, canceling_without_receiving_answer_returns_false)
+{
+  if (!(robotVersionLessThan(g_ROBOT_IP, "10.0.0") || g_HEADLESS))
+  {
+    GTEST_SKIP_("Running URCap tests for PolyScope X is currently not supported.");
+  }
+
+  std::ifstream in_file(SCRIPT_FILE);
+  std::ofstream out_file;
+  const std::string test_script_file = "test_script.urscript";
+  out_file.open(test_script_file);
+
+  std::string line;
+  std::string pattern = "socket_send_int(TRAJECTORY_RESULT_CANCELED, \"trajectory_socket\")";
+  while (std::getline(in_file, line))
+  {
+    if (line.find(pattern) == std::string::npos)
+    {
+      out_file << line << std::endl;
+    }
+  }
+  out_file.close();
+  auto my_robot = std::make_unique<ExampleRobotWrapper>(g_ROBOT_IP, OUTPUT_RECIPE, INPUT_RECIPE, g_HEADLESS,
+                                                        "external_control.urp", test_script_file);
+  auto executor = std::make_unique<InstructionExecutor>(my_robot->getUrDriver());
+  my_robot->clearProtectiveStop();
+  // Make sure script is running on the robot
+  if (!my_robot->waitForProgramRunning())
+  {
+    my_robot->resendRobotProgram();
+    ASSERT_TRUE(my_robot->waitForProgramRunning());
+  }
+  ASSERT_TRUE(executor->moveJ({ -1.59, -1.72, -2.2, -0.8, 1.6, 0.2 }, 2.0, 2.0));
+  std::thread move_thread([&executor]() { executor->moveJ({ -1.57, -1.6, 1.6, -0.7, 0.7, 2.7 }, 0.1, 0.1); });
+  bool is_trajectory_running = false;
+  std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
+  while (!is_trajectory_running || std::chrono::steady_clock::now() > start + std::chrono::seconds(5))
+  {
+    is_trajectory_running = executor->isTrajectoryRunning();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  ASSERT_TRUE(executor->isTrajectoryRunning());
+  ASSERT_FALSE(executor->cancelMotion());
+  move_thread.join();
+  std::remove(test_script_file.c_str());
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  for (int i = 0; i < argc; i++)
+  {
+    if (std::string(argv[i]) == "--robot_ip" && i + 1 < argc)
+    {
+      g_ROBOT_IP = argv[i + 1];
+      ++i;
+    }
+    if (std::string(argv[i]) == "--headless" && i + 1 < argc)
+    {
+      std::string headless = argv[i + 1];
+      g_HEADLESS = headless == "true" || headless == "1" || headless == "True" || headless == "TRUE";
+      ++i;
+    }
+  }
+
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_instruction_executor_standalone.cpp
+++ b/tests/test_instruction_executor_standalone.cpp
@@ -92,8 +92,8 @@ TEST(InstructionExecutorTestStandalone, canceling_without_receiving_answer_retur
     is_trajectory_running = executor->isTrajectoryRunning();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  ASSERT_TRUE(executor->isTrajectoryRunning());
-  ASSERT_FALSE(executor->cancelMotion());
+  EXPECT_TRUE(executor->isTrajectoryRunning());
+  EXPECT_FALSE(executor->cancelMotion());
   move_thread.join();
   std::remove(test_script_file.c_str());
 }


### PR DESCRIPTION
The test was being flaky because there were two instances of the robot wrapper running at the same time.
Closes #547 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production library changes; risk is limited to integration test coverage and CI behavior.
> 
> **Overview**
> Moves **`canceling_without_receiving_answer_returns_false`** out of `test_instruction_executor.cpp` into **`test_instruction_executor_standalone.cpp`**, so it no longer shares a process with the **`InstructionExecutorTest`** fixture’s global `ExampleRobotWrapper`—addressing flaky CI from two robot connections in one test executable.
> 
> CMake now builds **`instruction_executor_standalone_test_urcap`** and **`instruction_executor_standalone_test_headless`** (mirroring the existing instruction executor integration targets). The standalone file includes its own `main` for `--robot_ip` / `--headless` and documents that future tests needing a separate wrapper should live here.
> 
> In the moved test, the trajectory wait loop is corrected to **`&&`** with a **&lt;** timeout bound (instead of the previous **`||`** / **`&gt;`** logic), and **`ASSERT_TRUE`/`ASSERT_FALSE`** on trajectory state and cancel are **`EXPECT_*`** so the move thread can still be joined cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fde0fedf2236c8e2c5637c0f2312e61283570eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->