### PR TITLE
 Fix spline point velocity and acceleration precision

### DIFF
--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -57,11 +57,11 @@ representations in 21 datafields. The data fields have the following meaning:
           - For all MOVEC variants this field contains the via point (same
             joint-vs-pose interpretation as the target at indices 0-5, see the motion type at
             index 20).
-          - trajectory point velocities (multiplied by ``MULT_JOINTSTATE``) for spline joint types
+          - trajectory point velocities (multiplied by ``MULT_VEL_ACC``) for spline joint types
 
    12-17  Depending on the motion type, this represents either
 
-          - trajectory point accelerations (multiplied by ``MULT_JOINTSTATE``) for spline joint
+          - trajectory point accelerations (multiplied by ``MULT_VEL_ACC``) for spline joint
             types.
 
           - for all other motion types
@@ -112,11 +112,19 @@ where
 
 - ``MULT_JOINTSTATE``: 1000000
 - ``MULT_TIME``: 1000000
+- ``MULT_VEL_ACC``: 100000000
 
 .. note::
    With ``MULT_TIME`` being 1000000, the maximum duration that can be sent is 2147 seconds, while
    precision is cut off at 1 microsecond. (The same applies to the blend radius, respectively being
    max 2147 m and 1 μm precision.)
+
+.. note::
+   Spline point velocities and accelerations use the finer ``MULT_VEL_ACC`` scaling, giving 1e-8
+   resolution with a maximum magnitude of ~21.47 rad/s (rad/s²). The coarser ``MULT_JOINTSTATE``
+   scaling quantizes near-zero accelerations so heavily that the reconstructed acceleration
+   profile becomes jagged, which can trigger controller faults such as "Compensation current
+   disagreement". Values exceeding the maximum magnitude are rejected by the library.
 
 .. note::
    The ``*_POSE`` / ``*_JOINT`` motion-type variants let callers mix joint-space and Cartesian

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -122,9 +122,8 @@ where
 .. note::
    Spline point velocities and accelerations use the finer ``MULT_VEL_ACC`` scaling, giving 1e-8
    resolution with a maximum magnitude of ~21.47 rad/s (rad/s²). The coarser ``MULT_JOINTSTATE``
-   scaling quantizes near-zero accelerations so heavily that the reconstructed acceleration
-   profile becomes jagged, which can trigger controller faults such as "Compensation current
-   disagreement". Values exceeding the maximum magnitude are rejected by the library.
+   scaling quantizes near-zero accelerations, causing reconstructed acceleration
+   profile to become jagged, which can trigger controller faults. Values exceeding the maximum magnitude are rejected by the library.
 
 .. note::
    The ``*_POSE`` / ``*_JOINT`` motion-type variants let callers mix joint-space and Cartesian

--- a/doc/architecture/trajectory_point_interface.rst
+++ b/doc/architecture/trajectory_point_interface.rst
@@ -125,6 +125,10 @@ where
    scaling quantizes near-zero accelerations, causing reconstructed acceleration
    profile to become jagged, which can trigger controller faults. Values exceeding the maximum magnitude are rejected by the library.
 
+   Finer scaling is only used when the control script defines the matching multiplier through
+   the ``{{VEL_ACC_REPLACE}}`` placeholder. For user-supplied scripts without that placeholder the
+   library falls back to encoding spline velocities and accelerations with ``MULT_JOINTSTATE``.
+
 .. note::
    The ``*_POSE`` / ``*_JOINT`` motion-type variants let callers mix joint-space and Cartesian
    targets freely through the high-level APIs (see :ref:`instruction_executor` and the

--- a/include/ur_client_library/control/script_reader.h
+++ b/include/ur_client_library/control/script_reader.h
@@ -87,6 +87,14 @@ public:
    */
   static bool evaluateExpression(const std::string& expression, const DataDict& data);
 
+  /*!
+   * \brief Checks whether a variable placeholder was substituted during the last script read.
+   * This allows detecting which features a user-supplied script supports.
+   * \param key The variable name to check.
+   * \return True if the last read script, including its includes, contained the placeholder.
+   */
+  bool wasVariableUsed(const std::string& key) const;
+
 private:
   enum BlockType
   {
@@ -108,11 +116,13 @@ private:
   std::filesystem::path current_dir_;
   std::unordered_set<std::string> include_stack_;
   std::size_t include_depth_ = 0;
+  std::unordered_set<std::string> used_variables_;
 
   std::string readScriptFileImpl(const std::filesystem::path& canonical_path, const DataDict& data);
   static std::string readFileContent(const std::string& file_path);
   void replaceIncludes(std::string& script_code, const DataDict& data);
-  static void replaceVariables(std::string& script_code, const DataDict& data);
+  static void replaceVariables(std::string& script_code, const DataDict& data,
+                               std::unordered_set<std::string>& used_variables);
   static void replaceConditionals(std::string& script_code, const DataDict& data);
 };
 

--- a/include/ur_client_library/control/script_reader.h
+++ b/include/ur_client_library/control/script_reader.h
@@ -93,7 +93,7 @@ public:
    * \param key The variable name to check.
    * \return True if the last read script, including its includes, contained the placeholder.
    */
-  bool wasVariableUsed(const std::string& key) const;
+  bool isVariableRegistered(const std::string& key) const;
 
 private:
   enum BlockType
@@ -116,13 +116,13 @@ private:
   std::filesystem::path current_dir_;
   std::unordered_set<std::string> include_stack_;
   std::size_t include_depth_ = 0;
-  std::unordered_set<std::string> used_variables_;
+  std::unordered_set<std::string> variable_registry_;
 
   std::string readScriptFileImpl(const std::filesystem::path& canonical_path, const DataDict& data);
   static std::string readFileContent(const std::string& file_path);
   void replaceIncludes(std::string& script_code, const DataDict& data);
   static void replaceVariables(std::string& script_code, const DataDict& data,
-                               std::unordered_set<std::string>& used_variables);
+                               std::unordered_set<std::string>& variable_registry);
   static void replaceConditionals(std::string& script_code, const DataDict& data);
 };
 

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -135,6 +135,18 @@ public:
    */
   bool writeMotionPrimitive(const std::shared_ptr<control::MotionPrimitive> primitive);
 
+  /*!
+   * \brief Sets the multiplier used to encode spline point velocities and accelerations.
+   *
+   * Spline velocities and accelerations in legacy scripts have a coarser multiplier
+   * so the encoding has to match the running script. Defaults to the modern
+   * multiplier.
+   *
+   * \param multiplier The multiplier the running control script uses to decode spline velocities
+   * and accelerations.
+   */
+  void setVelAccMultiplier(const int32_t multiplier);
+
   void setTrajectoryEndCallback(std::function<void(TrajectoryResult)> callback);
 
   uint32_t addTrajectoryEndCallback(const std::function<void(TrajectoryResult)>& callback);
@@ -150,7 +162,8 @@ protected:
 
 private:
   const double MAX_GOAL_TIME_ = static_cast<double>(std::numeric_limits<int32_t>::max()) / MULT_TIME;
-  const double MAX_VEL_ACC_ = static_cast<double>(std::numeric_limits<int32_t>::max()) / MULT_VEL_ACC;
+
+  int32_t mult_vel_acc_ = MULT_VEL_ACC;
 
   std::list<HandlerFunction<void(TrajectoryResult)>> trajectory_end_callbacks_;
   uint32_t next_done_callback_id_ = 0;

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -63,9 +63,7 @@ std::string trajectoryResultToString(const TrajectoryResult result);
 class TrajectoryPointInterface : public ReverseInterface
 {
 public:
-  // Spline target velocities and accelerations use finer resolution than MULT_JOINTSTATE.
-  // Near-zero accelerations quantised at 1e-6 create jagged acceleration profiles that can trigger
-  // controller faults.
+  // Spline vel/acc need finer resolution: quantising near-zero values at 1e-6 causes controller faults.
   static const int32_t MULT_VEL_ACC = 100000000;
   static const int MESSAGE_LENGTH = 21;
 

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -64,7 +64,7 @@ class TrajectoryPointInterface : public ReverseInterface
 {
 public:
   // Spline vel/acc need finer resolution: quantising near-zero values at 1e-6 causes controller faults.
-  static const int32_t MULT_VEL_ACC = 100000000;
+  static constexpr int32_t MULT_VEL_ACC = 100000000;
   static const int MESSAGE_LENGTH = 21;
 
   TrajectoryPointInterface() = delete;
@@ -144,8 +144,18 @@ public:
    *
    * \param multiplier The multiplier the running control script uses to decode spline velocities
    * and accelerations.
+   *
+   * \throws std::invalid_argument if the multiplier is not positive.
    */
   void setVelAccMultiplier(const int32_t multiplier);
+
+  /*!
+   * \brief Returns the multiplier used to encode spline point velocities and accelerations.
+   */
+  int32_t getVelAccMultiplier() const
+  {
+    return mult_vel_acc_;
+  }
 
   void setTrajectoryEndCallback(std::function<void(TrajectoryResult)> callback);
 

--- a/include/ur_client_library/control/trajectory_point_interface.h
+++ b/include/ur_client_library/control/trajectory_point_interface.h
@@ -63,6 +63,10 @@ std::string trajectoryResultToString(const TrajectoryResult result);
 class TrajectoryPointInterface : public ReverseInterface
 {
 public:
+  // Spline target velocities and accelerations use finer resolution than MULT_JOINTSTATE.
+  // Near-zero accelerations quantised at 1e-6 create jagged acceleration profiles that can trigger
+  // controller faults.
+  static const int32_t MULT_VEL_ACC = 100000000;
   static const int MESSAGE_LENGTH = 21;
 
   TrajectoryPointInterface() = delete;
@@ -148,6 +152,7 @@ protected:
 
 private:
   const double MAX_GOAL_TIME_ = static_cast<double>(std::numeric_limits<int32_t>::max()) / MULT_TIME;
+  const double MAX_VEL_ACC_ = static_cast<double>(std::numeric_limits<int32_t>::max()) / MULT_VEL_ACC;
 
   std::list<HandlerFunction<void(TrajectoryResult)>> trajectory_end_callbacks_;
   uint32_t next_done_callback_id_ = 0;

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -976,6 +976,18 @@ public:
   }
 
   /*!
+   * \brief Returns the multiplier used to encode spline point velocities and accelerations.
+   *
+   * This is selected based on the loaded control script: Scripts containing the
+   * `{{VEL_ACC_REPLACE}}` placeholder use the finer `MULT_VEL_ACC` encoding, while
+   * legacy scripts fall back to `MULT_JOINTSTATE`.
+   */
+  int32_t getVelAccMultiplier() const
+  {
+    return trajectory_interface_->getVelAccMultiplier();
+  }
+
+  /*!
    * \brief Register a callback for the robot-based tool contact execution completion.
    *
    * If a tool contact is detected or tool contact is canceled, this callback function will be triggered mode of robot

--- a/include/ur_client_library/ur/ur_driver.h
+++ b/include/ur_client_library/ur/ur_driver.h
@@ -977,10 +977,6 @@ public:
 
   /*!
    * \brief Returns the multiplier used to encode spline point velocities and accelerations.
-   *
-   * This is selected based on the loaded control script: Scripts containing the
-   * `{{VEL_ACC_REPLACE}}` placeholder use the finer `MULT_VEL_ACC` encoding, while
-   * legacy scripts fall back to `MULT_JOINTSTATE`.
    */
   int32_t getVelAccMultiplier() const
   {

--- a/resources/external_control.urscript
+++ b/resources/external_control.urscript
@@ -7,6 +7,7 @@ steptime = get_steptime()
 textmsg("ExternalControl: steptime=", steptime)
 MULT_jointstate = {{JOINT_STATE_REPLACE}}
 MULT_time = {{TIME_REPLACE}}
+MULT_velacc = {{VEL_ACC_REPLACE}}
 
 DEBUG = False
 
@@ -668,7 +669,7 @@ thread trajectoryThread():
 
         # Cubic spline
         if raw_point[INDEX_SPLINE_TYPE] == SPLINE_CUBIC:
-          qd = [ raw_point[7] / MULT_jointstate, raw_point[8] / MULT_jointstate, raw_point[9] / MULT_jointstate, raw_point[10] / MULT_jointstate, raw_point[11] / MULT_jointstate, raw_point[12] / MULT_jointstate]
+          qd = [ raw_point[7] / MULT_velacc, raw_point[8] / MULT_velacc, raw_point[9] / MULT_velacc, raw_point[10] / MULT_velacc, raw_point[11] / MULT_velacc, raw_point[12] / MULT_velacc]
           is_robot_moving = cubicSplineRun(q, qd, tmptime, is_last_point, is_first_point)
 
           # reset old acceleration
@@ -676,8 +677,8 @@ thread trajectoryThread():
 
           # Quintic spline
         elif raw_point[INDEX_SPLINE_TYPE] == SPLINE_QUINTIC:
-          qd = [ raw_point[7] / MULT_jointstate, raw_point[8] / MULT_jointstate, raw_point[9] / MULT_jointstate, raw_point[10] / MULT_jointstate, raw_point[11] / MULT_jointstate, raw_point[12] / MULT_jointstate]
-          qdd = [ raw_point[13]/ MULT_jointstate, raw_point[14]/ MULT_jointstate, raw_point[15]/ MULT_jointstate, raw_point[16]/ MULT_jointstate, raw_point[17]/ MULT_jointstate, raw_point[18]/ MULT_jointstate]
+          qd = [ raw_point[7] / MULT_velacc, raw_point[8] / MULT_velacc, raw_point[9] / MULT_velacc, raw_point[10] / MULT_velacc, raw_point[11] / MULT_velacc, raw_point[12] / MULT_velacc]
+          qdd = [ raw_point[13]/ MULT_velacc, raw_point[14]/ MULT_velacc, raw_point[15]/ MULT_velacc, raw_point[16]/ MULT_velacc, raw_point[17]/ MULT_velacc, raw_point[18]/ MULT_velacc]
           is_robot_moving = quinticSplineRun(q, qd, qdd, tmptime, is_last_point, is_first_point)
         else:
           textmsg("Unknown spline type given:", raw_point[INDEX_POINT_TYPE])

--- a/src/control/script_reader.cpp
+++ b/src/control/script_reader.cpp
@@ -179,6 +179,11 @@ std::filesystem::path canonicalizeOrThrow(const std::filesystem::path& input, co
 }
 }  // namespace
 
+bool ScriptReader::wasVariableUsed(const std::string& key) const
+{
+  return used_variables_.count(key) != 0;
+}
+
 std::string ScriptReader::readScriptFile(const std::string& filename, const DataDict& data)
 {
   // Top-level entry point: normalize the input path, set up the include root, reset the include
@@ -190,6 +195,7 @@ std::string ScriptReader::readScriptFile(const std::string& filename, const Data
   current_dir_.clear();
   include_stack_.clear();
   include_depth_ = 0;
+  used_variables_.clear();
 
   return readScriptFileImpl(canonical_input, data);
 }
@@ -220,7 +226,7 @@ std::string ScriptReader::readScriptFileImpl(const std::filesystem::path& canoni
   try
   {
     script_code = readFileContent(path_key);
-    replaceVariables(script_code, data);
+    replaceVariables(script_code, data, used_variables_);
     replaceConditionals(script_code, data);
     replaceIncludes(script_code, data);
   }
@@ -305,7 +311,8 @@ void ScriptReader::replaceIncludes(std::string& script, const DataDict& data)
   }
 }
 
-void ScriptReader::replaceVariables(std::string& script_code, const DataDict& data)
+void ScriptReader::replaceVariables(std::string& script_code, const DataDict& data,
+                                    std::unordered_set<std::string>& used_variables)
 {
   std::regex pattern(R"(\{\{\s*([\w-]+)\s*\}\})");
   std::smatch match;
@@ -319,6 +326,7 @@ void ScriptReader::replaceVariables(std::string& script_code, const DataDict& da
       URCL_LOG_ERROR(ss.str().c_str());
       throw UnknownVariable(ss.str().c_str());
     }
+    used_variables.insert(key);
     std::string replaced_value;
 
     if (std::holds_alternative<std::string>(data.at(key)))

--- a/src/control/script_reader.cpp
+++ b/src/control/script_reader.cpp
@@ -179,9 +179,9 @@ std::filesystem::path canonicalizeOrThrow(const std::filesystem::path& input, co
 }
 }  // namespace
 
-bool ScriptReader::wasVariableUsed(const std::string& key) const
+bool ScriptReader::isVariableRegistered(const std::string& key) const
 {
-  return used_variables_.count(key) != 0;
+  return variable_registry_.count(key) != 0;
 }
 
 std::string ScriptReader::readScriptFile(const std::string& filename, const DataDict& data)
@@ -195,7 +195,7 @@ std::string ScriptReader::readScriptFile(const std::string& filename, const Data
   current_dir_.clear();
   include_stack_.clear();
   include_depth_ = 0;
-  used_variables_.clear();
+  variable_registry_.clear();
 
   return readScriptFileImpl(canonical_input, data);
 }
@@ -226,7 +226,7 @@ std::string ScriptReader::readScriptFileImpl(const std::filesystem::path& canoni
   try
   {
     script_code = readFileContent(path_key);
-    replaceVariables(script_code, data, used_variables_);
+    replaceVariables(script_code, data, variable_registry_);
     replaceConditionals(script_code, data);
     replaceIncludes(script_code, data);
   }
@@ -312,7 +312,7 @@ void ScriptReader::replaceIncludes(std::string& script, const DataDict& data)
 }
 
 void ScriptReader::replaceVariables(std::string& script_code, const DataDict& data,
-                                    std::unordered_set<std::string>& used_variables)
+                                    std::unordered_set<std::string>& variable_registry)
 {
   std::regex pattern(R"(\{\{\s*([\w-]+)\s*\}\})");
   std::smatch match;
@@ -326,7 +326,7 @@ void ScriptReader::replaceVariables(std::string& script_code, const DataDict& da
       URCL_LOG_ERROR(ss.str().c_str());
       throw UnknownVariable(ss.str().c_str());
     }
-    used_variables.insert(key);
+    variable_registry.insert(key);
     std::string replaced_value;
 
     if (std::holds_alternative<std::string>(data.at(key)))

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -198,8 +198,7 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
       throw UnsupportedMotionType();
   }
 
-  // Spline points carry per-sample velocities and accelerations in the second and third block,
-  // These need a finer resolution than profile parameters other motion types store.
+  // Only spline points carry per-sample vel/acc in the second and third block.
   const int32_t second_third_block_mult = primitive->type == MotionType::SPLINE ? MULT_VEL_ACC : MULT_JOINTSTATE;
 
   size_t index = 0;

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -101,17 +101,18 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
 
   if (primitive->type == MotionType::SPLINE)
   {
+    const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) / mult_vel_acc_;
     auto spline_primitive = std::static_pointer_cast<control::SplinePrimitive>(primitive);
-    auto within_range = [this](const vector6d_t& values) {
+    auto within_range = [max_vel_acc](const vector6d_t& values) {
       return std::all_of(values.begin(), values.end(),
-                         [this](const double value) { return std::abs(value) <= MAX_VEL_ACC_; });
+                         [max_vel_acc](const double value) { return std::abs(value) <= max_vel_acc; });
     };
     if (!within_range(spline_primitive->target_velocities) ||
         (spline_primitive->target_accelerations.has_value() &&
          !within_range(spline_primitive->target_accelerations.value())))
     {
       URCL_LOG_ERROR("Spline point velocity or acceleration out of range. Maximum allowed magnitude is %f.",
-                     MAX_VEL_ACC_);
+                     max_vel_acc);
       return false;
     }
   }
@@ -207,7 +208,7 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   };
 
   // Only spline points carry per-sample vel/acc in the second and third block.
-  const int32_t vel_acc_mult = primitive->type == MotionType::SPLINE ? MULT_VEL_ACC : MULT_JOINTSTATE;
+  const int32_t vel_acc_mult = primitive->type == MotionType::SPLINE ? mult_vel_acc_ : MULT_JOINTSTATE;
   write_block(first_block, MULT_JOINTSTATE);
   write_block(second_block, vel_acc_mult);
   write_block(third_block, vel_acc_mult);
@@ -339,6 +340,11 @@ void TrajectoryPointInterface::messageCallback([[maybe_unused]] const socket_t f
     URCL_LOG_WARN("Received %d bytes on TrajectoryPointInterface. Expecting 4 bytes, so ignoring this message",
                   nbytesrecv);
   }
+}
+
+void TrajectoryPointInterface::setVelAccMultiplier(const int32_t multiplier)
+{
+  mult_vel_acc_ = multiplier;
 }
 
 void TrajectoryPointInterface::setTrajectoryEndCallback(std::function<void(TrajectoryResult)> callback)

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -198,28 +198,19 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
       throw UnsupportedMotionType();
   }
 
-  // Only spline points carry per-sample vel/acc in the second and third block.
-  const int32_t second_third_block_mult = primitive->type == MotionType::SPLINE ? MULT_VEL_ACC : MULT_JOINTSTATE;
-
   size_t index = 0;
-  for (auto const& pos : first_block)
-  {
-    int32_t val = static_cast<int32_t>(round(pos * MULT_JOINTSTATE));
-    buffer[index] = htobe32(val);
-    index++;
-  }
-  for (auto const& item : second_block)
-  {
-    int32_t val = static_cast<int32_t>(round(item * second_third_block_mult));
-    buffer[index] = htobe32(val);
-    index++;
-  }
-  for (auto const& item : third_block)
-  {
-    int32_t val = static_cast<int32_t>(round(item * second_third_block_mult));
-    buffer[index] = htobe32(val);
-    index++;
-  }
+  auto write_block = [&buffer, &index](const vector6d_t& block, const int32_t mult) {
+    for (auto const& item : block)
+    {
+      buffer[index++] = htobe32(static_cast<int32_t>(round(item * mult)));
+    }
+  };
+
+  // Only spline points carry per-sample vel/acc in the second and third block.
+  const int32_t vel_acc_mult = primitive->type == MotionType::SPLINE ? MULT_VEL_ACC : MULT_JOINTSTATE;
+  write_block(first_block, MULT_JOINTSTATE);
+  write_block(second_block, vel_acc_mult);
+  write_block(third_block, vel_acc_mult);
 
   int32_t val = static_cast<int32_t>(round(primitive->duration.count() * MULT_TIME));
   buffer[index] = htobe32(val);

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -103,16 +103,21 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   {
     const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) / mult_vel_acc_;
     auto spline_primitive = std::static_pointer_cast<control::SplinePrimitive>(primitive);
-    auto within_range = [max_vel_acc](const vector6d_t& values) {
-      return std::all_of(values.begin(), values.end(),
-                         [max_vel_acc](const double value) { return std::abs(value) <= max_vel_acc; });
+    auto max_magnitude = [](const vector6d_t& values) {
+      return std::abs(*std::max_element(values.begin(), values.end(), [](const double lhs, const double rhs) {
+        return std::abs(lhs) < std::abs(rhs);
+      }));
     };
-    if (!within_range(spline_primitive->target_velocities) ||
-        (spline_primitive->target_accelerations.has_value() &&
-         !within_range(spline_primitive->target_accelerations.value())))
+    double largest_vel_acc = max_magnitude(spline_primitive->target_velocities);
+    if (spline_primitive->target_accelerations.has_value())
     {
-      URCL_LOG_ERROR("Spline point velocity or acceleration out of range. Maximum allowed magnitude is %f.",
-                     max_vel_acc);
+      largest_vel_acc = std::max(largest_vel_acc, max_magnitude(spline_primitive->target_accelerations.value()));
+    }
+    if (largest_vel_acc > max_vel_acc)
+    {
+      URCL_LOG_ERROR("Spline point velocity or acceleration out of range. Got %f, but the maximum allowed magnitude "
+                     "is %f.",
+                     largest_vel_acc, max_vel_acc);
       return false;
     }
   }
@@ -344,6 +349,10 @@ void TrajectoryPointInterface::messageCallback([[maybe_unused]] const socket_t f
 
 void TrajectoryPointInterface::setVelAccMultiplier(const int32_t multiplier)
 {
+  if (multiplier <= 0)
+  {
+    throw std::invalid_argument("Spline vel/acc multiplier has to be positive, got " + std::to_string(multiplier));
+  }
   mult_vel_acc_ = multiplier;
 }
 

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -29,6 +29,8 @@
 #include <ur_client_library/control/trajectory_point_interface.h>
 #include <ur_client_library/exceptions.h>
 #include <urcl_3rdparty/portable_endian.h>
+#include <algorithm>
+#include <cmath>
 #include <math.h>
 #include <cstdint>
 #include <stdexcept>
@@ -95,6 +97,23 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   {
     URCL_LOG_ERROR("Motion primitive duration is too long. Maximum allowed duration is %f seconds.", MAX_GOAL_TIME_);
     return false;
+  }
+
+  if (primitive->type == MotionType::SPLINE)
+  {
+    auto spline_primitive = std::static_pointer_cast<control::SplinePrimitive>(primitive);
+    auto within_range = [this](const vector6d_t& values) {
+      return std::all_of(values.begin(), values.end(),
+                         [this](const double value) { return std::abs(value) <= MAX_VEL_ACC_; });
+    };
+    if (!within_range(spline_primitive->target_velocities) ||
+        (spline_primitive->target_accelerations.has_value() &&
+         !within_range(spline_primitive->target_accelerations.value())))
+    {
+      URCL_LOG_ERROR("Spline point velocity or acceleration out of range. Maximum allowed magnitude is %f.",
+                     MAX_VEL_ACC_);
+      return false;
+    }
   }
 
   if (client_fd_ == -1)
@@ -179,6 +198,10 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
       throw UnsupportedMotionType();
   }
 
+  // Spline points carry per-sample velocities and accelerations in the second and third block,
+  // These need a finer resolution than profile parameters other motion types store.
+  const int32_t second_third_block_mult = primitive->type == MotionType::SPLINE ? MULT_VEL_ACC : MULT_JOINTSTATE;
+
   size_t index = 0;
   for (auto const& pos : first_block)
   {
@@ -188,13 +211,13 @@ bool TrajectoryPointInterface::writeMotionPrimitive(const std::shared_ptr<contro
   }
   for (auto const& item : second_block)
   {
-    int32_t val = static_cast<int32_t>(round(item * MULT_JOINTSTATE));
+    int32_t val = static_cast<int32_t>(round(item * second_third_block_mult));
     buffer[index] = htobe32(val);
     index++;
   }
   for (auto const& item : third_block)
   {
-    int32_t val = static_cast<int32_t>(round(item * MULT_JOINTSTATE));
+    int32_t val = static_cast<int32_t>(round(item * second_third_block_mult));
     buffer[index] = htobe32(val);
     index++;
   }

--- a/src/control/trajectory_point_interface.cpp
+++ b/src/control/trajectory_point_interface.cpp
@@ -351,7 +351,7 @@ void TrajectoryPointInterface::setVelAccMultiplier(const int32_t multiplier)
 {
   if (multiplier <= 0)
   {
-    throw std::invalid_argument("Spline vel/acc multiplier has to be positive, got " + std::to_string(multiplier));
+    throw std::invalid_argument("Velocity/acceleration multiplier must be positive.");
   }
   mult_vel_acc_ = multiplier;
 }

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -149,7 +149,7 @@ void UrDriver::init(const UrDriverConfiguration& config)
 
   // Legacy scripts decode spline vel/acc with MULT_jointstate; only scripts defining MULT_velacc
   // use the finer encoding.
-  if (script_reader_->wasVariableUsed(VEL_ACC_REPLACE))
+  if (script_reader_->isVariableRegistered(VEL_ACC_REPLACE))
   {
     trajectory_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   }

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -147,6 +147,21 @@ void UrDriver::init(const UrDriverConfiguration& config)
   script_reader_.reset(new control::ScriptReader());
   std::string prog = script_reader_->readScriptFile(config.script_file, data);
 
+  // Legacy scripts decode spline vel/acc with MULT_jointstate; only scripts defining MULT_velacc
+  // use the finer encoding.
+  if (script_reader_->wasVariableUsed(VEL_ACC_REPLACE))
+  {
+    trajectory_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
+  }
+  else
+  {
+    URCL_LOG_WARN("The provided control script does not contain the '{{%s}}' placeholder. Falling back to legacy "
+                  "spline velocity / acceleration encoding with reduced precision. Please update your control script "
+                  "to benefit from the increased precision.",
+                  VEL_ACC_REPLACE.c_str());
+    trajectory_interface_->setVelAccMultiplier(control::ReverseInterface::MULT_JOINTSTATE);
+  }
+
   if (in_headless_mode_)
   {
     full_robot_program_ = "stop program\n";

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -155,9 +155,8 @@ void UrDriver::init(const UrDriverConfiguration& config)
   }
   else
   {
-    URCL_LOG_WARN("The provided control script does not contain the '{{%s}}' placeholder. Falling back to legacy "
-                  "spline velocity / acceleration encoding with reduced precision. Please update your control script "
-                  "to benefit from the increased precision.",
+    URCL_LOG_WARN("Control script does not contain the '{{%s}}' placeholder. Falling back to legacy spline vel/acc "
+                  "encoding with reduced precision.",
                   VEL_ACC_REPLACE.c_str());
     trajectory_interface_->setVelAccMultiplier(control::ReverseInterface::MULT_JOINTSTATE);
   }

--- a/src/ur/ur_driver.cpp
+++ b/src/ur/ur_driver.cpp
@@ -49,6 +49,7 @@ namespace urcl
 static const std::string BEGIN_REPLACE("BEGIN_REPLACE");
 static const std::string JOINT_STATE_REPLACE("JOINT_STATE_REPLACE");
 static const std::string TIME_REPLACE("TIME_REPLACE");
+static const std::string VEL_ACC_REPLACE("VEL_ACC_REPLACE");
 static const std::string SERVO_J_REPLACE("SERVO_J_REPLACE");
 static const std::string SERVER_IP_REPLACE("SERVER_IP_REPLACE");
 static const std::string SERVER_PORT_REPLACE("SERVER_PORT_REPLACE");
@@ -111,6 +112,7 @@ void UrDriver::init(const UrDriverConfiguration& config)
   control::ScriptReader::DataDict data;
   data[JOINT_STATE_REPLACE] = std::to_string(control::ReverseInterface::MULT_JOINTSTATE);
   data[TIME_REPLACE] = std::to_string(control::TrajectoryPointInterface::MULT_TIME);
+  data[VEL_ACC_REPLACE] = std::to_string(control::TrajectoryPointInterface::MULT_VEL_ACC);
   std::ostringstream out;
   out << "lookahead_time=" << servoj_lookahead_time_ << ", gain=" << servoj_gain_;
   data[SERVO_J_REPLACE] = out.str();

--- a/tests/test_script_reader.cpp
+++ b/tests/test_script_reader.cpp
@@ -105,7 +105,7 @@ TEST_F(ScriptReaderTest, ReadNonExistentScript)
   EXPECT_THROW(reader.readScriptFile(invalid_script_path_), std::runtime_error);
 }
 
-TEST_F(ScriptReaderTest, VariableRegistryTracksSubstitutedPlaceholders)
+TEST_F(ScriptReaderTest, VariableRegistry)
 {
   std::ofstream script(valid_script_path_);
   script << "MULT_velacc = {{VEL_ACC_REPLACE}}";

--- a/tests/test_script_reader.cpp
+++ b/tests/test_script_reader.cpp
@@ -105,6 +105,29 @@ TEST_F(ScriptReaderTest, ReadNonExistentScript)
   EXPECT_THROW(reader.readScriptFile(invalid_script_path_), std::runtime_error);
 }
 
+TEST_F(ScriptReaderTest, WasVariableUsedTracksSubstitutedPlaceholders)
+{
+  std::ofstream script(valid_script_path_);
+  script << "MULT_velacc = {{VEL_ACC_REPLACE}}";
+  script.close();
+
+  ScriptReader reader;
+  ScriptReader::DataDict data;
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
+  data["UNUSED_KEY"] = 42;
+
+  reader.readScriptFile(valid_script_path_, data);
+  EXPECT_TRUE(reader.wasVariableUsed("VEL_ACC_REPLACE"));
+  EXPECT_FALSE(reader.wasVariableUsed("UNUSED_KEY"));
+
+  // Tracking is reset on each read.
+  std::ofstream plain_script(valid_script_path_);
+  plain_script << "movej([0,0,0,0,0,0])";
+  plain_script.close();
+  reader.readScriptFile(valid_script_path_, data);
+  EXPECT_FALSE(reader.wasVariableUsed("VEL_ACC_REPLACE"));
+}
+
 TEST_F(ScriptReaderTest, ReplaceIncludes)
 {
   ScriptReader reader;

--- a/tests/test_script_reader.cpp
+++ b/tests/test_script_reader.cpp
@@ -105,7 +105,7 @@ TEST_F(ScriptReaderTest, ReadNonExistentScript)
   EXPECT_THROW(reader.readScriptFile(invalid_script_path_), std::runtime_error);
 }
 
-TEST_F(ScriptReaderTest, WasVariableUsedTracksSubstitutedPlaceholders)
+TEST_F(ScriptReaderTest, VariableRegistryTracksSubstitutedPlaceholders)
 {
   std::ofstream script(valid_script_path_);
   script << "MULT_velacc = {{VEL_ACC_REPLACE}}";
@@ -117,15 +117,15 @@ TEST_F(ScriptReaderTest, WasVariableUsedTracksSubstitutedPlaceholders)
   data["UNUSED_KEY"] = 42;
 
   reader.readScriptFile(valid_script_path_, data);
-  EXPECT_TRUE(reader.wasVariableUsed("VEL_ACC_REPLACE"));
-  EXPECT_FALSE(reader.wasVariableUsed("UNUSED_KEY"));
+  EXPECT_TRUE(reader.isVariableRegistered("VEL_ACC_REPLACE"));
+  EXPECT_FALSE(reader.isVariableRegistered("UNUSED_KEY"));
 
   // Tracking is reset on each read.
   std::ofstream plain_script(valid_script_path_);
   plain_script << "movej([0,0,0,0,0,0])";
   plain_script.close();
   reader.readScriptFile(valid_script_path_, data);
-  EXPECT_FALSE(reader.wasVariableUsed("VEL_ACC_REPLACE"));
+  EXPECT_FALSE(reader.isVariableRegistered("VEL_ACC_REPLACE"));
 }
 
 TEST_F(ScriptReaderTest, ReplaceIncludes)

--- a/tests/test_script_reader.cpp
+++ b/tests/test_script_reader.cpp
@@ -460,6 +460,7 @@ TEST_F(ScriptReaderTest, TestParsingExternalControl)
   data["BEGIN_REPLACE"] = "";
   data["JOINT_STATE_REPLACE"] = std::to_string(urcl::control::ReverseInterface::MULT_JOINTSTATE);
   data["TIME_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
   data["SERVO_J_REPLACE"] = "lookahead_time=0.03, gain=2000";
   data["SERVER_IP_REPLACE"] = "1.2.3.4";
   data["SERVER_PORT_REPLACE"] = "50001";
@@ -500,6 +501,7 @@ TEST_F(ScriptReaderTest, TestDirectTorquePopupOnOldVersion)
   data["BEGIN_REPLACE"] = "";
   data["JOINT_STATE_REPLACE"] = std::to_string(urcl::control::ReverseInterface::MULT_JOINTSTATE);
   data["TIME_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
   data["SERVO_J_REPLACE"] = "lookahead_time=0.03, gain=2000";
   data["SERVER_IP_REPLACE"] = "1.2.3.4";
   data["SERVER_PORT_REPLACE"] = "50001";
@@ -527,6 +529,7 @@ TEST_F(ScriptReaderTest, TestFrictionCompensationConstantsAndHandlerPolyScope523
   data["BEGIN_REPLACE"] = "";
   data["JOINT_STATE_REPLACE"] = std::to_string(urcl::control::ReverseInterface::MULT_JOINTSTATE);
   data["TIME_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
   data["SERVO_J_REPLACE"] = "lookahead_time=0.03, gain=2000";
   data["SERVER_IP_REPLACE"] = "1.2.3.4";
   data["SERVER_PORT_REPLACE"] = "50001";
@@ -557,6 +560,7 @@ TEST_F(ScriptReaderTest, TestFrictionCompensationConstantsAndHandlerPolyScope101
   data["BEGIN_REPLACE"] = "";
   data["JOINT_STATE_REPLACE"] = std::to_string(urcl::control::ReverseInterface::MULT_JOINTSTATE);
   data["TIME_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
   data["SERVO_J_REPLACE"] = "lookahead_time=0.03, gain=2000";
   data["SERVER_IP_REPLACE"] = "1.2.3.4";
   data["SERVER_PORT_REPLACE"] = "50001";
@@ -588,6 +592,7 @@ TEST_F(ScriptReaderTest, TestFrictionScalesConstantsAndHandler)
   data["BEGIN_REPLACE"] = "";
   data["JOINT_STATE_REPLACE"] = std::to_string(urcl::control::ReverseInterface::MULT_JOINTSTATE);
   data["TIME_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
   data["SERVO_J_REPLACE"] = "lookahead_time=0.03, gain=2000";
   data["SERVER_IP_REPLACE"] = "1.2.3.4";
   data["SERVER_PORT_REPLACE"] = "50001";
@@ -861,6 +866,7 @@ TEST_F(ScriptReaderTest, TestProduceAllScriptFiles)
   data["BEGIN_REPLACE"] = "";
   data["JOINT_STATE_REPLACE"] = std::to_string(urcl::control::ReverseInterface::MULT_JOINTSTATE);
   data["TIME_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_TIME);
+  data["VEL_ACC_REPLACE"] = std::to_string(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
   data["SERVO_J_REPLACE"] = "lookahead_time=0.03, gain=2000";
   data["SERVER_IP_REPLACE"] = "1.2.3.4";
   data["SERVER_PORT_REPLACE"] = "50001";

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -598,9 +598,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_goal_time_above_max_encodable
                                                                 almost_too_long_goal_time));
 }
 
-// Wire format: int32 with MULT_VEL_ACC resolution. Near-zero spline velocities and accelerations
-// must survive the double -> int32 -> double roundtrip without collapsing to zero or getting
-// quantized so coarsely that the reconstructed acceleration profile becomes jagged.
+// Near-zero spline vel/acc must survive the int32 roundtrip instead of collapsing to zero.
 TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_and_acceleration)
 {
   urcl::vector6d_t send_pos = { 0, 0, 0, 0, 0, 0 };
@@ -621,7 +619,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_a
   }
 }
 
-// Spline velocities and accelerations are capped by int32 with MULT_VEL_ACC resolution (~21.47).
+// Spline velocities and accelerations are capped by int32 range at MULT_VEL_ACC resolution.
 TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_acceleration_above_max_encodable)
 {
   const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) /

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -413,6 +413,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_postions)
 
 TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
@@ -457,6 +458,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
 
 TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.3 };
   urcl::vector6d_t send_acc = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
@@ -501,6 +503,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
 
 TEST_F(TrajectoryPointInterfaceTest, write_splines_velocities)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.2 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
@@ -518,19 +521,20 @@ TEST_F(TrajectoryPointInterfaceTest, write_splines_velocities)
 
 TEST_F(TrajectoryPointInterfaceTest, write_splines_accelerations)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.2 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
   float send_goal_time = 0.5;
   traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &send_vel, &send_acc, send_goal_time);
-  vector6int32_t received_velocities = client_->getVelocity();
+  vector6int32_t received_accelerations = client_->getAcceleration();
 
-  EXPECT_EQ(send_vel[0], ((double)received_velocities[0]) / traj_point_interface_->MULT_VEL_ACC);
-  EXPECT_EQ(send_vel[1], ((double)received_velocities[1]) / traj_point_interface_->MULT_VEL_ACC);
-  EXPECT_EQ(send_vel[2], ((double)received_velocities[2]) / traj_point_interface_->MULT_VEL_ACC);
-  EXPECT_EQ(send_vel[3], ((double)received_velocities[3]) / traj_point_interface_->MULT_VEL_ACC);
-  EXPECT_EQ(send_vel[4], ((double)received_velocities[4]) / traj_point_interface_->MULT_VEL_ACC);
-  EXPECT_EQ(send_vel[5], ((double)received_velocities[5]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[0], ((double)received_accelerations[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[1], ((double)received_accelerations[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[2], ((double)received_accelerations[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[3], ((double)received_accelerations[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[4], ((double)received_accelerations[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[5], ((double)received_accelerations[5]) / traj_point_interface_->MULT_VEL_ACC);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_goal_time)
@@ -601,6 +605,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_goal_time_above_max_encodable
 // Near-zero spline vel/acc must survive the int32 roundtrip instead of collapsing to zero.
 TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_and_acceleration)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 0, 0, 0, 0, 0, 0 };
   urcl::vector6d_t send_vel = { 1e-5, -1e-5, 3.4e-6, -3.4e-6, 9.9e-5, -9.9e-5 };
   urcl::vector6d_t send_acc = { 2.3e-5, -2.3e-5, 7e-6, -7e-6, 5.5e-5, -5.5e-5 };
@@ -612,9 +617,11 @@ TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_a
   {
     EXPECT_NE(0, received_data.vel[i]);
     EXPECT_NE(0, received_data.acc[i]);
-    EXPECT_NEAR(send_vel[i], static_cast<double>(received_data.vel[i]) / control::TrajectoryPointInterface::MULT_VEL_ACC,
+    EXPECT_NEAR(send_vel[i],
+                static_cast<double>(received_data.vel[i]) / control::TrajectoryPointInterface::MULT_VEL_ACC,
                 resolution / 2);
-    EXPECT_NEAR(send_acc[i], static_cast<double>(received_data.acc[i]) / control::TrajectoryPointInterface::MULT_VEL_ACC,
+    EXPECT_NEAR(send_acc[i],
+                static_cast<double>(received_data.acc[i]) / control::TrajectoryPointInterface::MULT_VEL_ACC,
                 resolution / 2);
   }
 }
@@ -622,6 +629,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_a
 // Spline velocities and accelerations are capped by int32 range at MULT_VEL_ACC resolution.
 TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_acceleration_above_max_encodable)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) /
                              static_cast<double>(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
 
@@ -633,6 +641,22 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_accelerati
   EXPECT_FALSE(traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &in_range, &out_of_range, 0.02f));
   EXPECT_TRUE(traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &in_range, &in_range, 0.02f));
   client_->getData();
+}
+
+// Legacy scripts decode spline vel/acc with MULT_JOINTSTATE, so that has to stay the default.
+TEST_F(TrajectoryPointInterfaceTest, spline_vel_acc_default_to_legacy_encoding)
+{
+  urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
+  urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.2 };
+  urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
+  traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &send_vel, &send_acc, 0.5f);
+  Client::TrajData received_data = client_->getData();
+
+  for (size_t i = 0; i < send_vel.size(); ++i)
+  {
+    EXPECT_EQ(send_vel[i], static_cast<double>(received_data.vel[i]) / traj_point_interface_->MULT_JOINTSTATE);
+    EXPECT_EQ(send_acc[i], static_cast<double>(received_data.acc[i]) / traj_point_interface_->MULT_JOINTSTATE);
+  }
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_acceleration_velocity)

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -429,20 +429,20 @@ TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
   EXPECT_EQ(send_pos[5], ((double)received_data.pos[5]) / traj_point_interface_->MULT_JOINTSTATE);
 
   // Velocities
-  EXPECT_EQ(send_vel[0], ((double)received_data.vel[0]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[1], ((double)received_data.vel[1]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[2], ((double)received_data.vel[2]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[3], ((double)received_data.vel[3]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[4], ((double)received_data.vel[4]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[5], ((double)received_data.vel[5]) / traj_point_interface_->MULT_JOINTSTATE);
+  EXPECT_EQ(send_vel[0], ((double)received_data.vel[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[1], ((double)received_data.vel[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[2], ((double)received_data.vel[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[3], ((double)received_data.vel[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[4], ((double)received_data.vel[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[5], ((double)received_data.vel[5]) / traj_point_interface_->MULT_VEL_ACC);
 
   // Velocities
-  EXPECT_EQ(send_acc[0], ((double)received_data.acc[0]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[1], ((double)received_data.acc[1]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[2], ((double)received_data.acc[2]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[3], ((double)received_data.acc[3]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[4], ((double)received_data.acc[4]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[5], ((double)received_data.acc[5]) / traj_point_interface_->MULT_JOINTSTATE);
+  EXPECT_EQ(send_acc[0], ((double)received_data.acc[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[1], ((double)received_data.acc[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[2], ((double)received_data.acc[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[3], ((double)received_data.acc[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[4], ((double)received_data.acc[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[5], ((double)received_data.acc[5]) / traj_point_interface_->MULT_VEL_ACC);
 
   // Goal time (segment duration, ``MULT_TIME`` on the wire)
   EXPECT_EQ(send_goal_time, ((double)received_data.goal_time / traj_point_interface_->MULT_TIME));
@@ -473,20 +473,20 @@ TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
   EXPECT_EQ(send_pos[5], ((double)received_data.pos[5]) / traj_point_interface_->MULT_JOINTSTATE);
 
   // Velocities
-  EXPECT_EQ(send_vel[0], ((double)received_data.vel[0]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[1], ((double)received_data.vel[1]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[2], ((double)received_data.vel[2]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[3], ((double)received_data.vel[3]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[4], ((double)received_data.vel[4]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[5], ((double)received_data.vel[5]) / traj_point_interface_->MULT_JOINTSTATE);
+  EXPECT_EQ(send_vel[0], ((double)received_data.vel[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[1], ((double)received_data.vel[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[2], ((double)received_data.vel[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[3], ((double)received_data.vel[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[4], ((double)received_data.vel[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[5], ((double)received_data.vel[5]) / traj_point_interface_->MULT_VEL_ACC);
 
   // Velocities
-  EXPECT_EQ(send_acc[0], ((double)received_data.acc[0]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[1], ((double)received_data.acc[1]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[2], ((double)received_data.acc[2]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[3], ((double)received_data.acc[3]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[4], ((double)received_data.acc[4]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_acc[5], ((double)received_data.acc[5]) / traj_point_interface_->MULT_JOINTSTATE);
+  EXPECT_EQ(send_acc[0], ((double)received_data.acc[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[1], ((double)received_data.acc[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[2], ((double)received_data.acc[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[3], ((double)received_data.acc[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[4], ((double)received_data.acc[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_acc[5], ((double)received_data.acc[5]) / traj_point_interface_->MULT_VEL_ACC);
 
   // Goal time
   EXPECT_EQ(send_goal_time, ((double)received_data.goal_time) / traj_point_interface_->MULT_TIME);
@@ -508,12 +508,12 @@ TEST_F(TrajectoryPointInterfaceTest, write_splines_velocities)
   traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &send_vel, &send_acc, send_goal_time);
   vector6int32_t received_velocities = client_->getVelocity();
 
-  EXPECT_EQ(send_vel[0], ((double)received_velocities[0]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[1], ((double)received_velocities[1]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[2], ((double)received_velocities[2]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[3], ((double)received_velocities[3]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[4], ((double)received_velocities[4]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[5], ((double)received_velocities[5]) / traj_point_interface_->MULT_JOINTSTATE);
+  EXPECT_EQ(send_vel[0], ((double)received_velocities[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[1], ((double)received_velocities[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[2], ((double)received_velocities[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[3], ((double)received_velocities[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[4], ((double)received_velocities[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[5], ((double)received_velocities[5]) / traj_point_interface_->MULT_VEL_ACC);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_splines_accelerations)
@@ -525,12 +525,12 @@ TEST_F(TrajectoryPointInterfaceTest, write_splines_accelerations)
   traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &send_vel, &send_acc, send_goal_time);
   vector6int32_t received_velocities = client_->getVelocity();
 
-  EXPECT_EQ(send_vel[0], ((double)received_velocities[0]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[1], ((double)received_velocities[1]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[2], ((double)received_velocities[2]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[3], ((double)received_velocities[3]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[4], ((double)received_velocities[4]) / traj_point_interface_->MULT_JOINTSTATE);
-  EXPECT_EQ(send_vel[5], ((double)received_velocities[5]) / traj_point_interface_->MULT_JOINTSTATE);
+  EXPECT_EQ(send_vel[0], ((double)received_velocities[0]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[1], ((double)received_velocities[1]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[2], ((double)received_velocities[2]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[3], ((double)received_velocities[3]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[4], ((double)received_velocities[4]) / traj_point_interface_->MULT_VEL_ACC);
+  EXPECT_EQ(send_vel[5], ((double)received_velocities[5]) / traj_point_interface_->MULT_VEL_ACC);
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_goal_time)
@@ -596,6 +596,45 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_goal_time_above_max_encodable
       traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc, too_long_goal_time));
   EXPECT_TRUE(traj_point_interface_->writeTrajectorySplinePoint(&send_positions, &send_vel, &send_acc,
                                                                 almost_too_long_goal_time));
+}
+
+// Wire format: int32 with MULT_VEL_ACC resolution. Near-zero spline velocities and accelerations
+// must survive the double -> int32 -> double roundtrip without collapsing to zero or getting
+// quantized so coarsely that the reconstructed acceleration profile becomes jagged.
+TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_and_acceleration)
+{
+  urcl::vector6d_t send_pos = { 0, 0, 0, 0, 0, 0 };
+  urcl::vector6d_t send_vel = { 1e-5, -1e-5, 3.4e-6, -3.4e-6, 9.9e-5, -9.9e-5 };
+  urcl::vector6d_t send_acc = { 2.3e-5, -2.3e-5, 7e-6, -7e-6, 5.5e-5, -5.5e-5 };
+  traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &send_vel, &send_acc, 0.02f);
+  Client::TrajData received_data = client_->getData();
+
+  const double resolution = 1.0 / control::TrajectoryPointInterface::MULT_VEL_ACC;
+  for (size_t i = 0; i < 6; ++i)
+  {
+    EXPECT_NE(0, received_data.vel[i]);
+    EXPECT_NE(0, received_data.acc[i]);
+    EXPECT_NEAR(send_vel[i], static_cast<double>(received_data.vel[i]) / control::TrajectoryPointInterface::MULT_VEL_ACC,
+                resolution / 2);
+    EXPECT_NEAR(send_acc[i], static_cast<double>(received_data.acc[i]) / control::TrajectoryPointInterface::MULT_VEL_ACC,
+                resolution / 2);
+  }
+}
+
+// Spline velocities and accelerations are capped by int32 with MULT_VEL_ACC resolution (~21.47).
+TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_acceleration_above_max_encodable)
+{
+  const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) /
+                             static_cast<double>(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
+
+  urcl::vector6d_t send_pos = { 0, 0, 0, 0, 0, 0 };
+  urcl::vector6d_t in_range = { 0, 0, 0, 0, 0, max_vel_acc - 1.0 };
+  urcl::vector6d_t out_of_range = { 0, 0, 0, 0, 0, -(max_vel_acc + 1.0) };
+
+  EXPECT_FALSE(traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &out_of_range, &in_range, 0.02f));
+  EXPECT_FALSE(traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &in_range, &out_of_range, 0.02f));
+  EXPECT_TRUE(traj_point_interface_->writeTrajectorySplinePoint(&send_pos, &in_range, &in_range, 0.02f));
+  client_->getData();
 }
 
 TEST_F(TrajectoryPointInterfaceTest, write_acceleration_velocity)

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -413,7 +413,6 @@ TEST_F(TrajectoryPointInterfaceTest, write_postions)
 
 TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
 {
-  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
@@ -458,7 +457,6 @@ TEST_F(TrajectoryPointInterfaceTest, write_quintic_joint_spline)
 
 TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
 {
-  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.3 };
   urcl::vector6d_t send_acc = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
@@ -503,7 +501,6 @@ TEST_F(TrajectoryPointInterfaceTest, write_cubic_joint_spline)
 
 TEST_F(TrajectoryPointInterfaceTest, write_splines_velocities)
 {
-  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.2 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
@@ -521,7 +518,6 @@ TEST_F(TrajectoryPointInterfaceTest, write_splines_velocities)
 
 TEST_F(TrajectoryPointInterfaceTest, write_splines_accelerations)
 {
-  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.2 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };
@@ -605,7 +601,6 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_goal_time_above_max_encodable
 // Near-zero spline vel/acc must survive the int32 roundtrip instead of collapsing to zero.
 TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_and_acceleration)
 {
-  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   urcl::vector6d_t send_pos = { 0, 0, 0, 0, 0, 0 };
   urcl::vector6d_t send_vel = { 1e-5, -1e-5, 3.4e-6, -3.4e-6, 9.9e-5, -9.9e-5 };
   urcl::vector6d_t send_acc = { 2.3e-5, -2.3e-5, 7e-6, -7e-6, 5.5e-5, -5.5e-5 };
@@ -629,7 +624,6 @@ TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_a
 // Spline velocities and accelerations are capped by int32 range at MULT_VEL_ACC resolution.
 TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_acceleration_above_max_encodable)
 {
-  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_VEL_ACC);
   const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) /
                              static_cast<double>(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
 

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -654,6 +654,14 @@ TEST_F(TrajectoryPointInterfaceTest, write_splines_legacy_vel_acc)
   }
 }
 
+// Check validity of multipliers.
+TEST_F(TrajectoryPointInterfaceTest, set_vel_acc_multiplier_rejects_non_positive_values)
+{
+  EXPECT_THROW(traj_point_interface_->setVelAccMultiplier(0), std::invalid_argument);
+  EXPECT_THROW(traj_point_interface_->setVelAccMultiplier(-1), std::invalid_argument);
+  EXPECT_EQ(traj_point_interface_->getVelAccMultiplier(), control::TrajectoryPointInterface::MULT_VEL_ACC);
+}
+
 TEST_F(TrajectoryPointInterfaceTest, write_acceleration_velocity)
 {
   urcl::vector6d_t send_positions = { 0, 0, 0, 0, 0, 0 };

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -599,7 +599,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_goal_time_above_max_encodable
 }
 
 // Near-zero spline vel/acc must survive the int32 roundtrip instead of collapsing to zero.
-TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_and_acceleration)
+TEST_F(TrajectoryPointInterfaceTest, write_spline_near_zero_vel_acc)
 {
   urcl::vector6d_t send_pos = { 0, 0, 0, 0, 0, 0 };
   urcl::vector6d_t send_vel = { 1e-5, -1e-5, 3.4e-6, -3.4e-6, 9.9e-5, -9.9e-5 };
@@ -622,7 +622,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_spline_preserves_near_zero_velocity_a
 }
 
 // Spline velocities and accelerations are capped by int32 range at MULT_VEL_ACC resolution.
-TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_acceleration_above_max_encodable)
+TEST_F(TrajectoryPointInterfaceTest, write_spline_vel_acc_out_of_range)
 {
   const double max_vel_acc = static_cast<double>(std::numeric_limits<int32_t>::max()) /
                              static_cast<double>(urcl::control::TrajectoryPointInterface::MULT_VEL_ACC);
@@ -638,7 +638,7 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_accelerati
 }
 
 // Legacy scripts decode spline vel/acc with the coarser multiplier; the encoding must follow suit.
-TEST_F(TrajectoryPointInterfaceTest, spline_vel_acc_legacy_encoding_can_be_selected)
+TEST_F(TrajectoryPointInterfaceTest, write_splines_legacy_vel_acc)
 {
   traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_JOINTSTATE);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };

--- a/tests/test_trajectory_point_interface.cpp
+++ b/tests/test_trajectory_point_interface.cpp
@@ -637,9 +637,10 @@ TEST_F(TrajectoryPointInterfaceTest, write_rejects_spline_velocity_or_accelerati
   client_->getData();
 }
 
-// Legacy scripts decode spline vel/acc with MULT_JOINTSTATE, so that has to stay the default.
-TEST_F(TrajectoryPointInterfaceTest, spline_vel_acc_default_to_legacy_encoding)
+// Legacy scripts decode spline vel/acc with the coarser multiplier; the encoding must follow suit.
+TEST_F(TrajectoryPointInterfaceTest, spline_vel_acc_legacy_encoding_can_be_selected)
 {
+  traj_point_interface_->setVelAccMultiplier(control::TrajectoryPointInterface::MULT_JOINTSTATE);
   urcl::vector6d_t send_pos = { 1.2, 3.1, 2.2, -1.4, -2.1, -3.2 };
   urcl::vector6d_t send_vel = { 2.2, 2.1, 3.2, -2.4, -3.1, -2.2 };
   urcl::vector6d_t send_acc = { 3.2, 1.1, 1.2, -3.4, -1.1, -1.2 };

--- a/tests/test_ur_driver.cpp
+++ b/tests/test_ur_driver.cpp
@@ -34,6 +34,8 @@
 #include <ur_client_library/ur/ur_driver.h>
 #include <ur_client_library/example_robot_wrapper.h>
 #include <algorithm>
+#include <fstream>
+#include <iterator>
 #include <thread>
 #include "test_utils.h"
 
@@ -491,6 +493,52 @@ TEST(UrDriverInitTest, both_recipe_file_and_vector_select_vector)
   auto input_recipe = driver.getRTDEInputRecipe();
   EXPECT_TRUE(std::find(input_recipe.begin(), input_recipe.end(), INPUT_RECIPE_VECTOR_EXCLUDED_VALUE) ==
               input_recipe.end());
+}
+
+TEST(UrDriverInitTest, script_with_vel_acc_placeholder_uses_fine_multiplier)
+{
+  UrDriverConfiguration config;
+  config.robot_ip = g_ROBOT_IP;
+  config.input_recipe_file = INPUT_RECIPE;
+  config.output_recipe_file = OUTPUT_RECIPE;
+  config.headless_mode = g_HEADLESS;
+  config.script_file = SCRIPT_FILE;
+
+  UrDriver ur_driver(config);
+  EXPECT_EQ(ur_driver.getVelAccMultiplier(), control::TrajectoryPointInterface::MULT_VEL_ACC);
+}
+
+TEST(UrDriverInitTest, legacy_script_falls_back_to_joint_state_multiplier)
+{
+  // Legacy scripts define no dedicated spline vel/acc multiplier.
+  std::ifstream ifs(SCRIPT_FILE);
+  ASSERT_TRUE(ifs.is_open());
+  std::string script((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+  const std::string placeholder = "{{VEL_ACC_REPLACE}}";
+  ASSERT_NE(script.find(placeholder), std::string::npos);
+  while (script.find(placeholder) != std::string::npos)
+  {
+    script.replace(script.find(placeholder), placeholder.size(), "{{JOINT_STATE_REPLACE}}");
+  }
+
+  const char legacy_script_file[] = "legacy_urscript.HRRW";
+  std::ofstream ofs(legacy_script_file);
+  ASSERT_TRUE(ofs.is_open());
+  ofs << script;
+  ofs.close();
+
+  UrDriverConfiguration config;
+  config.robot_ip = g_ROBOT_IP;
+  config.input_recipe_file = INPUT_RECIPE;
+  config.output_recipe_file = OUTPUT_RECIPE;
+  config.headless_mode = g_HEADLESS;
+  config.script_file = legacy_script_file;
+
+  UrDriver ur_driver(config);
+  const int32_t legacy_multiplier = control::ReverseInterface::MULT_JOINTSTATE;
+  EXPECT_EQ(ur_driver.getVelAccMultiplier(), legacy_multiplier);
+
+  std::remove(legacy_script_file);
 }
 // TODO we should add more tests for the UrDriver class.
 


### PR DESCRIPTION
The spline vel/acc are quantised at `1e-6` by `MULT_JOINTSTATE`, so near-zero accelerations reconstruct as jagged profiles. On our UR15 we notice many current compensation errors, that make the arm unusable with the ROS 2 driver. 

I think this is a problem only encountered by the larger arms, given higher intertia.

We have this fix that is working, implementing the same strategy as #482.

We implement a finer dedicated multiplier (`MULT_VEL_ACC = 1e8`) and an explicit range guard (~21.47 rad/s(²)), analagous to max goal time check. 

This is backwards compatible. We achieve this by only setting the range guard if the modern encoding is used. `UrDriver` detects whether the control script defines the new multiplier via `{{VEL_ACC_REPLACE}}`. If undefined, we fall back to legacy `MULT_JOINTSTATE` encoding with a warning.



Credit to @tdivic for discovering this bug and implementing a fix in our ROS 2 driver.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time trajectory wire encoding and robot script decoding for splines; mismatch between library and script would corrupt motion, though auto-detection and legacy fallback mitigate custom-script risk.
> 
> **Overview**
> Spline trajectory points now encode **velocities and accelerations** with a dedicated **`MULT_VEL_ACC` (1e8)** instead of **`MULT_JOINTSTATE` (1e6)**, so near-zero values survive the int32 wire format and the robot no longer reconstructs jagged acceleration profiles that can fault the controller.
> 
> **`TrajectoryPointInterface`** applies the finer scale only to spline second/third blocks (positions stay on joint-state scale), rejects spline vel/acc above ~21.47 rad/s(²), and exposes **`setVelAccMultiplier` / `getVelAccMultiplier`**. The bundled **`external_control.urscript`** adds **`MULT_velacc`** via **`{{VEL_ACC_REPLACE}}`** and decodes cubic/quintic spline **`qd`/`qdd`** with that multiplier.
> 
> **Backward compatibility:** **`ScriptReader`** records which placeholders were actually substituted (**`isVariableRegistered`**). On init, **`UrDriver`** uses fine encoding when the script contains **`VEL_ACC_REPLACE`**; otherwise it logs a warning and falls back to legacy **`MULT_JOINTSTATE`** encoding so older custom scripts keep working. Architecture docs and tests cover the new multiplier, range checks, near-zero roundtrip, and driver init behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e05eb2bfe2b82120e0820e2088025743b2d6db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->