### PR TITLE
Remove Symlink to UR5 programs

### DIFF
--- a/tests/resources/dockerursim/programs/cb3/programs.UR5
+++ b/tests/resources/dockerursim/programs/cb3/programs.UR5
@@ -1,1 +1,0 @@
-/ursim/programs.UR5


### PR DESCRIPTION
This is a symlink used by the simulator. It's not strictly necessary to keep around in the test program folder, but it gets flagged on newer python versions (>3.14) during a release, since a symlink to an absolute path is a potential attack vector.