### PR TITLE
[CI] Fix check_error_codes workflow

### DIFF
--- a/.github/workflows/check_error_codes.yml
+++ b/.github/workflows/check_error_codes.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * *'   # Every night at 06:00 UTC
+  pull_request:
+    paths:
+      - '.github/workflows/check_error_codes.yml'
 
 jobs:
   check_error_codes:
@@ -61,7 +64,10 @@ jobs:
           echo "upstream=$UPSTREAM"   >> "$GITHUB_OUTPUT"
 
       - name: Ensure label exists
-        if: steps.check.outcome == 'failure' && steps.versions.outcome == 'success'
+        if: >-
+          github.event_name != 'pull_request' &&
+          steps.check.outcome == 'failure' &&
+          steps.versions.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -71,12 +77,29 @@ jobs:
             --force
 
       - name: Regenerate header and open PR
-        if: steps.check.outcome == 'failure' && steps.versions.outcome == 'success'
+        if: >-
+          github.event_name != 'pull_request' &&
+          steps.check.outcome == 'failure' &&
+          steps.versions.outcome == 'success'
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMITTED: ${{ steps.versions.outputs.committed }}
           UPSTREAM: ${{ steps.versions.outputs.upstream }}
+          PR_BODY: |
+            The upstream UR ErrorCodes JSON has been updated. This PR regenerates `error_code_texts.h` automatically.
+
+            | | Version |
+            |---|---|
+            | Previous header (`ERROR_CODE_JSON_VERSION`) | `${{ steps.versions.outputs.committed }}` |
+            | Upstream JSON | `${{ steps.versions.outputs.upstream }}` |
+
+            **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            > [!NOTE]
+            > Only `include/ur_client_library/ur/error_code_texts.h` is updated here.
+            > If you have pending entries in `scripts/error_code_overrides.json`, verify
+            > they are still correct against the new JSON before merging.
         run: |
           BRANCH="auto/update-error-codes-v${UPSTREAM}"
 
@@ -108,22 +131,11 @@ jobs:
               --label "error-codes-outdated" \
               --base "${{ github.event.repository.default_branch }}" \
               --head "$BRANCH" \
-              --body "The upstream UR ErrorCodes JSON has been updated. This PR regenerates \`error_code_texts.h\` automatically.
-
-| | Version |
-|---|---|
-| Previous header (\`ERROR_CODE_JSON_VERSION\`) | \`${COMMITTED}\` |
-| Upstream JSON | \`${UPSTREAM}\` |
-
-**Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-> [!NOTE]
-> Only \`include/ur_client_library/ur/error_code_texts.h\` is updated here.
-> If you have pending entries in \`scripts/error_code_overrides.json\`, verify
-> they are still correct against the new JSON before merging.")
+              --body "$PR_BODY")
 
             echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           fi
+
       - name: Fail if version mismatch
         if: steps.check.outcome == 'failure'
         run: exit 1


### PR DESCRIPTION
Before, the PR body wasn't indented correctly.

Also add a trigger for this workflow on PRs that modify this workflow file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub Actions workflow-only changes; no runtime or application code affected.
> 
> **Overview**
> **CI workflow fixes** for `check_error_codes`: the workflow now runs on **pull requests** that touch `.github/workflows/check_error_codes.yml`, so changes to the workflow are validated in PRs.
> 
> **Auto-remediation is disabled on PR runs.** Steps that create the `error-codes-outdated` label and open an auto-update PR only run when `github.event_name != 'pull_request'` (scheduled/dispatch). PR runs still perform the version check and **fail** on mismatch via the dedicated **Fail if version mismatch** step.
> 
> **PR body formatting** is fixed by moving the auto-PR description into a `PR_BODY` environment variable (with GitHub Actions expressions for versions) and passing `--body "$PR_BODY"` to `gh pr create`, instead of a long inline `--body` string with broken indentation/escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eefaa4da197f34736d8b03f5017aa2cb20ea387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->