### PR TITLE
Update downstream branch for lyrical

### DIFF
--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -23,7 +23,7 @@ jobs:
           - NAME: kilted
             DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#kilted"
           - NAME: lyrical
-            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#main"
+            DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#lyrical"
           - NAME: rolling
             DOWNSTREAM_WORKSPACE: "github:UniversalRobots/Universal_Robots_ROS2_Driver#main"
             CLANG_TIDY: pedantic

--- a/.github/workflows/industrial-ci.yml
+++ b/.github/workflows/industrial-ci.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           IMMEDIATE_TEST_OUTPUT: true
           DOWNSTREAM_CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
-          ADDITIONAL_DEBS: docker.io netcat-openbsd  # Needed for integration tests
+          ADDITIONAL_DEBS: docker.io netcat-openbsd curl # Needed for integration tests
           DOWNSTREAM_WORKSPACE: ${{matrix.ROS_DISTRO.DOWNSTREAM_WORKSPACE}}
           ROS_DISTRO: ${{matrix.ROS_DISTRO.NAME}}
           ROS_REPO: ${{matrix.ROS_REPO}}


### PR DESCRIPTION
When branching out for lyrical in the driver, we didn't update this repo's downstream branch. This fixes that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no runtime or application code impact.
> 
> **Overview**
> Updates the **lyrical** ROS distro entry in industrial CI so `DOWNSTREAM_WORKSPACE` tracks `Universal_Robots_ROS2_Driver#lyrical` instead of `#main`, matching the driver’s lyrical branch.
> 
> Also adds **`curl`** to `ADDITIONAL_DEBS` alongside the existing packages used for integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0caeef76b4a7e95298d67d67bd023b6e79f66b87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->