### PR TITLE
Release/2.15.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Robot api 10.14 (`#549 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/549>`_)
+* Fix spline point velocity and acceleration precision (`#559 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/559>`_)
+* MotionTarget helpers (`#558 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/558>`_)
+* [CI] Support running PolyScope X robot in remote control mode in CI (`#553 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/553>`_)
+* [CI] Update downstream branch for lyrical (`#555 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/555>`_)
+* [CI] Add exclude rule for stackoverflow (`#557 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/557>`_)
+* [CI] Separate standalone instruction executor test into its own file (`#554 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/554>`_)
+* Contributors: Felix Exner, Hasan Amin, URJala
+
 2.14.1 (2026-08-07)
 -------------------
 * fix: teardown blocks indefinitely when a reconnect thread is active and the robot is unreachable (`#519 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/519>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_client_library
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.15.0 (2026-09-03)
+-------------------
 * Robot api 10.14 (`#549 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/549>`_)
 * Fix spline point velocity and acceleration precision (`#559 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/559>`_)
 * MotionTarget helpers (`#558 <https://github.com/UniversalRobots/Universal_Robots_Client_Library/issues/558>`_)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_client_library</name>
-  <version>2.14.1</version>
+  <version>2.15.0</version>
   <description>Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.</description>
   <author>Thomas Timm Andersen</author>
   <author>Simon Rasmussen</author>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release PR with no runtime code changes in the diff.
> 
> **Overview**
> This PR **releases version 2.15.0** by bumping `package.xml` from **2.14.1** to **2.15.0** and adding the **2.15.0 (2026-09-03)** section to `CHANGELOG.rst`.
> 
> The changelog records work already merged on the branch: **Robot API / PolyScope X 10.14** support (#549), **spline point velocity and acceleration precision** fixes (#559), **MotionTarget helpers** (#558), and several **CI** updates (PolyScope X remote control in CI, lyrical downstream branch, stackoverflow link-check exclude, standalone instruction executor test split).
> 
> No library source changes appear in this diff—only release metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbda1311dc32d869a887678bfba24e5ecc60258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->