### PR TITLE
Tolerate null values in the PolyScope X program list

### DIFF
--- a/src/ur/dashboard_client_implementation_x.cpp
+++ b/src/ur/dashboard_client_implementation_x.cpp
@@ -715,6 +715,16 @@ DashboardResponse DashboardClientImplX::commandGetProgramList()
     std::vector<ProgramInformation> programs;
     for (auto prog : json_data["programs"])
     {
+      // The Robot API schema declares every field of ProgramInformation except
+      // "name" as nullable, so each of them has to be read defensively. Reading
+      // a null directly into the constructor's std::string / unsigned int
+      // parameters throws a json type_error and fails the whole query.
+      unsigned int created = 0;
+      if (!prog["createdDate"].is_null())
+      {
+        created = static_cast<unsigned int>(prog["createdDate"]);
+      }
+
       unsigned int last_modified = 0;
       if (!prog["lastModifiedDate"].is_null())
       {
@@ -727,8 +737,19 @@ DashboardResponse DashboardClientImplX::commandGetProgramList()
         last_saved = static_cast<unsigned int>(prog["lastSavedDate"]);
       }
 
-      ProgramInformation pi(prog["createdDate"], prog["description"], last_modified, last_saved, prog["name"],
-                            prog["programState"]);
+      std::string description;
+      if (!prog["description"].is_null())
+      {
+        description = prog["description"];
+      }
+
+      std::string program_state;
+      if (!prog["programState"].is_null())
+      {
+        program_state = prog["programState"];
+      }
+
+      ProgramInformation pi(created, description, last_modified, last_saved, prog["name"], program_state);
       programs.push_back(pi);
     }
     response.data["programs"] = programs;

--- a/tests/test_dashboard_client_x.cpp
+++ b/tests/test_dashboard_client_x.cpp
@@ -1048,6 +1048,145 @@ TEST_F(DashboardClientImplXMockTest, download_support_files_rename_failure)
   std::filesystem::remove_all(out);
 }
 
+// --- commandGetProgramList ---
+// Spec: GET /programs/v1/
+//   200 → ProgramListResponse {"programs": [ProgramInformation, ...]}
+//
+// ProgramInformation declares "name" as the only non-nullable field; the other
+// five are "anyOf": [<type>, {"type": "null"}], so a null is a spec-conforming
+// value for each of them:
+//
+//   "name":             {"type": "string"}
+//   "description":      {"anyOf": [{"type": "string"},  {"type": "null"}]}
+//   "createdDate":      {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+//   "lastSavedDate":    {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+//   "lastModifiedDate": {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+//   "programState":     {"anyOf": [{"$ref": "ProgramState-Output"}, {"type": "null"}]}
+static constexpr const char* MOCK_PROGRAMS_ENDPOINT = "/universal-robots/robot-api/programs/v1/";
+
+TEST_F(DashboardClientImplXMockTest, get_program_list_all_fields_populated)
+{
+  // Baseline: every field carries a value. Reading the nullable fields
+  // defensively must not change the result for a fully populated response.
+  const std::string body = R"({"programs":[{
+    "createdDate":1757000000,
+    "description":"a program with all fields set",
+    "lastModifiedDate":1757000001,
+    "lastSavedDate":1757000002,
+    "name":"full_program",
+    "programState":"FINAL"
+  }]})";
+  server_.Get(MOCK_PROGRAMS_ENDPOINT,
+              [&body](const httplib::Request&, httplib::Response& res) { res.set_content(body, "application/json"); });
+
+  auto response = impl_->commandGetProgramList();
+  ASSERT_TRUE(response.ok);
+
+  const auto programs = std::get<std::vector<ProgramInformation>>(response.data.at("programs"));
+  ASSERT_EQ(programs.size(), 1u);
+  EXPECT_EQ(programs[0].createdDate, 1757000000u);
+  EXPECT_EQ(programs[0].description, "a program with all fields set");
+  EXPECT_EQ(programs[0].lastModifiedDate, 1757000001u);
+  EXPECT_EQ(programs[0].lastSavedDate, 1757000002u);
+  EXPECT_EQ(programs[0].name, "full_program");
+  EXPECT_EQ(programs[0].programState, "FINAL");
+}
+
+TEST_F(DashboardClientImplXMockTest, get_program_list_tolerates_null_description)
+{
+  // "description" is nullable per the schema, so a null here is a valid
+  // response. Converting it straight into the constructor's std::string
+  // parameter threw
+  //   [json.exception.type_error.302] type must be string, but is null
+  // which failed the whole query, including the "name" field most callers need.
+  const std::string body = R"({"programs":[{
+    "createdDate":1757000000,
+    "description":null,
+    "lastModifiedDate":1757000001,
+    "lastSavedDate":1757000002,
+    "name":"program_without_description",
+    "programState":"FINAL"
+  }]})";
+  server_.Get(MOCK_PROGRAMS_ENDPOINT,
+              [&body](const httplib::Request&, httplib::Response& res) { res.set_content(body, "application/json"); });
+
+  auto response = impl_->commandGetProgramList();
+  ASSERT_TRUE(response.ok);
+
+  const auto programs = std::get<std::vector<ProgramInformation>>(response.data.at("programs"));
+  ASSERT_EQ(programs.size(), 1u);
+  EXPECT_EQ(programs[0].name, "program_without_description");
+  EXPECT_EQ(programs[0].description, "");
+  EXPECT_EQ(programs[0].programState, "FINAL");
+}
+
+TEST_F(DashboardClientImplXMockTest, get_program_list_tolerates_all_nullable_fields_null)
+{
+  // Every field the schema declares nullable is null at once. Only "name" is
+  // guaranteed by the spec, so that is the only value that must survive; the
+  // rest default to an empty string / 0.
+  const std::string body = R"({"programs":[{
+    "createdDate":null,
+    "description":null,
+    "lastModifiedDate":null,
+    "lastSavedDate":null,
+    "name":"only_a_name",
+    "programState":null
+  }]})";
+  server_.Get(MOCK_PROGRAMS_ENDPOINT,
+              [&body](const httplib::Request&, httplib::Response& res) { res.set_content(body, "application/json"); });
+
+  auto response = impl_->commandGetProgramList();
+  ASSERT_TRUE(response.ok);
+
+  const auto programs = std::get<std::vector<ProgramInformation>>(response.data.at("programs"));
+  ASSERT_EQ(programs.size(), 1u);
+  EXPECT_EQ(programs[0].name, "only_a_name");
+  EXPECT_EQ(programs[0].description, "");
+  EXPECT_EQ(programs[0].createdDate, 0u);
+  EXPECT_EQ(programs[0].lastModifiedDate, 0u);
+  EXPECT_EQ(programs[0].lastSavedDate, 0u);
+  EXPECT_EQ(programs[0].programState, "");
+}
+
+TEST_F(DashboardClientImplXMockTest, get_program_list_null_field_does_not_drop_other_programs)
+{
+  // The conversion happens inside the loop over "programs", so before the fix a
+  // single program with a null field made the entire list unavailable. All
+  // programs must be returned, in response order.
+  const std::string body = R"({"programs":[
+    {"createdDate":null,"description":null,"lastModifiedDate":null,"lastSavedDate":null,
+     "name":"program_with_nulls","programState":null},
+    {"createdDate":1757000000,"description":"fully populated","lastModifiedDate":1757000001,
+     "lastSavedDate":1757000002,"name":"program_without_nulls","programState":"DRAFT"}
+  ]})";
+  server_.Get(MOCK_PROGRAMS_ENDPOINT,
+              [&body](const httplib::Request&, httplib::Response& res) { res.set_content(body, "application/json"); });
+
+  auto response = impl_->commandGetProgramList();
+  ASSERT_TRUE(response.ok);
+
+  const auto programs = std::get<std::vector<ProgramInformation>>(response.data.at("programs"));
+  ASSERT_EQ(programs.size(), 2u);
+  EXPECT_EQ(programs[0].name, "program_with_nulls");
+  EXPECT_EQ(programs[0].description, "");
+  EXPECT_EQ(programs[1].name, "program_without_nulls");
+  EXPECT_EQ(programs[1].description, "fully populated");
+  EXPECT_EQ(programs[1].programState, "DRAFT");
+}
+
+TEST_F(DashboardClientImplXMockTest, get_program_list_empty)
+{
+  // A robot with no programs answers with an empty array.
+  const std::string body = R"({"programs":[]})";
+  server_.Get(MOCK_PROGRAMS_ENDPOINT,
+              [&body](const httplib::Request&, httplib::Response& res) { res.set_content(body, "application/json"); });
+
+  auto response = impl_->commandGetProgramList();
+  ASSERT_TRUE(response.ok);
+  EXPECT_TRUE(std::get<std::vector<ProgramInformation>>(response.data.at("programs")).empty());
+}
+
 // ---------------------------------------------------------------------------
 // Connection-state tests
 //


### PR DESCRIPTION
## What

`DashboardClientImplX::commandGetProgramList()` reads each program's fields straight
out of the JSON response and into the `ProgramInformation` constructor. Any field that
comes back as `null` is therefore converted directly into a `std::string` or an
`unsigned int`, which nlohmann rejects:

```
[json.exception.type_error.302] type must be string, but is null
```

The conversion happens inside the loop, so a single program with a null field fails the
whole query — including `name`, which is the only field many callers need.

Only `lastModifiedDate` and `lastSavedDate` were guarded. This PR guards the remaining
nullable fields the same way.

## Why null is a valid response

The Robot API schema (`/universal-robots/robot-api/openapi.json`) declares five of the
six `ProgramInformation` fields as nullable:

```json
"required": ["name", "description"],
"properties": {
  "name":             {"type": "string"},
  "description":      {"anyOf": [{"type": "string"},  {"type": "null"}]},
  "createdDate":      {"anyOf": [{"type": "integer"}, {"type": "null"}]},
  "lastSavedDate":    {"anyOf": [{"type": "integer"}, {"type": "null"}]},
  "lastModifiedDate": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
  "programState":     {"anyOf": [{"$ref": "#/components/schemas/ProgramState-Output"},
                                 {"type": "null"}]}
}
```

`name` is the only field declared non-nullable, and it is the only one still read
directly.

## How to reproduce

On a real robot (firmware 10.13.1.0, Robot API 3.1.7.0):

1. Export a program to a USB stick from the teach pendant.
2. Import it again from the USB stick.
3. `GET /universal-robots/robot-api/programs/v1/`

The imported program comes back with a null description, even though the exported
`.urpx` contains one:

```json
{"name":"my_program","description":null,"createdDate":1788882381574,
 "lastSavedDate":null,"lastModifiedDate":null,"programState":"FINAL"}
```

`commandGetProgramList()` then throws `type_error.302` and no program list can be
retrieved at all. For us this makes the UR backend unable to complete its
initialisation against a real controller, since querying the program list is the first
thing it does.

The exported `.urpx` does contain a description, so the import path appears to drop it.
That may be a bug in PolyScope X rather than in this library.

Two details that may be useful:

- A program *created* on the teach pendant gets `""`, not `null` — only the USB
  import path produces the null.

## Verification
Built against a real robot with a null-description program installed:

Present in 2.14.1, 2.15.0 and current `master`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized JSON parsing change in program list handling with regression tests; no auth or persistence impact.
> 
> **Overview**
> Fixes **`commandGetProgramList()`** so PolyScope X program list responses no longer fail when the Robot API returns **`null`** for schema-nullable fields (`createdDate`, `description`, `programState`, plus the date fields that were already guarded).
> 
> Nullable values are now read with **`is_null()`** checks and mapped to **empty strings or `0`** before building **`ProgramInformation`**, instead of letting nlohmann throw **`type_error.302`** and abort parsing of the entire **`programs`** array. **`name`** remains the only field read without a null guard.
> 
> Adds **mock HTTP tests** for fully populated programs, null **`description`**, all nullable fields null, mixed lists where one entry has nulls, and an empty list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be8728c6a26426171f440822d318e321fcbceb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->