### PR TITLE
Add a workflow that checks the PR title

### DIFF
--- a/.github/check_pr_title.sh
+++ b/.github/check_pr_title.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Check a PR title for meaningfulness (heuristics), spelling (cspell), and
+# grammar (LanguageTool). Intended for CI; can also be run locally:
+#   PR_TITLE='My title here' .github/check_pr_title.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CSPELL_CONFIG="${SCRIPT_DIR}/cspell-pr-title.json"
+
+TITLE="${PR_TITLE:-${1:-}}"
+if [ -z "${TITLE}" ]; then
+  echo "Usage: PR_TITLE='...' $0   or   $0 'title'" >&2
+  exit 2
+fi
+
+FAILED=0
+
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$1" | tee -a "${GITHUB_STEP_SUMMARY}"
+  else
+    echo "$1"
+  fi
+}
+
+summary "## PR title check"
+summary ""
+summary "Title: \`${TITLE}\`"
+summary ""
+
+# Release PRs use Release/X.Y.Z and are exempt from all checks.
+if echo "${TITLE}" | grep -Eq '^Release/[0-9]+\.[0-9]+\.[0-9]+$'; then
+  summary "Skipped: release title exception (\`Release/X.Y.Z\`)."
+  exit 0
+fi
+
+# --- Heuristics (meaningfulness) ---
+summary "### Heuristics"
+if [ -z "${TITLE// }" ]; then
+  summary "- Empty or whitespace-only title"
+  FAILED=1
+fi
+if [ "${TITLE}" != "${TITLE#"${TITLE%%[![:space:]]*}"}" ] || \
+   [ "${TITLE}" != "${TITLE%"${TITLE##*[![:space:]]}"}" ]; then
+  summary "- Leading or trailing whitespace"
+  FAILED=1
+fi
+WORD_COUNT=$(echo "${TITLE}" | wc -w)
+if [ "${WORD_COUNT}" -lt 3 ]; then
+  summary "- Fewer than 3 words (found ${WORD_COUNT})"
+  FAILED=1
+fi
+TITLE_LOWER=$(echo "${TITLE}" | tr '[:upper:]' '[:lower:]')
+case "${TITLE_LOWER}" in
+  fix|update|wip|test|changes|misc|tmp|temp)
+    summary "- Title is on the denylist (\`${TITLE_LOWER}\`)"
+    FAILED=1
+    ;;
+esac
+if [ "${#TITLE}" -lt 12 ]; then
+  summary "- Length is less than 12 characters (found ${#TITLE})"
+  FAILED=1
+fi
+if [ "${FAILED}" -eq 0 ]; then
+  summary "- OK"
+fi
+summary ""
+
+# --- Spelling (cspell) ---
+summary "### Spelling (cspell)"
+if ! command -v cspell >/dev/null 2>&1; then
+  npm install --global cspell@8
+fi
+if ! CSPELL_OUT=$(echo "${TITLE}" | cspell --config "${CSPELL_CONFIG}" --no-progress stdin 2>&1); then
+  summary '```'
+  summary "${CSPELL_OUT}"
+  summary '```'
+  FAILED=1
+else
+  summary "- OK"
+fi
+summary ""
+
+# --- Grammar (LanguageTool, local Docker) ---
+summary "### Grammar (LanguageTool)"
+docker rm -f languagetool >/dev/null 2>&1 || true
+docker run -d --name languagetool -p 8010:8010 erikvl87/languagetool
+cleanup_lt() {
+  docker rm -f languagetool >/dev/null 2>&1 || true
+}
+trap cleanup_lt EXIT
+
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:8010/v2/languages >/dev/null; then
+    break
+  fi
+  if [ "${i}" -eq 60 ]; then
+    summary "- LanguageTool did not become ready in time"
+    exit 1
+  fi
+  sleep 2
+done
+
+DISABLED_RULES='WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE'
+
+LT_JSON=$(curl -sf \
+  --data-urlencode "text=${TITLE}" \
+  --data "language=en-US" \
+  --data "disabledRules=${DISABLED_RULES}" \
+  --data "disabledCategories=TYPOS" \
+  http://localhost:8010/v2/check)
+
+LT_MATCHES=$(echo "${LT_JSON}" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+matches = data.get("matches", [])
+for m in matches:
+    rule = m.get("rule", {}).get("id", "")
+    message = m.get("message", "")
+    replacements = ", ".join(r.get("value", "") for r in m.get("replacements", [])[:5])
+    line = f"- {message} [{rule}]"
+    if replacements:
+        line += f" (suggestions: {replacements})"
+    print(line)
+')
+
+if [ -n "${LT_MATCHES}" ]; then
+  summary "${LT_MATCHES}"
+  FAILED=1
+else
+  summary "- OK"
+fi
+summary ""
+
+if [ "${FAILED}" -ne 0 ]; then
+  summary "**Result: failed**"
+  exit 1
+fi
+summary "**Result: passed**"

--- a/.github/cspell-pr-title.json
+++ b/.github/cspell-pr-title.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "CI",
+    "GH",
+    "MotionTarget",
+    "OOB",
+    "PolyScope",
+    "PRs",
+    "RTDE",
+    "RTDEInvalidKeyException",
+    "UR",
+    "URCap",
+    "changelog",
+    "changelogs",
+    "lyrical",
+    "script_reader",
+    "stackoverflow",
+    "start_ursim",
+    "teardown",
+    "urcap",
+    "ursim"
+  ]
+}

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -1,0 +1,20 @@
+name: Check PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check_pr_title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: .github/check_pr_title.sh


### PR DESCRIPTION
Since we use the PR titles as commit messages on the master branch and we use those for the changelogs, we would like to make sure they don't contain any obvious mistakes. This PR uses heuristics and spell checking rather than throwing an LLM at it.

## Used checks:

**Exception: titles matching Release/X.Y.Z skip everything.**

### Heuristics
  • Not empty / whitespace-only
  • No leading or trailing whitespace
  • At least 3 words
  • Not exactly one of: fix, update, wip, test, changes, misc, tmp, temp
(case-insensitive)
  • At least 12 characters

### Spelling — cspell (https://cspell.org/) v8
  • English dictionary (language: en in `.github/cspell-pr-title.json`)
  • Extra allowed words: CI, GH, MotionTarget, OOB, PolyScope, PRs,
RTDE, RTDEInvalidKeyException, UR, URCap, changelog, changelogs, lyrical, script_reader, stackoverflow, start_ursim, teardown, urcap, ursim

### Grammar — LanguageTool (https://languagetool.org/) (erikvl87/languagetool Docker, en-US)
  • Full grammar check, except:
    • Category TYPOS disabled (spelling left to cspell)
    • Rules disabled for title-style fragments: WHITESPACE_RULE,
EN_QUOTES, DASH_RULE, WORD_CONTAINS_UNDERSCORE,
UPPERCASE_SENTENCE_START, ARROWS, COMMA_PARENTHESIS_WHITESPACE, UNLIKELY_OPENING_PUNCTUATION, SENTENCE_WHITESPACE, CURRENCY, EN_UNPAIRED_BRACKETS, PHRASE_REPETITION, PUNCTUATION_PARAGRAPH_END, METRIC_UNITS_EN_US, ENGLISH_WORD_REPEAT_BEGINNING_RULE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only gate on PR metadata; no runtime or auth changes, though Docker/cspell install and grammar rules may occasionally block or slow PRs.
> 
> **Overview**
> Adds **automated PR title validation** in CI so titles stay suitable for squash-merge commit messages and changelogs.
> 
> A new workflow runs on pull request open, edit, reopen, and sync. It calls `.github/check_pr_title.sh`, which writes results to the GitHub step summary. **Release/X.Y.Z** titles skip all checks.
> 
> The script enforces **heuristics** (non-empty, no stray whitespace, ≥3 words, ≥12 characters, denylist for vague one-word titles), **spelling** via cspell v8 and `.github/cspell-pr-title.json` (project terms like URCap, RTDE), and **grammar** via a local LanguageTool Docker container with typo rules and title-style noise rules disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ed04401d8382c0bf946cbfd6d23f0a3dacf365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->