### PR TITLE
MotionTarget helpers

### DIFF
--- a/include/ur_client_library/helpers.h
+++ b/include/ur_client_library/helpers.h
@@ -186,5 +186,7 @@ RobotSeries robotSeriesFromTypeAndVersion(const RobotType type, const VersionInf
  */
 RobotType robotTypeFromString(const std::string& robot_type_str);
 
+std::string stringFromMotionTarget(const MotionTarget& target);
+
 }  // namespace urcl
 #endif  // ifndef UR_CLIENT_LIBRARY_HELPERS_H_INCLUDED

--- a/include/ur_client_library/types.h
+++ b/include/ur_client_library/types.h
@@ -29,6 +29,7 @@
 #include <optional>
 #include <variant>
 #include <vector>
+#include <string>
 
 namespace urcl
 {

--- a/include/ur_client_library/types.h
+++ b/include/ur_client_library/types.h
@@ -59,6 +59,8 @@ public:
   void setValues(const vector6d_t& values);
   void setValues(const std::vector<double>& values);
 
+  std::string toString() const;
+
 private:
   std::vector<double> values_;
 };
@@ -88,6 +90,8 @@ public:
   void setQNear(const Q& q_near);
 
   void setPose(const double x, const double y, const double z, const double rx, const double ry, const double rz);
+
+  std::string toString() const;
 
   double x;
   double y;

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -225,4 +225,9 @@ RobotType robotTypeFromString(const std::string& robot_type_str)
   return it->second;
 }
 
+std::string stringFromMotionTarget(const MotionTarget& target)
+{
+  return std::visit([](const auto& target) { return target.toString(); }, target);
+}
+
 }  // namespace urcl

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -31,6 +31,7 @@
 #include <ur_client_library/types.h>
 
 #include <algorithm>
+#include <sstream>
 
 namespace urcl
 {
@@ -69,6 +70,22 @@ bool operator==(const Q& lhs, const Q& rhs)
 {
   return lhs.getValues().size() == rhs.getValues().size() &&
          std::equal(lhs.getValues().begin(), lhs.getValues().end(), rhs.getValues().begin());
+}
+
+std::string Q::toString() const
+{
+  std::stringstream ss;
+  ss << "Q([";
+  for (size_t i = 0; i < values_.size(); ++i)
+  {
+    ss << values_[i];
+    if (i < values_.size() - 1)
+    {
+      ss << ", ";
+    }
+  }
+  ss << "])";
+  return ss.str();
 }
 
 Pose::Pose() : x(0.0), y(0.0), z(0.0), rx(0.0), ry(0.0), rz(0.0), q_near_(std::nullopt)
@@ -127,6 +144,14 @@ void Pose::setPose(const double x, const double y, const double z, const double 
   this->rx = rx;
   this->ry = ry;
   this->rz = rz;
+}
+
+std::string Pose::toString() const
+{
+  std::stringstream ss;
+  ss << "Pose(x = " << x << ", y = " << y << ", z = " << z << ", rx = " << rx << ", ry = " << ry << ", rz = " << rz
+     << ")";
+  return ss.str();
 }
 
 }  // namespace urcl

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -151,6 +151,22 @@ std::string Pose::toString() const
   std::stringstream ss;
   ss << "Pose(x = " << x << ", y = " << y << ", z = " << z << ", rx = " << rx << ", ry = " << ry << ", rz = " << rz
      << ")";
+
+  if (q_near_.has_value())
+  {
+    ss << "\n";
+    ss << "With Q_near([";
+    auto q_values = q_near_.value().getValues();
+    for (size_t i = 0; i < q_values.size(); ++i)
+    {
+      ss << q_values[i];
+      if (i < q_values.size() - 1)
+      {
+        ss << ", ";
+      }
+    }
+    ss << "])";
+  }
   return ss.str();
 }
 

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -145,3 +145,12 @@ TEST(TestHelpers, robotSeriesString)
   EXPECT_EQ(robotSeriesString(RobotSeries::UR_SERIES), "UR_SERIES");
   EXPECT_EQ(robotSeriesString(RobotSeries::UNDEFINED), "UNDEFINED");
 }
+
+TEST(TestHelpers, stringFromMotionTarget)
+{
+  const MotionTarget joint_target = Q{ 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 };
+  EXPECT_EQ(stringFromMotionTarget(joint_target), "Q([0, 0.1, 0.2, 0.3, 0.4, 0.5])");
+
+  const MotionTarget pose_target = Pose{ 1.0, 2.0, 3.0, 0.1, 0.2, 0.3 };
+  EXPECT_EQ(stringFromMotionTarget(pose_target), "Pose(x = 1, y = 2, z = 3, rx = 0.1, ry = 0.2, rz = 0.3)");
+}

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -148,9 +148,13 @@ TEST(TestHelpers, robotSeriesString)
 
 TEST(TestHelpers, stringFromMotionTarget)
 {
-  const MotionTarget joint_target = Q{ 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 };
+  const auto q = Q{ 0.0, 0.1, 0.2, 0.3, 0.4, 0.5 };
+  const MotionTarget joint_target = q;
   EXPECT_EQ(stringFromMotionTarget(joint_target), "Q([0, 0.1, 0.2, 0.3, 0.4, 0.5])");
 
   const MotionTarget pose_target = Pose{ 1.0, 2.0, 3.0, 0.1, 0.2, 0.3 };
   EXPECT_EQ(stringFromMotionTarget(pose_target), "Pose(x = 1, y = 2, z = 3, rx = 0.1, ry = 0.2, rz = 0.3)");
+  const MotionTarget pose_with_q_near = Pose{ 1.0, 2.0, 3.0, 0.1, 0.2, 0.3, q };
+  EXPECT_EQ(stringFromMotionTarget(pose_with_q_near), "Pose(x = 1, y = 2, z = 3, rx = 0.1, ry = 0.2, rz = 0.3)\nWith "
+                                                      "Q_near([0, 0.1, 0.2, 0.3, 0.4, 0.5])");
 }


### PR DESCRIPTION
Adding string representations of `urcl::Q` and `urcl::Pose`, to use instead of having to access individual elements.
Add `stringFromMotionTarget` to access the string representations when `Q` or `Pose` is in a `urcl::MotionTarget`.
Also added a test of `stringFromMotionTarget` in the helpers test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formatting helpers and tests only; no changes to motion execution or controller communication.
> 
> **Overview**
> Adds **`toString()`** on **`urcl::Q`** and **`urcl::Pose`** so joint and Cartesian targets can be logged or debugged without reading individual fields. **`Pose::toString()`** includes an optional second line for **`q_near`** when it is set.
> 
> Adds **`stringFromMotionTarget()`** in helpers, which dispatches over the **`MotionTarget`** variant via **`std::visit`** and returns the matching **`toString()`** output. **`types.h`** now includes **`<string>`** for the new return types.
> 
> Unit coverage in **`test_helpers.cpp`** checks joint targets, plain poses, and poses with **`q_near`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2991eca518633dff44dbefdba507b0a36d81b06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->